### PR TITLE
fix: improve addProject function to handle mono release fallback and better error handling

### DIFF
--- a/src/electron/commands/addProject.test.ts
+++ b/src/electron/commands/addProject.test.ts
@@ -1,0 +1,219 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { addProject } from './addProject';
+
+const fsMocks = vi.hoisted(() => ({
+    existsSync: vi.fn(),
+    readdirSync: vi.fn(),
+    readFile: vi.fn(),
+}));
+
+vi.mock('node:fs', () => ({
+    existsSync: fsMocks.existsSync,
+    readdirSync: fsMocks.readdirSync,
+    promises: { readFile: fsMocks.readFile },
+    default: {
+        existsSync: fsMocks.existsSync,
+        readdirSync: fsMocks.readdirSync,
+        promises: { readFile: fsMocks.readFile },
+    },
+}));
+
+const godotProjectMocks = vi.hoisted(() => ({
+    parseGodotProjectFile: vi.fn(),
+    getProjectNameFromParsed: vi.fn(),
+    getProjectRendererFromParsed: vi.fn(),
+    getProjectConfigVersionFromParsed: vi.fn(),
+    createNewEditorSettings: vi.fn(),
+}));
+
+vi.mock('../utils/godotProject.utils.js', () => godotProjectMocks);
+
+const platformMocks = vi.hoisted(() => ({
+    getDefaultDirs: vi.fn(),
+}));
+
+vi.mock('../utils/platform.utils.js', () => platformMocks);
+
+const projectUtilsMocks = vi.hoisted(() => ({
+    addProjectToList: vi.fn(),
+}));
+
+vi.mock('../utils/projects.utils.js', () => projectUtilsMocks);
+
+const releasesMocks = vi.hoisted(() => ({
+    getInstalledReleases: vi.fn(),
+}));
+
+vi.mock('./releases.js', () => releasesMocks);
+
+const userPreferencesMocks = vi.hoisted(() => ({
+    getUserPreferences: vi.fn(),
+}));
+
+vi.mock('./userPreferences.js', () => userPreferencesMocks);
+
+const projectsMocks = vi.hoisted(() => ({
+    getProjectsDetails: vi.fn(),
+}));
+
+vi.mock('./projects.js', () => projectsMocks);
+
+const installedToolsMocks = vi.hoisted(() => ({
+    getInstalledTools: vi.fn(),
+}));
+
+vi.mock('./installedTools.js', () => installedToolsMocks);
+
+const godotUtilsMocks = vi.hoisted(() => ({
+    DEFAULT_PROJECT_DEFINITION: new Map(),
+    getProjectDefinition: vi.fn(),
+    SetProjectEditorRelease: vi.fn(),
+}));
+
+vi.mock('../utils/godot.utils.js', () => godotUtilsMocks);
+
+vi.mock('electron-updater', () => ({
+    default: {
+        autoUpdater: {
+            on: vi.fn(),
+            logger: null,
+            channel: null,
+            checkForUpdates: vi.fn(),
+            checkForUpdatesAndNotify: vi.fn(),
+            downloadUpdate: vi.fn(),
+            quitAndInstall: vi.fn(),
+            setFeedURL: vi.fn(),
+            addAuthHeader: vi.fn(),
+            isUpdaterActive: vi.fn(),
+            currentVersion: '1.0.0',
+        },
+    },
+    UpdateCheckResult: {},
+}));
+
+vi.mock('electron', () => ({
+    Menu: {
+        setApplicationMenu: vi.fn(),
+    },
+    app: {
+        getAppPath: vi.fn(() => '/app/path'),
+        isPackaged: false,
+        getName: vi.fn(),
+        getVersion: vi.fn(() => '1.0.0'),
+        getLocale: vi.fn(),
+        getPath: vi.fn(),
+        on: vi.fn(),
+        whenReady: vi.fn(),
+        quit: vi.fn(),
+        requestSingleInstanceLock: vi.fn(() => true),
+        dock: {
+            show: vi.fn(),
+            hide: vi.fn(),
+        },
+    },
+    BrowserWindow: vi.fn(),
+    shell: {
+        showItemInFolder: vi.fn(),
+        openExternal: vi.fn(),
+    },
+    dialog: {
+        showOpenDialog: vi.fn(),
+        showMessageBox: vi.fn(),
+    },
+}));
+
+vi.mock('electron-log', () => ({
+    default: { debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const { existsSync, readdirSync, readFile } = fsMocks;
+const {
+    parseGodotProjectFile,
+    getProjectNameFromParsed,
+    getProjectRendererFromParsed,
+    getProjectConfigVersionFromParsed,
+} = godotProjectMocks;
+const { getDefaultDirs } = platformMocks;
+const { addProjectToList } = projectUtilsMocks;
+const { getInstalledReleases } = releasesMocks;
+const { getUserPreferences } = userPreferencesMocks;
+const { getProjectsDetails } = projectsMocks;
+const { getInstalledTools } = installedToolsMocks;
+const { getProjectDefinition, SetProjectEditorRelease: setProjectEditorRelease } =
+    godotUtilsMocks;
+
+describe('addProject', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        existsSync.mockImplementation((target) =>
+            typeof target === 'string' && target.endsWith('project.godot')
+        );
+        readdirSync.mockReturnValue(['project.godot']);
+        readFile.mockResolvedValue('dummy');
+        parseGodotProjectFile.mockReturnValue(new Map());
+        getProjectNameFromParsed.mockResolvedValue('Sample Project');
+        getProjectRendererFromParsed.mockResolvedValue('FORWARD_PLUS');
+        getProjectConfigVersionFromParsed.mockResolvedValue(5);
+
+        getDefaultDirs.mockReturnValue({
+            configDir: '/config',
+            dataDir: '',
+            projectDir: '',
+            prefsPath: '',
+            releaseCachePath: '',
+            installedReleasesCachePath: '',
+            prereleaseCachePath: '',
+        });
+
+        getProjectsDetails.mockResolvedValue([]);
+        getUserPreferences.mockResolvedValue({
+            prefs_version: 1,
+            install_location: '/install',
+            config_location: '',
+            projects_location: '',
+            post_launch_action: 'none',
+            auto_check_updates: false,
+            auto_start: false,
+            start_in_tray: false,
+            confirm_project_remove: false,
+            first_run: false,
+        });
+
+        getInstalledReleases.mockResolvedValue([
+            {
+                version: '4.3-stable',
+                version_number: 4.3,
+                install_path: '/install/4.3',
+                editor_path: '/install/4.3/Godot',
+                platform: 'linux',
+                arch: 'x86_64',
+                mono: true,
+                prerelease: false,
+                config_version: 5,
+                published_at: null,
+                valid: true,
+            },
+        ]);
+
+        getInstalledTools.mockResolvedValue([]);
+        addProjectToList.mockImplementation(async (_path, project) => [project]);
+        getProjectDefinition.mockReturnValue({
+            editorConfigFilename: () => 'editor_settings-4.tres',
+            editorConfigFormat: 3,
+        });
+        setProjectEditorRelease.mockResolvedValue('/fake/launch');
+    });
+
+    it('falls back to an installed mono editor when no flavor-specific match is found', async () => {
+        const result = await addProject('/fake/project/project.godot');
+
+        expect(result.success).toBe(true);
+        expect(result.newProject?.release.mono).toBe(true);
+        expect(result.newProject?.release.version).toBe('4.3-stable');
+        expect(setProjectEditorRelease).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({ mono: true, version: '4.3-stable' })
+        );
+    });
+});

