### PR TITLE
Fix: add persistence to project sorting

### DIFF
--- a/src/ui/views/projects.view.tsx
+++ b/src/ui/views/projects.view.tsx
@@ -1,5 +1,5 @@
 import logger from 'electron-log';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 import TimeAgo from 'javascript-time-ago';
 import en from 'javascript-time-ago/locale/en';
@@ -26,7 +26,23 @@ export const ProjectsView: React.FC = () => {
 
     const [busyProjects, setBusyProjects] = useState<string[]>([]);
 
-    const [sortData, setSortData] = useState<{ field: string, order: 'asc' | 'desc'; }>({ field: 'modified', order: 'desc' });
+    // Initialize sortData from localStorage or use default
+    const [sortData, setSortData] = useState<{ field: string, order: 'asc' | 'desc'; }>(() => {
+        const saved = localStorage.getItem('projectsSortData');
+        if (saved) {
+            try {
+                return JSON.parse(saved);
+            } catch {
+                return { field: 'modified', order: 'desc' };
+            }
+        }
+        return { field: 'modified', order: 'desc' };
+    });
+
+    // Save sortData to localStorage whenever it changes
+    useEffect(() => {
+        localStorage.setItem('projectsSortData', JSON.stringify(sortData));
+    }, [sortData]);
 
     const { addAlert } = useAlerts();
 
@@ -270,17 +286,17 @@ export const ProjectsView: React.FC = () => {
                                                     </button>
 
                                                     {row.release.mono &&
-                                                        <p className='tooltip tooltip-bottom tooltip-primary' data-tip="This is a .Net Project">
+                                                        <p className='tooltip tooltip-right tooltip-primary' data-tip="This is a .Net Project">
                                                             <p className="badge badge-outline text-xs text-base-content/50 ">c#</p>
                                                         </p>
                                                     }
                                                     {row.release.prerelease &&
-                                                        <p className='tooltip tooltip-bottom tooltip-secondary' data-tip="Using a pre-release Godot editor version">
+                                                        <p className='tooltip tooltip-right right-0 tooltip-secondary' data-tip="Using a pre-release Godot editor version">
                                                             <p className="badge badge-secondary badge-outline text-xs text-base-content/50 ">pr</p>
                                                         </p>
                                                     }
                                                     {row.open_windowed &&
-                                                        <p className='tooltip tooltip-bottom tooltip-primary' data-tip="This project is open in windowed mode">
+                                                        <p className='tooltip tooltip-right tooltip-primary' data-tip="This project is open in windowed mode">
                                                             <p className="badge badge-outline text-xs text-base-content/50">w</p>
                                                         </p>
                                                     }


### PR DESCRIPTION
This pull request includes updates to the `ProjectsView` component in `src/ui/views/projects.view.tsx`, focusing on improving user experience and functionality. Key changes include persisting sort preferences using `localStorage`, modifying tooltip positioning for better visibility, and adding `useEffect` for state synchronization.

### Enhancements to state management:
* Added `useEffect` to persist `sortData` in `localStorage` whenever it changes, ensuring user preferences for sorting are saved and restored across sessions.

### Improvements to UI/UX:
* Changed tooltip positioning from `tooltip-bottom` to `tooltip-right` for better alignment and readability in various contexts. This affects tooltips for `.Net Project`, pre-release Godot editor, and windowed mode indicators.

### Dependency updates:
* Imported `useEffect` from React to enable side effects for state synchronization