### PR TITLE
chore: add Azure timestamp options to signing configuration

### DIFF
--- a/electron-builder-config.cjs
+++ b/electron-builder-config.cjs
@@ -64,11 +64,14 @@ module.exports =
         "icon": "build/icon.ico",
         "executableName": "GodotLauncher",
         "artifactName": "Godot_Launcher-${version}-${os}.${ext}",
+
         "azureSignOptions": {
 
             "endpoint": process.env.WIN_SIGN_ENDPOINT,
             "certificateProfileName": process.env.WIN_SIGN_CERTIFICATE_PROFILE_NAME,
             "codeSigningAccountName": process.env.WIN_SIGN_CODE_SIGNING_ACCOUNT_NAME,
+            "TimestampRfc3161": process.env.AZURE_TIMESTAMP_URL,
+            "TimestampDigest": process.env.AZURE_TIMESTAMP_DIGEST
         },
 
         "target": [


### PR DESCRIPTION
This pull request adds additional Azure signing configuration options to the Windows build settings in `electron-builder-config.cjs`. These changes allow the build process to use custom timestamping settings when signing Windows executables.

Windows signing configuration:

* Added `TimestampRfc3161` and `TimestampDigest` options to the `azureSignOptions` section, allowing the use of custom timestamp server URL and digest algorithm for code signing.