### PR TITLE
chore: update installer SHA256 and add missing metadata in locale file

### DIFF
--- a/manifests/g/GodotLauncher/Launcher/1.4.0/GodotLauncher.Launcher.installer.yaml
+++ b/manifests/g/GodotLauncher/Launcher/1.4.0/GodotLauncher.Launcher.installer.yaml
@@ -7,6 +7,7 @@ InstallerType: nullsoft
 Installers:
 - Architecture: neutral
   InstallerUrl: https://github.com/godotlauncher/launcher/releases/download/v1.4.0/Godot_Launcher-1.4.0-win.exe
-  InstallerSha256: 1953E50F36045ABC81526C74AFEA31D4DE0C2C38CBF80BCE84EB0A2DA6C641A9
+  InstallerSha256: E2A59621688C2F9E4E20FC8308F5F8EDE41E845A23164B1A5E329AA6928BC76F
 ManifestType: installer
 ManifestVersion: 1.10.0
+ReleaseDate: 2025-10-03

--- a/manifests/g/GodotLauncher/Launcher/1.4.0/GodotLauncher.Launcher.locale.en-US.yaml
+++ b/manifests/g/GodotLauncher/Launcher/1.4.0/GodotLauncher.Launcher.locale.en-US.yaml
@@ -5,9 +5,20 @@ PackageIdentifier: GodotLauncher.Launcher
 PackageVersion: 1.4.0
 PackageLocale: en-US
 Publisher: Godot Launcher
+PublisherUrl: https://github.com/godotlauncher
+PublisherSupportUrl: https://github.com/godotlauncher/launcher/issues
 PackageName: Godot Launcher
+PackageUrl: https://github.com/godotlauncher/launcher
 License: MIT License
 Copyright: Copyright © 2025 Mario Debono - godotlauncher.org
 ShortDescription: Godot Launcher is a companion app for managing Godot projects with per-project editor settings.
+Tags:
+- electron
+- godot-engine
+- godot-launcher
+- godot-launcher-app
+- react
+- tailwindcss
+ReleaseNotesUrl: https://github.com/godotlauncher/launcher/releases/tag/v1.4.0
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0


### PR DESCRIPTION
This pull request updates the metadata for the `GodotLauncher.Launcher` package to improve accuracy and completeness. The most important changes are grouped below.

Installer metadata updates:

* Updated the `InstallerSha256` value in `GodotLauncher.Launcher.installer.yaml` to reflect the latest installer binary.
* Added a `ReleaseDate` field to specify the release date of version 1.4.0.

Locale and package metadata improvements:

* Added `PublisherUrl`, `PublisherSupportUrl`, and `PackageUrl` fields to provide direct links to the publisher and support resources.
* Added a `Tags` section to improve discoverability and categorization of the package.
* Added a `ReleaseNotesUrl` field to link to the release notes for version 1.4.0.