--- a/src/electron/commands/addProject.ts
+++ b/src/electron/commands/addProject.ts
@@ -139,18 +139,27 @@ export async function addProject(
     }
 
     if (hasDotNET && !releases.some((r) => r.mono)) {
-    // no mono release available for this version
+        // no mono release available for this version
         return {
             success: false,
             error:
-        'Project seems to be a .NET project but no Editor with .NET release found',
+                'Project seems to be a .NET project but no Editor with .NET release found',
         };
     }
 
-    release = releases.find((r) => r.mono === hasDotNET);
+    const compatibleReleases = releases.filter(
+        (r) => r.config_version >= configVersion
+    );
 
-    if (!release || release.config_version < configVersion) {
-        release = undefined;
+    release =
+        compatibleReleases.find((r) => r.mono === hasDotNET) ??
+        compatibleReleases[0];
+
+    if (!release) {
+        return {
+            success: false,
+            error: `No installed releases found for Godot ${releaseBaseVersion}.x that support config_version ${configVersion}.`,
+        };
     }
 
     let config: ProjectConfig | null = null;


### PR DESCRIPTION
Fixes #29 

**Release selection logic:**

* Updated the release selection in `addProject.ts` to filter installed releases by `config_version` compatibility before matching the `mono` property, ensuring only compatible releases are considered. If no matching release is found, the function now returns an error message indicating the lack of a suitable release.