### PR TITLE
Feat: Add Change Log button to Help view and link to app version changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta http-equiv="content-security-policy"
-    content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src http: https: data: " />
+    content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src http: https: data:; connect-src 'self' https://github.com https://raw.githubusercontent.com;" />
   <meta http-equiv="content-security-policy-report-only" />
   <link rel="icon" type="image/png" href="/assets/icon.png" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/electron/app.ts
+++ b/src/electron/app.ts
@@ -1,15 +1,37 @@
 import * as fs from 'node:fs';
 
 import { ipcMainHandler } from './utils.js';
-import { getConfigDir, getDefaultPrefs, getPrefsPath, setAutoCheckUpdates } from './utils/prefs.utils.js';
+import {
+    getConfigDir,
+    getDefaultPrefs,
+    getPrefsPath,
+    setAutoCheckUpdates,
+} from './utils/prefs.utils.js';
 
 import { getInstalledTools } from './commands/installedTools.js';
-import { getUserPreferences, setUserPreferences } from './commands/userPreferences.js';
-import { openDirectoryDialog, openFileDialog, openShellFolder } from './commands/shellFolders.js';
-import { getAvailablePrereleases, getAvailableReleases, getInstalledReleases, openProjectManager } from './commands/releases.js';
+import {
+    getUserPreferences,
+    setUserPreferences,
+} from './commands/userPreferences.js';
+import {
+    openDirectoryDialog,
+    openFileDialog,
+    openShellFolder,
+} from './commands/shellFolders.js';
+import {
+    getAvailablePrereleases,
+    getAvailableReleases,
+    getInstalledReleases,
+    openProjectManager,
+} from './commands/releases.js';
 import { installRelease } from './commands/installRelease.js';
 import { removeRelease } from './commands/removeRelease.js';
-import { checkProjectIsValid, getProjectsDetails, launchProject, removeProject } from './commands/projects.js';
+import {
+    checkProjectIsValid,
+    getProjectsDetails,
+    launchProject,
+    removeProject,
+} from './commands/projects.js';
 import { setProjectEditor } from './commands/setProjectEditor.js';
 import { createProject } from './commands/createProject.js';
 import { addProject } from './commands/addProject.js';
@@ -18,7 +40,6 @@ import { showProjectMenu, showReleaseMenu } from './commands/menuCommands.js';
 import { app, shell } from 'electron';
 import { setAutoStart } from './utils/platform.utils.js';
 import { checkForUpdates, installUpdateAndRestart } from './autoUpdater.js';
