### PR TITLE
fix: handle case when no stable releases are found for Godot

### DIFF
--- a/src/electron/commands/addProject.ts
+++ b/src/electron/commands/addProject.ts
@@ -131,6 +131,13 @@ export async function addProject(
         )
         .sort(sortReleases) || [];
 
+    if (releases.length === 0) {
+        return {
+            success: false,
+            error: `No installed Stable releases found for Godot ${releaseBaseVersion}.x\nPlease install a stable release for Godot ${releaseBaseVersion}.x, then try adding the project again.`,
+        };
+    }
+
     if (hasDotNET && !releases.some((r) => r.mono)) {
     // no mono release available for this version
         return {


### PR DESCRIPTION
This pull request adds an important validation step to the `addProject` command to improve user experience when adding a new project. Now, the function provides a clear error message if no stable Godot versions are found.

Project addition validation:

* [`src/electron/commands/addProject.ts`](diffhunk://#diff-9301d3a2a3265be6348d19decbe68316109c2112b1b96805b1958004f75b7fedR134-R140): Added a check to ensure there are installed stable releases for the requested Godot version, returning a descriptive error if none are found.