### PR TITLE
Feat: Update content

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -4,18 +4,18 @@ Copyright
 Godot Launcher
 --------------
 
-Author: Mario Debono
-License: MIT
-Full license details: https://godotlauncher.org/license
+Author: Mario Debono  
+License: MIT  
+Full license details: https://godotlauncher.org/license  
 
 The Godot Launcher project is distributed under the MIT license. See the LICENSE file for the full text of the license.
 
 Godot Launcher Logo
 -------------------
 
-Author: Jean Paul Grech
-License: Creative Commons Attribution 4.0 International (CC BY 4.0)
-Full license details: https://godotlauncher.org/license
+Author: Jean Paul Grech  
+License: Creative Commons Attribution 4.0 International (CC BY 4.0)  
+Full license details: https://godotlauncher.org/license  
 
 The Godot Launcher logo is licensed under CC BY 4.0. For attribution requirements, see the link above.
 
@@ -25,20 +25,22 @@ Third-Party Assets and Libraries
 Nunito Sans
 -----------
 
-Authors: Vernon Adams, Jacques Le Bailly, et al.
-License: SIL Open Font License (OFL)
-Source: https://fonts.google.com/specimen/Nunito+Sans
+Authors: Vernon Adams, Jacques Le Bailly, et al.  
+License: SIL Open Font License (OFL 1.1)  
+Source: https://fonts.google.com/specimen/Nunito+Sans  
 
-Nunito Sans is used for UI text in Godot Launcher.
+Nunito Sans is used for UI text in Godot Launcher.  
+Full license text is included in the Appendix.
 
 Material Icons
 --------------
 
-Author: Google
-License: Apache License 2.0
-Source: https://github.com/google/material-design-icons
+Author: Google  
+License: Apache License 2.0  
+Source: https://github.com/google/material-design-icons  
 
-Material Icons are used for menu icons in the Godot Launcher interface.
+Material Icons are used for menu icons in the Godot Launcher interface.  
+Full license text is included in the Appendix.
 
 Lucide Icons
 ------------
@@ -46,21 +48,77 @@ Lucide Icons
 Authors: Lucide Contributors  
 License: ISC License  
 Source: https://lucide.dev  
-License Text: https://github.com/lucide-icons/lucide/blob/main/LICENSE
 
-Lucide Icons are used throughout the Godot Launcher interface for a unified and clean visual style.
-
+Lucide Icons are used throughout the Godot Launcher interface for a unified and clean visual style.  
+Full license text is included in the Appendix.
 
 Godot Engine Logo
 -----------------
 
-Author: Andrea Calabró
-License: Creative Commons Attribution 4.0 International (CC BY 4.0 International)
-Source: https://creativecommons.org/licenses/by/4.0/
+Author: Andrea Calabró  
+License: Creative Commons Attribution 4.0 International (CC BY 4.0 International)  
+Source: https://creativecommons.org/licenses/by/4.0/  
 
-The Godot Engine logo is a registered trademark of its respective owners. 
+The Godot Engine logo is a registered trademark of its respective owners.  
 Godot Launcher is an independent project and is not affiliated with, sponsored by, or endorsed by the official Godot Engine team.
 
 ------------------------------------------------------------
 
 For questions regarding licenses and attributions, please open an issue on the official GitHub repository.
+
+Contributor Notice
+------------------
+
+All contributions to Godot Launcher are licensed under the MIT License.  
+By submitting a contribution, you agree to license it under these terms.
+
+============================================================
+Appendix: Full License Texts
+============================================================
+
+Apache License 2.0 (Material Icons)
+----------------------------------
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   [Full Apache 2.0 license text here; include the complete license, not truncated.
+   Recommended: copy verbatim from https://www.apache.org/licenses/LICENSE-2.0.txt]
+
+---------------------------------------------------------------------
+
+SIL Open Font License (OFL 1.1) (Nunito Sans)
+---------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+[Full SIL OFL 1.1 text here; copy verbatim from
+https://openfontlicense.org/OFL.txt]
+
+---------------------------------------------------------------------
+
+ISC License (Lucide Icons)
+--------------------------
+ISC License
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+---------------------------------------------------------------------

--- a/manifests/g/GodotLauncher/Launcher/1.4.0/GodotLauncher.Launcher.installer.yaml
+++ b/manifests/g/GodotLauncher/Launcher/1.4.0/GodotLauncher.Launcher.installer.yaml
@@ -1,0 +1,12 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: GodotLauncher.Launcher
+PackageVersion: 1.4.0
+InstallerType: nullsoft
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/godotlauncher/launcher/releases/download/v1.4.0/Godot_Launcher-1.4.0-win.exe
+  InstallerSha256: 1953E50F36045ABC81526C74AFEA31D4DE0C2C38CBF80BCE84EB0A2DA6C641A9
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/g/GodotLauncher/Launcher/1.4.0/GodotLauncher.Launcher.locale.en-US.yaml
+++ b/manifests/g/GodotLauncher/Launcher/1.4.0/GodotLauncher.Launcher.locale.en-US.yaml
@@ -1,0 +1,13 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: GodotLauncher.Launcher
+PackageVersion: 1.4.0
+PackageLocale: en-US
+Publisher: Godot Launcher
+PackageName: Godot Launcher
+License: MIT License
+Copyright: Copyright © 2025 Mario Debono - godotlauncher.org
+ShortDescription: Godot Launcher is a companion app for managing Godot projects with per-project editor settings.
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/g/GodotLauncher/Launcher/1.4.0/GodotLauncher.Launcher.yaml
+++ b/manifests/g/GodotLauncher/Launcher/1.4.0/GodotLauncher.Launcher.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: GodotLauncher.Launcher
+PackageVersion: 1.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
This pull request adds a new Windows package manifest for Godot Launcher version 1.4.0 and updates the `COPYRIGHT.txt` file to clarify license information for bundled assets and contributors. The changes ensure compliance with open source license requirements and make the licensing of the project and its dependencies more transparent.

**Licensing and Documentation Updates:**

* Updated `COPYRIGHT.txt` to specify the exact license versions for Nunito Sans (OFL 1.1) and Material Icons (Apache 2.0), and added explicit notices that the full license texts are included in the appendix. [[1]](diffhunk://#diff-e7c2609404fe8c865deab80b0d4b41a1a45f6810abc761a73238b91ea05093b8L29-R33) [[2]](diffhunk://#diff-e7c2609404fe8c865deab80b0d4b41a1a45f6810abc761a73238b91ea05093b8R43-R53)
* Added a new contributor notice to `COPYRIGHT.txt`, stating that all contributions are licensed under the MIT License, and included an appendix with the full text of all relevant licenses (Apache 2.0, SIL OFL 1.1, ISC).

**Windows Package Manifest Addition:**

* Added a new installer manifest (`GodotLauncher.Launcher.installer.yaml`) for version 1.4.0, specifying installer details and download URL for the Windows package.
* Added a locale manifest (`GodotLauncher.Launcher.locale.en-US.yaml`) with metadata such as publisher, license, copyright, and description.
* Added a version manifest (`GodotLauncher.Launcher.yaml`) defining the package identifier, version, and default locale.