-
 
 // create default folder if not exist
 async function createDefaultFolder() {
@@ -43,119 +64,164 @@ createDefaultFolder();
 export function registerEvents() {
     // ##### user-preferences #####
 
-    ipcMainHandler('get-user-preferences', async () =>
-        await getUserPreferences());
+    ipcMainHandler(
+        'get-user-preferences',
+        async () => await getUserPreferences()
+    );
 
-    ipcMainHandler('set-user-preferences', async (_, newPrefs: UserPreferences) =>
-        await setUserPreferences(newPrefs));
+    ipcMainHandler(
+        'set-user-preferences',
+        async (_, newPrefs: UserPreferences) => await setUserPreferences(newPrefs)
+    );
 
-    ipcMainHandler('shell-open-folder', async (_, pathToOpen) =>
-        await openShellFolder(pathToOpen));
+    ipcMainHandler(
+        'shell-open-folder',
+        async (_, pathToOpen) => await openShellFolder(pathToOpen)
+    );
 
-    ipcMainHandler('open-external', async (_, url) =>
-        await shell.openExternal(url));
+    ipcMainHandler(
+        'open-external',
+        async (_, url) => await shell.openExternal(url)
+    );
 
-    ipcMainHandler('set-auto-start', async (_, autoStart, hidden) =>
-        await setAutoStart(autoStart, hidden));
+    ipcMainHandler(
+        'set-auto-start',
+        async (_, autoStart, hidden) => await setAutoStart(autoStart, hidden)
+    );
 
-    ipcMainHandler('set-auto-check-updates', async (_, enabled) =>
-        await setAutoCheckUpdates(enabled));
+    ipcMainHandler(
+        'set-auto-check-updates',
+        async (_, enabled) => await setAutoCheckUpdates(enabled)
+    );
 
-    ipcMainHandler('install-update-and-restart', async () =>
-        await installUpdateAndRestart());
-
+    ipcMainHandler(
+        'install-update-and-restart',
+        async () => await installUpdateAndRestart()
+    );
 
     // ##### releases #####
 
+    ipcMainHandler(
+        'get-available-releases',
+        async () => await getAvailableReleases()
+    );
 
-    ipcMainHandler('get-available-releases', async () =>
-        await getAvailableReleases());
+    ipcMainHandler(
+        'get-available-prereleases',
+        async () => await getAvailablePrereleases()
+    );
 
-    ipcMainHandler('get-available-prereleases', async () =>
-        await getAvailablePrereleases());
+    ipcMainHandler(
+        'get-installed-releases',
+        async () => await getInstalledReleases()
+    );
 
-    ipcMainHandler('get-installed-releases', async () =>
-        await getInstalledReleases());
+    ipcMainHandler(
+        'install-release',
+        async (_, release, mono) => await installRelease(release, mono)
+    );
 
-    ipcMainHandler('install-release', async (_, release, mono) =>
-        await installRelease(release, mono));
+    ipcMainHandler(
+        'remove-release',
+        async (_, installedRelease) => await removeRelease(installedRelease)
+    );
 
-    ipcMainHandler('remove-release', async (_, installedRelease) =>
-        await removeRelease(installedRelease));
-
-
-    ipcMainHandler('open-editor-project-manager', async (_, release) =>
-        await openProjectManager(release));
-    ipcMainHandler('check-all-releases-valid', async () =>
-        await checkAndUpdateReleases());
+    ipcMainHandler(
+        'open-editor-project-manager',
+        async (_, release) => await openProjectManager(release)
+    );
+    ipcMainHandler(
+        'check-all-releases-valid',
+        async () => await checkAndUpdateReleases()
+    );
 
     // ##### projects #####
 
+    ipcMainHandler(
+        'create-project',
+        async (
+            _,
+            name: string,
+            release: InstalledRelease,
+            renderer: RendererType,
+            withVSCode: boolean,
+            withGit: boolean
+        ) => await createProject(name, release, renderer, withVSCode, withGit)
+    );
 
-    ipcMainHandler('create-project', async (_, name: string, release: InstalledRelease, renderer: RendererType, withVSCode: boolean, withGit: boolean) =>
-        await createProject(name, release, renderer, withVSCode, withGit));
+    ipcMainHandler(
+        'get-projects-details',
+        async () => await getProjectsDetails()
+    );
 
+    ipcMainHandler(
+        'remove-project',
+        async (_, project: ProjectDetails) => await removeProject(project)
+    );
 
-    ipcMainHandler('get-projects-details', async () =>
-        await getProjectsDetails());
+    ipcMainHandler(
+        'add-project',
+        async (_, projectPath: string) => await addProject(projectPath)
+    );
 
-
-    ipcMainHandler('remove-project', async (_, project: ProjectDetails) =>
-        await removeProject(project));
-
-
-    ipcMainHandler('add-project', async (_, projectPath: string) =>
-        await addProject(projectPath));
-
-
-    ipcMainHandler('set-project-editor', async (_, project: ProjectDetails, newRelease: InstalledRelease) =>
-        await setProjectEditor(project, newRelease));
-
+    ipcMainHandler(
+        'set-project-editor',
+        async (_, project: ProjectDetails, newRelease: InstalledRelease) =>
+            await setProjectEditor(project, newRelease)
+    );
 
     ipcMainHandler('launch-project', async (_, project: ProjectDetails) =>
-        launchProject(project));
+        launchProject(project)
+    );
 
+    ipcMainHandler(
+        'check-project-valid',
+        async (_, project: ProjectDetails) => await checkProjectIsValid(project)
+    );
 
-    ipcMainHandler('check-project-valid', async (_, project: ProjectDetails) =>
-        await checkProjectIsValid(project));
-
-    ipcMainHandler('check-all-projects-valid', async () =>
-        await checkAndUpdateProjects());
+    ipcMainHandler(
+        'check-all-projects-valid',
+        async () => await checkAndUpdateProjects()
+    );
 
     // ##### dialogs #####
 
+    ipcMainHandler(
+        'open-file-dialog',
+        (_, defaultPath: string, title: string, filters: Electron.FileFilter[]) =>
+            openFileDialog(defaultPath, title, filters)
+    );
 
-    ipcMainHandler('open-file-dialog', (_, defaultPath: string, title: string, filters: Electron.FileFilter[]) =>
-        openFileDialog(defaultPath, title, filters));
-
-
-    ipcMainHandler('open-directory-dialog', (_, defaultPath: string, title?: string, filters?: Electron.FileFilter[]) =>
-        openDirectoryDialog(defaultPath, title, filters));
-
+    ipcMainHandler(
+        'open-directory-dialog',
+        (_, defaultPath: string, title?: string, filters?: Electron.FileFilter[]) =>
+            openDirectoryDialog(defaultPath, title, filters)
+    );
 
     ipcMainHandler('show-project-menu', (_, project: ProjectDetails) =>
-        showProjectMenu(project));
-
+        showProjectMenu(project)
+    );
 
     ipcMainHandler('show-release-menu', (_, release: InstalledRelease) =>
-        showReleaseMenu(release));
+        showReleaseMenu(release)
+    );
 
     // ##### tools #####
 
