### PR TITLE
Display the godot icon and not launcher icon on linux

### DIFF
--- a/src/electron/commands/projects.ts
+++ b/src/electron/commands/projects.ts
@@ -92,6 +92,9 @@ export async function launchProject(project: ProjectDetails): Promise<void> {
         if (project.open_windowed) {
             options.push('-w');
         }
+        if (process.platform === 'linux') {
+            options.push('--class', 'Godot');
+        }
         editor = spawn(command, options, { detached: true, stdio: 'ignore' });
     }
 


### PR DESCRIPTION
Changes the window class to Godot so that Linux desktops will properly get the icon.