### PR TITLE
Feat/windows symlink notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ The best way to get the latest installer is from [the Godot Launcher website](ht
 
 ### **Cross-Platform Availability**
 
-- **Windows:** Fully supported.
-- **Mac & Linux:** Coming soon to ensure you can use the same streamlined workflow on any machine.
+- **Windows, Mac, and Linux:** You can use the same streamlined workflow on any machine.
+
 
 ### **Free and Open Source**
 

--- a/src/electron/commands/userPreferences.ts
+++ b/src/electron/commands/userPreferences.ts
@@ -1,13 +1,39 @@
 import { getDefaultDirs } from '../utils/platform.utils.js';
 import { getDefaultPrefs, readPrefsFromDisk, writePrefsToDisk } from '../utils/prefs.utils.js';
 
+function migrateUserPreferences(
+    prefs: UserPreferences,
+    defaultPrefs: UserPreferences
+): { updated: boolean; value: UserPreferences } {
+    let updated = false;
+    const nextPrefs: UserPreferences = { ...prefs };
+
+    if (nextPrefs.prefs_version < 3) {
+        nextPrefs.prefs_version = 3;
+        updated = true;
+    }
+
+    if (typeof nextPrefs.windows_enable_symlinks === 'undefined') {
+        nextPrefs.windows_enable_symlinks = defaultPrefs.windows_enable_symlinks;
+        updated = true;
+    }
+
+    return { updated, value: nextPrefs };
+}
 
 export async function getUserPreferences(): Promise<UserPreferences> {
 
     const { prefsPath } = getDefaultDirs();
 
-    const prefs = await readPrefsFromDisk(prefsPath, await getDefaultPrefs());
-    return prefs;
+    const defaultPrefs = await getDefaultPrefs();
+    const prefs = await readPrefsFromDisk(prefsPath, defaultPrefs);
+    const migrated = migrateUserPreferences(prefs, defaultPrefs);
+
+    if (migrated.updated) {
+        await writePrefsToDisk(prefsPath, migrated.value);
+    }
+
+    return migrated.value;
 }
 
 export async function setUserPreferences(

--- a/src/electron/commands/userPreferences.ts
+++ b/src/electron/commands/userPreferences.ts
@@ -1,3 +1,4 @@
+import * as os from 'node:os';
 import { getDefaultDirs } from '../utils/platform.utils.js';
 import { getDefaultPrefs, readPrefsFromDisk, writePrefsToDisk } from '../utils/prefs.utils.js';
 
@@ -7,6 +8,7 @@ function migrateUserPreferences(
 ): { updated: boolean; value: UserPreferences } {
     let updated = false;
     const nextPrefs: UserPreferences = { ...prefs };
+    const platform = os.platform();
 
     if (nextPrefs.prefs_version < 3) {
         nextPrefs.prefs_version = 3;
@@ -15,6 +17,12 @@ function migrateUserPreferences(
 
     if (typeof nextPrefs.windows_enable_symlinks === 'undefined') {
         nextPrefs.windows_enable_symlinks = defaultPrefs.windows_enable_symlinks;
+        updated = true;
+    }
+
+    if (typeof nextPrefs.windows_symlink_win_notify === 'undefined') {
+        const receivedWindowsPrefsUpgrade = platform === 'win32' && prefs.prefs_version < 3;
+        nextPrefs.windows_symlink_win_notify = receivedWindowsPrefsUpgrade ? false : defaultPrefs.windows_symlink_win_notify;
         updated = true;
     }
 

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -190,7 +190,8 @@ function handleCloseEvents(mainWindow: BrowserWindow) {
 
         // close if onboarding has not been completed
         getUserPreferences().then(prefs => {
-            if (prefs.prefs_version == 1 || (prefs.first_run && willClose === false)) {
+            const onboardingIncomplete = (prefs.first_run && willClose === false) || (process.platform === 'win32' && !prefs.windows_symlink_win_notify && willClose === false);
+            if (onboardingIncomplete) {
                 logger.debug('Incomplete onboarding, quitting instead of hiding');
                 app.quit();
             }

--- a/src/electron/utils/prefs.util.test.ts
+++ b/src/electron/utils/prefs.util.test.ts
@@ -151,7 +151,7 @@ suite('prefs.util', test => {
                 confirm_project_remove: true,
                 post_launch_action: "close_to_tray",
                 first_run: true,
-                windows_enable_symlinks: true,
+                windows_enable_symlinks: false,
                 windows_symlink_win_notify: false,
                 vs_code_path: "",
             });

--- a/src/electron/utils/prefs.util.test.ts
+++ b/src/electron/utils/prefs.util.test.ts
@@ -141,7 +141,7 @@ suite('prefs.util', test => {
             const defaultDirs = getDefaultDirs();
             const prefs = await getDefaultPrefs();
             expect(prefs).toEqual({
-                prefs_version: 2,
+                prefs_version: 3,
                 install_location: defaultDirs.dataDir,
                 config_location: defaultDirs.configDir,
                 projects_location: defaultDirs.projectDir,
@@ -151,6 +151,7 @@ suite('prefs.util', test => {
                 confirm_project_remove: true,
                 post_launch_action: "close_to_tray",
                 first_run: true,
+                windows_enable_symlinks: true,
                 vs_code_path: "",
             });
         });
@@ -176,7 +177,7 @@ suite('prefs.util', test => {
             const defaultDirs = getDefaultDirs();
             const prefs = await getDefaultPrefs();
             expect(prefs).toEqual({
-                prefs_version: 2,
+                prefs_version: 3,
                 install_location: defaultDirs.dataDir,
                 config_location: defaultDirs.configDir,
                 projects_location: defaultDirs.projectDir,
@@ -186,6 +187,7 @@ suite('prefs.util', test => {
                 confirm_project_remove: true,
                 post_launch_action: "close_to_tray",
                 first_run: true,
+                windows_enable_symlinks: false,
                 vs_code_path: "",
             });
         });

--- a/src/electron/utils/prefs.util.test.ts
+++ b/src/electron/utils/prefs.util.test.ts
@@ -152,6 +152,7 @@ suite('prefs.util', test => {
                 post_launch_action: "close_to_tray",
                 first_run: true,
                 windows_enable_symlinks: true,
+                windows_symlink_win_notify: false,
                 vs_code_path: "",
             });
         });
@@ -188,6 +189,7 @@ suite('prefs.util', test => {
                 post_launch_action: "close_to_tray",
                 first_run: true,
                 windows_enable_symlinks: false,
+                windows_symlink_win_notify: true,
                 vs_code_path: "",
             });
         });

--- a/src/electron/utils/prefs.utils.ts
+++ b/src/electron/utils/prefs.utils.ts
@@ -37,7 +37,7 @@ export async function getDefaultPrefs(): Promise<UserPreferences> {
         start_in_tray: true,
         confirm_project_remove: true,
         first_run: true,
-        windows_enable_symlinks: platform === 'win32',
+        windows_enable_symlinks: false,
         windows_symlink_win_notify: platform === 'win32' ? false : true,
         vs_code_path: '',
 

--- a/src/electron/utils/prefs.utils.ts
+++ b/src/electron/utils/prefs.utils.ts
@@ -27,7 +27,7 @@ export async function getDefaultPrefs(): Promise<UserPreferences> {
     const pathModule = platform === 'win32' ? path.win32 : path.posix;
 
     return {
-        prefs_version: 2,
+        prefs_version: 3,
         install_location: pathModule.resolve(defaultPrefs.dataDir),
         config_location: pathModule.resolve(defaultPrefs.configDir),
         projects_location: pathModule.resolve(defaultPrefs.projectDir),
@@ -37,6 +37,7 @@ export async function getDefaultPrefs(): Promise<UserPreferences> {
         start_in_tray: true,
         confirm_project_remove: true,
         first_run: true,
+        windows_enable_symlinks: platform === 'win32',
         vs_code_path: '',
 
     };

--- a/src/electron/utils/prefs.utils.ts
+++ b/src/electron/utils/prefs.utils.ts
@@ -38,6 +38,7 @@ export async function getDefaultPrefs(): Promise<UserPreferences> {
         confirm_project_remove: true,
         first_run: true,
         windows_enable_symlinks: platform === 'win32',
+        windows_symlink_win_notify: platform === 'win32' ? false : true,
         vs_code_path: '',
 
     };

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -40,12 +40,10 @@ function App() {
         if (preferences) {
             setFirstRun(preferences.first_run || false);
 
-            // migrate from v1 to v2
-            // windows users need to be shown the windows step for changes
-            // the migration happens below after loading is done
-            if (preferences.prefs_version === 1 && platform !== 'win32') {
-                updatePreferences({ prefs_version: 3 });
-            }
+            // migrate legacy preference versions for non-Windows users
+            // if (preferences.prefs_version < 3 && platform !== 'win32') {
+            //     updatePreferences({ prefs_version: 3 });
+            // }
 
             setPrefsLoading(false);
         }
@@ -92,9 +90,8 @@ function App() {
         return <WelcomeView />;
     }
 
-    // if the user is on windows and the prefs_version is 1, show the windows step
-    // this is a one time step, so we can just show it and then update the prefs_version
-    if (preferences?.prefs_version === 1 && platform === 'win32') {
+    // if the user is on windows and has not acknowledged the symlink change, show the windows step
+    if (platform === 'win32' && preferences && !preferences.windows_symlink_win_notify) {
         return (
             <div className='flex flex-col items-center justify-start w-full h-full'>
                 <div className="flex flex-col h-[535px] w-[1008px] p-10">
@@ -102,7 +99,10 @@ function App() {
                     <div className='flex-1'></div>
                     <div className='flex justify-center'>
                         <button className="btn btn-primary" onClick={() => {
-                            updatePreferences({ prefs_version: 3 });
+                            updatePreferences({
+                                windows_symlink_win_notify: true,
+                                prefs_version: Math.max(preferences.prefs_version ?? 3, 3)
+                            });
                         }}>Continue</button>
                     </div>
                 </div >

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -44,7 +44,7 @@ function App() {
             // windows users need to be shown the windows step for changes
             // the migration happens below after loading is done
             if (preferences.prefs_version === 1 && platform !== 'win32') {
-                updatePreferences({ prefs_version: 2 });
+                updatePreferences({ prefs_version: 3 });
             }
 
             setPrefsLoading(false);
@@ -102,7 +102,7 @@ function App() {
                     <div className='flex-1'></div>
                     <div className='flex justify-center'>
                         <button className="btn btn-primary" onClick={() => {
-                            updatePreferences({ prefs_version: 2 });
+                            updatePreferences({ prefs_version: 3 });
                         }}>Continue</button>
                     </div>
                 </div >

--- a/src/ui/components/settings/WindowsSymlinkSetting.component.tsx
+++ b/src/ui/components/settings/WindowsSymlinkSetting.component.tsx
@@ -38,13 +38,14 @@ export const WindowsSymlinkSetting: React.FC = () => {
             ? (
                 <div className="flex flex-col gap-2 text-sm">
                     <p>When enabled, Godot Launcher links each project to the installed editor instead of copying it.</p>
-                    <p>This keeps disk usage low and speeds up editor updates, but Windows may request administrator approval when new symlinks are created.</p>
+                    <p>This keeps disk usage low, but Windows may request administrator approval when new symlinks are created.</p>
+                    <p>Existing projects keep their current local copies until their editor version is changed or reinstalled.</p>
                 </div>
             )
             : (
                 <div className="flex flex-col gap-2 text-sm">
-                    <p>Disable symlinks to avoid elevation prompts. Godot Launcher will copy the editor files into each project instead.</p>
-                    <p>Existing symlinks will be replaced with local copies the next time the editor is refreshed. This can take longer for .NET builds.</p>
+                    <p>Switch back to local copies to avoid elevation prompts. Godot Launcher will copy the editor files into each project instead.</p>
+                    <p>Existing symlinks remain in place until their editor version is changed or reinstalled.</p>
                 </div>
             );
 
@@ -65,9 +66,9 @@ export const WindowsSymlinkSetting: React.FC = () => {
     return (
         <div className="flex flex-col gap-3">
             <div className="flex flex-col gap-1">
-                <h2 className="font-bold">Editor symlinks <span className='badge badge-sm badge-info'>Windows only</span></h2>
+                <h2 className="font-bold">Editor symlinks <span className='badge badge-sm badge-info'>Windows Only</span></h2>
                 <p className="text-sm text-base-content/80">
-                    Choose whether project editors use symbolic links (recommended) or local copies.
+                    Choose whether project editors use optional symbolic links or stay with local copies.
                 </p>
             </div>
             <label className="flex flex-row items-start gap-4 cursor-pointer">
@@ -79,9 +80,12 @@ export const WindowsSymlinkSetting: React.FC = () => {
                     disabled={saving}
                 />
                 <span className="text-sm">
-                    Use symbolic links for Windows project editors. When enabled, elevation prompts may appear when creating or updating editor links.
+                    Use symbolic links for Windows project editors. This stays off by default so you can opt in when you are ready for potential elevation prompts during editor updates.
                 </span>
             </label>
+            <p className="text-xs text-base-content/70">
+                Changing this setting does not convert existing project links; it only affects how future editor refreshes behave.
+            </p>
         </div>
     );
 };

--- a/src/ui/components/settings/WindowsSymlinkSetting.component.tsx
+++ b/src/ui/components/settings/WindowsSymlinkSetting.component.tsx
@@ -1,0 +1,87 @@
+import { TriangleAlert } from 'lucide-react';
+import { useState } from 'react';
+import { useAlerts } from '../../hooks/useAlerts';
+import { usePreferences } from '../../hooks/usePreferences';
+
+export const WindowsSymlinkSetting: React.FC = () => {
+    const { preferences, savePreferences, platform } = usePreferences();
+    const { addCustomConfirm } = useAlerts();
+    const [saving, setSaving] = useState(false);
+
+    if (platform !== 'win32' || !preferences) {
+        return null;
+    }
+
+    const applyPreferenceChange = async (nextValue: boolean) => {
+        setSaving(true);
+        try {
+            await savePreferences({
+                ...preferences,
+                windows_enable_symlinks: nextValue,
+            });
+        }
+        finally {
+            setSaving(false);
+        }
+
+        return true;
+    };
+
+    const handleToggleChange = (checked: boolean) => {
+        if (preferences.windows_enable_symlinks === checked) {
+            return;
+        }
+
+        const title = checked ? 'Enable editor symlinks' : 'Disable editor symlinks';
+        const actionLabel = checked ? 'Enable symlinks' : 'Disable symlinks';
+        const description = checked
+            ? (
+                <div className="flex flex-col gap-2 text-sm">
+                    <p>When enabled, Godot Launcher links each project to the installed editor instead of copying it.</p>
+                    <p>This keeps disk usage low and speeds up editor updates, but Windows may request administrator approval when new symlinks are created.</p>
+                </div>
+            )
+            : (
+                <div className="flex flex-col gap-2 text-sm">
+                    <p>Disable symlinks to avoid elevation prompts. Godot Launcher will copy the editor files into each project instead.</p>
+                    <p>Existing symlinks will be replaced with local copies the next time the editor is refreshed. This can take longer for .NET builds.</p>
+                </div>
+            );
+
+        addCustomConfirm(title, description, [
+            {
+                isCancel: true,
+                typeClass: 'btn-neutral',
+                text: 'Cancel',
+            },
+            {
+                typeClass: 'btn-primary',
+                text: actionLabel,
+                onClick: () => applyPreferenceChange(checked),
+            },
+        ], <TriangleAlert className="text-warning" />);
+    };
+
+    return (
+        <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-1">
+                <h2 className="font-bold">Editor symlinks</h2>
+                <p className="text-sm text-base-content/80">
+                    Choose whether project editors use symbolic links (recommended) or local copies.
+                </p>
+            </div>
+            <label className="flex flex-row items-start gap-4 cursor-pointer">
+                <input
+                    type="checkbox"
+                    className="checkbox"
+                    checked={preferences.windows_enable_symlinks}
+                    onChange={(e) => handleToggleChange(e.target.checked)}
+                    disabled={saving}
+                />
+                <span className="text-sm">
+                    Use symbolic links for Windows project editors. When enabled, elevation prompts may appear when creating or updating editor links.
+                </span>
+            </label>
+        </div>
+    );
+};

--- a/src/ui/components/settings/WindowsSymlinkSetting.component.tsx
+++ b/src/ui/components/settings/WindowsSymlinkSetting.component.tsx
@@ -65,7 +65,7 @@ export const WindowsSymlinkSetting: React.FC = () => {
     return (
         <div className="flex flex-col gap-3">
             <div className="flex flex-col gap-1">
-                <h2 className="font-bold">Editor symlinks</h2>
+                <h2 className="font-bold">Editor symlinks <span className='badge badge-sm badge-info'>Windows only</span></h2>
                 <p className="text-sm text-base-content/80">
                     Choose whether project editors use symbolic links (recommended) or local copies.
                 </p>

--- a/src/ui/components/welcomeSteps/CustomizeBehaviorStep.tsx
+++ b/src/ui/components/welcomeSteps/CustomizeBehaviorStep.tsx
@@ -3,6 +3,7 @@ import { ChangeEvent } from 'react';
 
 import { usePreferences } from '../../hooks/usePreferences';
 
+
 export const CustomizeBehaviorStep: React.FC = () => {
 
     const { preferences, updatePreferences, setAutoStart } = usePreferences();

--- a/src/ui/components/welcomeSteps/WindowsStep.tsx
+++ b/src/ui/components/welcomeSteps/WindowsStep.tsx
@@ -11,9 +11,9 @@ export const WindowsStep: React.FC = () => {
         <div className='text-sm'>
             <h1 className="text-xl">Windows Note</h1>
             <p>
-                Starting from version 1.4.0, Godot Launcher creates{' '}
+                Starting from version 1.4.0, Godot Launcher can create{' '}
                 <code className="bg-base-300 px-2 rounded text-warning">symlinks</code> to the editor for each project.
-                You can switch this off later in <strong>Settings → Behavior → Editor symlinks</strong> if you prefer local copies.
+                To keep setup simple, we now default to local copies. You can enable symlinks anytime from <strong>Settings → Behavior → Editor symlinks</strong> when you want lower disk usage.
             </p>
             <div className="pt-6 flex flex-col gap-2">
                 <h2 className="font-bold">What changed?</h2>
@@ -26,7 +26,7 @@ export const WindowsStep: React.FC = () => {
                         <code className="bg-base-300 px-2 rounded text-warning">Developer Mode</code> is not enabled.
                     </li>
                     <li>
-                        Prefer to avoid elevation prompts? Toggle off <strong>Editor symlinks</strong> in Settings and the launcher will copy the editor into each project instead.
+                        Ready to try symlinks? Toggle on <strong>Editor symlinks</strong> in Settings when you're prepared for the occasional elevation prompt.
                     </li>
                     <li className="flex flex-row gap-1 font-bold">
                         NOTE: If you are using .NET-based editors, you need to install the .NET SDK from{' '}

--- a/src/ui/components/welcomeSteps/WindowsStep.tsx
+++ b/src/ui/components/welcomeSteps/WindowsStep.tsx
@@ -13,6 +13,7 @@ export const WindowsStep: React.FC = () => {
             <p>
                 Starting from version 1.4.0, Godot Launcher creates{' '}
                 <code className="bg-base-300 px-2 rounded text-warning">symlinks</code> to the editor for each project.
+                You can switch this off later in <strong>Settings → Behavior → Editor symlinks</strong> if you prefer local copies.
             </p>
             <div className="pt-6 flex flex-col gap-2">
                 <h2 className="font-bold">What changed?</h2>
@@ -23,6 +24,9 @@ export const WindowsStep: React.FC = () => {
                     <li>
                         You will see a UAC prompt only if you are not an  <code className="bg-base-300 px-2 rounded text-warning">Administrator</code> on your PC and if{' '}
                         <code className="bg-base-300 px-2 rounded text-warning">Developer Mode</code> is not enabled.
+                    </li>
+                    <li>
+                        Prefer to avoid elevation prompts? Toggle off <strong>Editor symlinks</strong> in Settings and the launcher will copy the editor into each project instead.
                     </li>
                     <li className="flex flex-row gap-1 font-bold">
                         NOTE: If you are using .NET-based editors, you need to install the .NET SDK from{' '}

--- a/src/ui/views/projects.view.tsx
+++ b/src/ui/views/projects.view.tsx
@@ -286,18 +286,18 @@ export const ProjectsView: React.FC = () => {
                                                     </button>
 
                                                     {row.release.mono &&
-                                                        <p className='tooltip tooltip-right tooltip-primary' data-tip="This is a .Net Project">
-                                                            <p className="badge badge-outline text-xs text-base-content/50 ">c#</p>
+                                                        <p className='tooltip tooltip-right tooltip-primary flex items-center' data-tip="This is a .Net Project">
+                                                            <span className="badge badge-outline text-xs text-base-content/50 ">c#</span>
                                                         </p>
                                                     }
                                                     {row.release.prerelease &&
-                                                        <p className='tooltip tooltip-right right-0 tooltip-secondary' data-tip="Using a pre-release Godot editor version">
-                                                            <p className="badge badge-secondary badge-outline text-xs text-base-content/50 ">pr</p>
+                                                        <p className='tooltip tooltip-right right-0 tooltip-secondary flex items-center' data-tip="Using a pre-release Godot editor version">
+                                                            <span className="badge badge-secondary badge-outline text-xs text-base-content/50 ">pr</span>
                                                         </p>
                                                     }
                                                     {row.open_windowed &&
-                                                        <p className='tooltip tooltip-right tooltip-primary' data-tip="This project is open in windowed mode">
-                                                            <p className="badge badge-outline text-xs text-base-content/50">w</p>
+                                                        <p className='tooltip tooltip-right tooltip-primary flex items-center' data-tip="This project is open in windowed mode">
+                                                            <span className="badge badge-outline text-xs text-base-content/50">w</span>
                                                         </p>
                                                     }
 

--- a/src/ui/views/settings.view.tsx
+++ b/src/ui/views/settings.view.tsx
@@ -7,6 +7,7 @@ import { GitToolSettings } from '../components/settings/gitToolSettings.componen
 import { ProjectLaunchAction } from '../components/settings/projectLaunchAction.component';
 import { ProjectsLocation } from '../components/settings/projectsLocation.component';
 import { VSCodeToolSettings } from '../components/settings/vsCodeToolSettings.component';
+import { WindowsSymlinkSetting } from '../components/settings/WindowsSymlinkSetting.component';
 import { usePreferences } from '../hooks/usePreferences';
 import { useTheme } from '../hooks/useTheme';
 
@@ -125,6 +126,8 @@ export const SettingsView: React.FC = () => {
                                 <div className="divider"></div>
 
                                 <ProjectLaunchAction />
+                                <div className="divider"></div>
+                                <WindowsSymlinkSetting />
                                 <div className="divider"></div>
                                 <AutoStartSetting />
                             </div>

--- a/src/ui/views/welcome.view.tsx
+++ b/src/ui/views/welcome.view.tsx
@@ -11,6 +11,7 @@ import { usePreferences } from '../hooks/usePreferences';
 import { MacOSStep } from '../components/welcomeSteps/macosStep';
 import { WindowsStep } from '../components/welcomeSteps/WindowsStep';
 import { LinuxStep } from '../components/welcomeSteps/linuxStep';
+import { WindowsSymlinkSetting } from '../components/settings/WindowsSymlinkSetting.component';
 
 interface StepDetails {
     title: string;
@@ -41,7 +42,8 @@ export const WelcomeView: React.FC = () => {
         { title: 'Windows', nextButton: 'Next: Current Settings', prevButton: 'Back: Welcome', component: <WindowsStep /> },
         { title: 'Current Settings', nextButton: 'Next: Set Locations', prevButton: 'Back: Windows', component: <CurrentSettingsStep onSkip={() => setStepIndex(4)} /> },
         { title: 'Set Locations', nextButton: 'Next: Customize Behavior', prevButton: 'Back: Current Settings', component: <SetLocationStep /> },
-        { title: 'Customize Behavior', nextButton: 'Next: Ready', prevButton: 'Back: Customize Behavior', component: <CustomizeBehaviorStep /> },
+        { title: 'Customize Behavior', nextButton: 'Next: Ready', prevButton: 'Back: Set Locations', component: <CustomizeBehaviorStep /> },
+        { title: 'Windows Symlink', nextButton: 'Next: Ready', prevButton: 'Back: Customize Behavior', component: <WindowsSymlinkSetting /> },
         { title: 'Ready', nextButton: 'Start', prevButton: 'Back: Customize Behavior', component: <StartStep /> },
     ];
 
@@ -90,7 +92,11 @@ export const WelcomeView: React.FC = () => {
         if (stepIndex >= maxSteps + 1) {
             setStepIndex(undefined);
             localStorage?.clear();
-            updatePreferences({ first_run: false });
+            const updates: Partial<UserPreferences> = { first_run: false };
+            if (platform === 'win32') {
+                updates.windows_symlink_win_notify = true;
+            }
+            updatePreferences(updates);
 
             return;
         }

--- a/types.d.ts
+++ b/types.d.ts
@@ -34,6 +34,7 @@ type UserPreferences = {
     start_in_tray: boolean;
     confirm_project_remove: boolean;
     first_run: boolean;
+    windows_enable_symlinks: boolean;
     vs_code_path?: string;
 };
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -35,6 +35,7 @@ type UserPreferences = {
     confirm_project_remove: boolean;
     first_run: boolean;
     windows_enable_symlinks: boolean;
+    windows_symlink_win_notify: boolean;
     vs_code_path?: string;
 };
 


### PR DESCRIPTION
This pull request introduces a new user preference for Windows users that allows them to choose between using symbolic links (symlinks) or local copies for project editors. It implements a migration path for existing users, updates onboarding and settings UI, and improves the symlink/copy logic for Windows editor installation. The changes also update default preferences and related tests.

**Windows symlink preference and onboarding improvements:**

- Added a new user preference `windows_enable_symlinks` (default: false) to let Windows users opt in to using symlinks for project editors, reducing disk usage but possibly requiring elevation. A new `windows_symlink_win_notify` preference tracks whether the user has acknowledged this change. The onboarding flow now prompts Windows users to review this setting, and the Welcome step and documentation have been updated to explain the change. [[1]](diffhunk://#diff-08e228d1946b2a7f4e61ff980b767d58c707b7749ee966cb347b0522a2897dd2R1-R44) [[2]](diffhunk://#diff-744726f3a09b998514c5365e9c4b4cfdbb0bb6c35be81dca92f995d023033650R40-R41) [[3]](diffhunk://#diff-deade10a591a0aade6995b4c5cf6e538047485a99cacce82d98cd5c5da6a76afL14-R16) [[4]](diffhunk://#diff-deade10a591a0aade6995b4c5cf6e538047485a99cacce82d98cd5c5da6a76afR28-R30) [[5]](diffhunk://#diff-0022b32944774e72bcbec1b0520e753925073bfbeff256269d0f668f5f515b0eL95-R105)

- Added a new settings component, `WindowsSymlinkSetting`, allowing users to toggle the symlink behavior with clear explanations and confirmation prompts.

**Windows editor installation logic:**

- Updated the Windows editor installation logic in `godot.utils.windows.ts` to respect the new `windows_enable_symlinks` preference: if disabled, editor files are copied instead of symlinked. If symlink creation fails, the logic gracefully falls back to copying. [[1]](diffhunk://#diff-8d52bbb128ab2f561dad15ea2ac0b3f78db32e6b6bf00fdd9d28413f3930fde9R5-R38) [[2]](diffhunk://#diff-8d52bbb128ab2f561dad15ea2ac0b3f78db32e6b6bf00fdd9d28413f3930fde9L71-R108) [[3]](diffhunk://#diff-8d52bbb128ab2f561dad15ea2ac0b3f78db32e6b6bf00fdd9d28413f3930fde9L92) [[4]](diffhunk://#diff-8d52bbb128ab2f561dad15ea2ac0b3f78db32e6b6bf00fdd9d28413f3930fde9R142-R175)

**User preference migration and defaults:**

- Implemented a migration function to ensure existing user preferences are upgraded to include the new symlink-related fields, and to update the preference version.
- Updated default preferences and related tests to set `prefs_version: 3` and include the new Windows-specific fields. [[1]](diffhunk://#diff-744726f3a09b998514c5365e9c4b4cfdbb0bb6c35be81dca92f995d023033650L30-R30) [[2]](diffhunk://#diff-a78f173f5f8255d186c991cdc2e67d0dba6c88194c6bf2f53f4dbcbf826aede0L144-R144) [[3]](diffhunk://#diff-a78f173f5f8255d186c991cdc2e67d0dba6c88194c6bf2f53f4dbcbf826aede0R154-R155) [[4]](diffhunk://#diff-a78f173f5f8255d186c991cdc2e67d0dba6c88194c6bf2f53f4dbcbf826aede0L179-R181) [[5]](diffhunk://#diff-a78f173f5f8255d186c991cdc2e67d0dba6c88194c6bf2f53f4dbcbf826aede0R191-R192)

**Other onboarding and documentation improvements:**

- Adjusted onboarding logic to use the new `windows_symlink_win_notify` field instead of just `prefs_version`, ensuring users are properly notified of the symlink option. [[1]](diffhunk://#diff-ecd6b47508d8dd0178b7715ca56f19a9ae4644df6c2dca43533d53b8fe2788eaL193-R194) [[2]](diffhunk://#diff-0022b32944774e72bcbec1b0520e753925073bfbeff256269d0f668f5f515b0eL43-R46)
- Updated documentation to clarify cross-platform support and the new Windows symlink workflow.