-    ipcMainHandler('get-installed-tools', async () =>
-        await getInstalledTools());
+    ipcMainHandler('get-installed-tools', async () => await getInstalledTools());
 
     ipcMainHandler('relaunch-app', async () => {
         app.relaunch();
         app.exit();
     });
 
-    ipcMainHandler('check-updates', async () =>
-        checkForUpdates());
+    ipcMainHandler('check-updates', async () => checkForUpdates());
 
     ipcMainHandler('get-platform', async () => {
         return process.platform;
     });
 
+    ipcMainHandler('get-app-version', async () => {
+        return app.getVersion();
+    });
 }
-

--- a/src/electron/preload.cts
+++ b/src/electron/preload.cts
@@ -1,72 +1,96 @@
-const electron = require('electron');
+const electron = require("electron");
 
-electron.contextBridge.exposeInMainWorld('electron', {
-
+electron.contextBridge.exposeInMainWorld("electron", {
     // ##### user-preferences #####
 
-    getUserPreferences: () => ipcInvoke('get-user-preferences'),
-    setUserPreferences: (prefs: UserPreferences) => ipcInvoke('set-user-preferences', prefs),
-    setAutoStart: (autoStart: boolean, hidden: boolean) => ipcInvoke('set-auto-start', autoStart, hidden),
-    setAutoCheckUpdates: (enabled: boolean) => ipcInvoke('set-auto-check-updates', enabled),
+    getUserPreferences: () => ipcInvoke("get-user-preferences"),
+    setUserPreferences: (prefs: UserPreferences) =>
+        ipcInvoke("set-user-preferences", prefs),
+    setAutoStart: (autoStart: boolean, hidden: boolean) =>
+        ipcInvoke("set-auto-start", autoStart, hidden),
+    setAutoCheckUpdates: (enabled: boolean) =>
+        ipcInvoke("set-auto-check-updates", enabled),
 
     // ##### releases #####
 
-    getAvailableReleases: () => ipcInvoke('get-available-releases'),
-    getAvailablePrereleases: () => ipcInvoke('get-available-prereleases'),
-    getInstalledReleases: () => ipcInvoke('get-installed-releases'),
-    installRelease: (release: ReleaseSummary, mono: boolean) => ipcInvoke('install-release', release, mono),
-    removeRelease: (release: InstalledRelease) => ipcInvoke('remove-release', release),
+    getAvailableReleases: () => ipcInvoke("get-available-releases"),
+    getAvailablePrereleases: () => ipcInvoke("get-available-prereleases"),
+    getInstalledReleases: () => ipcInvoke("get-installed-releases"),
+    installRelease: (release: ReleaseSummary, mono: boolean) =>
+        ipcInvoke("install-release", release, mono),
+    removeRelease: (release: InstalledRelease) =>
+        ipcInvoke("remove-release", release),
 
-    openEditorProjectManager: (release: InstalledRelease) => ipcInvoke('open-editor-project-manager', release),
-    checkAllReleasesValid: () => ipcInvoke('check-all-releases-valid'),
+    openEditorProjectManager: (release: InstalledRelease) =>
+        ipcInvoke("open-editor-project-manager", release),
+    checkAllReleasesValid: () => ipcInvoke("check-all-releases-valid"),
 
     // ##### dialogs #####
-    openDirectoryDialog: (defaultPath: string, title: string = 'Select Folder', filters?: Electron.FileFilter[], properties?: Electron.OpenDialogOptions['properties']) =>
-        ipcInvoke('open-directory-dialog', defaultPath, title, filters, properties),
-    openFileDialog: (defaultPath: string, title: string = 'Select File', filters?: Electron.FileFilter[], properties?: Electron.OpenDialogOptions['properties']) =>
-        ipcInvoke('open-file-dialog', defaultPath, title, filters, properties),
+    openDirectoryDialog: (
+        defaultPath: string,
+        title: string = "Select Folder",
+        filters?: Electron.FileFilter[],
+        properties?: Electron.OpenDialogOptions["properties"]
+    ) =>
+        ipcInvoke("open-directory-dialog", defaultPath, title, filters, properties),
+    openFileDialog: (
+        defaultPath: string,
+        title: string = "Select File",
+        filters?: Electron.FileFilter[],
+        properties?: Electron.OpenDialogOptions["properties"]
+    ) => ipcInvoke("open-file-dialog", defaultPath, title, filters, properties),
 
-    openShellFolder: (pathToOpen: string) => ipcInvoke('shell-open-folder', pathToOpen),
+    openShellFolder: (pathToOpen: string) =>
+        ipcInvoke("shell-open-folder", pathToOpen),
 
-    showProjectMenu: (project: ProjectDetails) => ipcInvoke('show-project-menu', project),
-    showReleaseMenu: (release: InstalledRelease) => ipcInvoke('show-release-menu', release),
+    showProjectMenu: (project: ProjectDetails) =>
+        ipcInvoke("show-project-menu", project),
+    showReleaseMenu: (release: InstalledRelease) =>
+        ipcInvoke("show-release-menu", release),
 
-    openExternal: (url: string) => ipcInvoke('open-external', url),
+    openExternal: (url: string) => ipcInvoke("open-external", url),
 
     // ##### projects #####
 
-    createProject: (name: string, release: InstalledRelease, renderer: RendererType[5], withVSCode: boolean, withGit: boolean) =>
-        ipcInvoke('create-project', name, release, renderer, withVSCode, withGit),
+    createProject: (
+        name: string,
+        release: InstalledRelease,
+        renderer: RendererType[5],
+        withVSCode: boolean,
+        withGit: boolean
+    ) =>
+        ipcInvoke("create-project", name, release, renderer, withVSCode, withGit),
 
-    getProjectsDetails: () => ipcInvoke('get-projects-details'),
-    removeProject: (project: ProjectDetails) => ipcInvoke('remove-project', project),
-    addProject: (projectPath: string) => ipcInvoke('add-project', projectPath),
-    setProjectEditor: (project: ProjectDetails, release: InstalledRelease) => ipcInvoke('set-project-editor', project, release),
+    getProjectsDetails: () => ipcInvoke("get-projects-details"),
+    removeProject: (project: ProjectDetails) =>
+        ipcInvoke("remove-project", project),
+    addProject: (projectPath: string) => ipcInvoke("add-project", projectPath),
+    setProjectEditor: (project: ProjectDetails, release: InstalledRelease) =>
+        ipcInvoke("set-project-editor", project, release),
 
-    launchProject: (project: ProjectDetails) => ipcInvoke('launch-project', project),
+    launchProject: (project: ProjectDetails) =>
+        ipcInvoke("launch-project", project),
 
-    checkProjectValid: (project: ProjectDetails) => ipcInvoke('check-project-valid', project),
-    checkAllProjectsValid: () => ipcInvoke('check-all-projects-valid'),
+    checkProjectValid: (project: ProjectDetails) =>
+        ipcInvoke("check-project-valid", project),
+    checkAllProjectsValid: () => ipcInvoke("check-all-projects-valid"),
 
     // ##### tools #####
 
-    getInstalledTools: () => ipcInvoke('get-installed-tools'),
+    getInstalledTools: () => ipcInvoke("get-installed-tools"),
 
+    subscribeProjects: (callback) => ipcOn("projects-updated", callback),
+    subscribeReleases: (callback) => ipcOn("releases-updated", callback),
 
-    subscribeProjects: (callback) => ipcOn('projects-updated', callback),
-    subscribeReleases: (callback) => ipcOn('releases-updated', callback),
+    subscribeAppUpdates: (callback) => ipcOn("app-updates", callback),
 
-    subscribeAppUpdates: (callback) => ipcOn('app-updates', callback),
+    relaunchApp: () => ipcInvoke("relaunch-app"),
+    installUpdateAndRestart: () => ipcInvoke("install-update-and-restart"),
 
-    relaunchApp: () => ipcInvoke('relaunch-app'),
-    installUpdateAndRestart: () => ipcInvoke('install-update-and-restart'),
-
-    getPlatform: () => ipcInvoke('get-platform'),
-    checkForUpdates: () => ipcInvoke('check-updates'),
-
-} satisfies Window['electron']);
-
-
+    getPlatform: () => ipcInvoke("get-platform"),
+    getAppVersion: () => ipcInvoke("get-app-version"),
+    checkForUpdates: () => ipcInvoke("check-updates"),
+} satisfies Window["electron"]);
 
 function ipcInvoke<Channel extends keyof EventChannelMapping>(
     key: Channel,

--- a/src/ui/hooks/useApp.tsx
+++ b/src/ui/hooks/useApp.tsx
@@ -1,6 +1,7 @@
 import { createContext, FC, PropsWithChildren, useContext, useEffect, useState } from 'react';
 
 type AppContext = {
+    appVersion: string | undefined;
     updateAvailable: AppUpdateMessage | undefined;
     installAndRelaunch: () => void;
     checkForAppUpdates: () => void;
@@ -13,6 +14,7 @@ export const useApp = () => useContext(appContext);
 export const AppProvider: FC<PropsWithChildren> = ({ children }) => {
 
     const [updateAvailable, setUpdateAvailable] = useState<AppUpdateMessage>();
+    const [appVersion, setAppVersion] = useState<string>();
 
     const installAndRelaunch = async () => {
         await window.electron.installUpdateAndRestart();
@@ -23,13 +25,16 @@ export const AppProvider: FC<PropsWithChildren> = ({ children }) => {
     };
     useEffect(() => {
 
+        // get app version
+        window.electron.getAppVersion().then(setAppVersion);
+
         const unsubscribeUpdates = window.electron.subscribeAppUpdates(setUpdateAvailable);
         return () => {
             unsubscribeUpdates();
         };
     }, []);
 
-    return <appContext.Provider value={{ updateAvailable, installAndRelaunch, checkForAppUpdates }}>
+    return <appContext.Provider value={{ appVersion, updateAvailable, installAndRelaunch, checkForAppUpdates }}>
         {children}
     </appContext.Provider>;
 };

--- a/src/ui/views/help.view.tsx
+++ b/src/ui/views/help.view.tsx
@@ -109,8 +109,8 @@ export const HelpVIew: React.FC = () => {
 
                                         <h1 className="text-xl flex flex-row items-baseline gap-1"
                                         >How to Contribute <button
-                                            onClick={() => openExternalLink(LAUNCHER_CONTRIBUTE_URL)}
-                                            className="btn-link flex-row items-center text-sm m-0 p-0 flex gap-1">Learn More<ExternalLink className="h-4 w-4 m-0 p-0" />
+                                                onClick={() => openExternalLink(LAUNCHER_CONTRIBUTE_URL)}
+                                                className="btn-link flex-row items-center text-sm m-0 p-0 flex gap-1">Learn More<ExternalLink className="h-4 w-4 m-0 p-0" />
                                             </button>
                                         </h1>
                                         <p>Report bugs or suggestions by submitting and issue on the official GitHub repository</p>

--- a/src/ui/views/help.view.tsx
+++ b/src/ui/views/help.view.tsx
@@ -13,10 +13,18 @@ import {
     LAUNCHER_THIRD_PARTY_RAW_URL
 } from '../constants';
 import { useAppNavigation } from '../hooks/useAppNavigation';
+import { useApp } from '../hooks/useApp';
+
 
 export const HelpVIew: React.FC = () => {
 
     const { openExternalLink } = useAppNavigation();
+    const { appVersion } = useApp();
+
+    const openChangeLog = () => {
+        const url = `https://github.com/godotlauncher/launcher/blob/v${appVersion}/CHANGELOG.md`;
+        openExternalLink(url);
+    };
 
     return (
         <>
@@ -49,7 +57,12 @@ export const HelpVIew: React.FC = () => {
 
                                 <div className="flex flex-row gap-0">
                                     <div className="flex flex-col flex-1 gap-2">
-                                        <h1 className="text-xl">Godot Launcher</h1>
+                                        <h1 className="flex gap-1 items-baseline text-xl">Godot Launcher
+                                            <button
+                                                onClick={() => openChangeLog()}
+                                                className="btn-link flex-row items-center text-sm m-0 p-0 flex gap-1">Change Log<ExternalLink className="h-4 w-4 m-0 p-0" />
+                                            </button>
+                                        </h1>
                                         <ul className="flex flex-col gap-0">
                                             <li>
                                                 <h3 className="font-bold">Home Page</h3>
@@ -96,8 +109,8 @@ export const HelpVIew: React.FC = () => {
 
                                         <h1 className="text-xl flex flex-row items-baseline gap-1"
                                         >How to Contribute <button
-                                                onClick={() => openExternalLink(LAUNCHER_CONTRIBUTE_URL)}
-                                                className="btn-link flex-row items-center text-sm m-0 p-0 flex gap-1">Learn More<ExternalLink className="h-4 w-4 m-0 p-0" />
+                                            onClick={() => openExternalLink(LAUNCHER_CONTRIBUTE_URL)}
+                                            className="btn-link flex-row items-center text-sm m-0 p-0 flex gap-1">Learn More<ExternalLink className="h-4 w-4 m-0 p-0" />
                                             </button>
                                         </h1>
                                         <p>Report bugs or suggestions by submitting and issue on the official GitHub repository</p>

--- a/types.d.ts
+++ b/types.d.ts
@@ -156,7 +156,6 @@ type EventChannelMapping = {
     'app-updates': AppUpdateMessage;
     'check-updates': Promise<void>;
 
-
     // ##### dialogs #####
     'open-file-dialog': Promise<Electron.OpenDialogReturnValue>;
     'open-directory-dialog': Promise<Electron.OpenDialogReturnValue>;
@@ -198,7 +197,7 @@ type EventChannelMapping = {
     'releases-updated': InstalledRelease[];
 
     'get-platform': Promise<string>;
-
+    'get-app-version': Promise<string>;
 };
 
 interface Window {
@@ -208,11 +207,22 @@ interface Window {
 
         getUserPreferences: () => Promise<UserPreferences>;
         setUserPreferences: (prefs: UserPreferences) => Promise<UserPreferences>;
-        setAutoStart: (autoStart: boolean, hidden: boolean) => Promise<SetAutoStartResult>;
+        setAutoStart: (
+            autoStart: boolean,
+            hidden: boolean
+        ) => Promise<SetAutoStartResult>;
         setAutoCheckUpdates: (enabled: boolean) => Promise<boolean>;
 
-        openFileDialog: (defaultPath: string, title: string, filters?: Electron.FileFilter[]) => Promise<Electron.OpenDialogReturnValue>;
-        openDirectoryDialog: (defaultPath: string, title: string, filters?: Electron.FileFilter[]) => Promise<Electron.OpenDialogReturnValue>;
+        openFileDialog: (
+            defaultPath: string,
+            title: string,
+            filters?: Electron.FileFilter[]
+        ) => Promise<Electron.OpenDialogReturnValue>;
+        openDirectoryDialog: (
+            defaultPath: string,
+            title: string,
+            filters?: Electron.FileFilter[]
+        ) => Promise<Electron.OpenDialogReturnValue>;
         openShellFolder: (pathToOpen: string) => Promise<void>;
 
         showProjectMenu: (project: ProjectDetails) => Promise<void>;
@@ -224,7 +234,10 @@ interface Window {
         getAvailablePrereleases: () => Promise<ReleaseSummary[]>;
         getInstalledReleases: () => Promise<InstalledRelease[]>;
 
-        installRelease: (release: ReleaseSummary, mono: boolean) => Promise<InstallReleaseResult>;
+        installRelease: (
+            release: ReleaseSummary,
+            mono: boolean
+        ) => Promise<InstallReleaseResult>;
         removeRelease: (release: InstalledRelease) => Promise<RemovedReleaseResult>;
 
         openEditorProjectManager: (release: InstalledRelease) => Promise<void>;
@@ -233,10 +246,19 @@ interface Window {
         // ##### projects #####
 
         getProjectsDetails: () => Promise<ProjectDetails[]>;
-        createProject: (name: string, release: InstalledRelease, renderer: RendererType[4 | 5], withVSCode: boolean, withGit: boolean) => Promise<CreateProjectResult>;
+        createProject: (
+            name: string,
+            release: InstalledRelease,
+            renderer: RendererType[4 | 5],
+            withVSCode: boolean,
+            withGit: boolean
+        ) => Promise<CreateProjectResult>;
         removeProject: (project: ProjectDetails) => Promise<ProjectDetails[]>;
         addProject: (path: string) => Promise<AddProjectToListResult>;
-        setProjectEditor: (project: ProjectDetails, release: InstalledRelease) => Promise<ChangeProjectEditorResult>;
+        setProjectEditor: (
+            project: ProjectDetails,
+            release: InstalledRelease
+        ) => Promise<ChangeProjectEditorResult>;
         launchProject: (project: ProjectDetails) => Promise<void>;
         checkProjectValid: (project: ProjectDetails) => Promise<ProjectDetails>;
         checkAllProjectsValid: () => Promise<ProjectDetails[]>;
@@ -245,12 +267,19 @@ interface Window {
         getInstalledTools: () => Promise<InstalledTool[]>;
 
         getPlatform: () => Promise<string>;
+        getAppVersion: () => Promise<string>;
 
         // ##### OTHER #####
-        subscribeProjects: (callback: (projects: ProjectDetails[]) => void) => UnsubscribeFunction;
-        subscribeReleases: (callback: (releases: InstallRelease[]) => void) => UnsubscribeFunction;
+        subscribeProjects: (
+            callback: (projects: ProjectDetails[]) => void
+        ) => UnsubscribeFunction;
+        subscribeReleases: (
+            callback: (releases: InstallRelease[]) => void
+        ) => UnsubscribeFunction;
 
-        subscribeAppUpdates: (callback: (message: AppUpdateMessage) => void) => UnsubscribeFunction;
+        subscribeAppUpdates: (
+            callback: (message: AppUpdateMessage) => void
+        ) => UnsubscribeFunction;
 
         openExternal: (url: string) => Promise<void>;
 


### PR DESCRIPTION
This pull request introduces several updates across multiple files to enhance functionality, improve code readability, and add new features. The most significant changes include updates to the Content Security Policy (CSP), restructuring of imports and handlers in the Electron app, the addition of app version retrieval, and the integration of a "Change Log" button in the UI.

### Security and Configuration Updates:
* Updated the Content Security Policy in `index.html` to allow connections to GitHub and raw GitHub URLs, enabling secure access to external resources.

### Codebase Organization and Readability:
* Reformatted imports in `src/electron/app.ts` for better readability by grouping and aligning them.
* Refactored `ipcMainHandler` registrations in `src/electron/app.ts` to use consistent multiline formatting for improved clarity.

### New Features:
* Added a new `getAppVersion` IPC handler in `src/electron/app.ts` and exposed it in `src/electron/preload.cts` to allow the frontend to retrieve the app version. [[1]](diffhunk://#diff-6b0dcb66665f2fe80af990e9f20589ded5150a8d1df28291d0c56285a0d24821L46-L161) [[2]](diffhunk://#diff-27d1f206a32cba8534737a64ebdd7a89703be6c14116417211069991aee41f8aL1-R93)
* Integrated app version retrieval into the `useApp` hook in `src/ui/hooks/useApp.tsx` and passed it to the context provider. [[1]](diffhunk://#diff-6c97a8f35ce61606360fca225acf97a9f0ec592ac03559594f06bc1d343b3876R4) [[2]](diffhunk://#diff-6c97a8f35ce61606360fca225acf97a9f0ec592ac03559594f06bc1d343b3876R28-R37)

### UI Enhancements:
* Added a "Change Log" button in the `HelpView` component (`src/ui/views/help.view.tsx`) to open the changelog for the current app version on GitHub. [[1]](diffhunk://#diff-daac5dc2737e33917d903a657f9ddbed3f1870955bdb67e4e9340b3440133882R16-R27) [[2]](diffhunk://#diff-daac5dc2737e33917d903a657f9ddbed3f1870955bdb67e4e9340b3440133882L52-R65)