### PR TITLE
Fix prefs read/write race condition

### DIFF
--- a/src/electron/utils/prefs.util.test.ts
+++ b/src/electron/utils/prefs.util.test.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 
-import { beforeEach, describe, expect, it, MockedObject, suite, vi } from 'vitest';
-import { getConfigDir, getDefaultPrefs, getPrefsPath, readPrefsFromDisk, writePrefsToDisk } from './prefs.utils';
+import { afterEach, beforeEach, describe, expect, it, MockedObject, suite, vi } from 'vitest';
+import { __resetPrefsCacheForTesting, getConfigDir, getDefaultPrefs, getPrefsPath, readPrefsFromDisk, writePrefsToDisk } from './prefs.utils';
 
 import { APP_INTERNAL_NAME } from '../constants';
 import { getDefaultDirs } from "./platform.utils";
@@ -82,6 +82,9 @@ const fsMock = fs as unknown as MockedObject<typeof fs>;
 const fsPromisesMock = fs.promises as unknown as MockedObject<typeof fs.promises>;
 
 suite('prefs.util', test => {
+    afterEach(() => {
+        __resetPrefsCacheForTesting();
+    });
     describe('should be able to get default data and config locations for Windows', () => {
         beforeEach(() => {
             (os.platform as any).mockReturnValue('win32');
@@ -224,7 +227,7 @@ suite('prefs.util', test => {
 
 
         const prefsPath = "/home/user/.godot/prefs.json";
-        const prefs = writePrefsToDisk(prefsPath, { a: 1 });
+        await writePrefsToDisk(prefsPath, { a: 1 });
 
         expect(fsPromisesMock.writeFile).toBeCalledWith(prefsPath, JSON.stringify({ a: 1 }, null, 4), "utf-8");
         expect(fsPromisesMock.writeFile).toHaveBeenCalledTimes(1);

--- a/src/electron/utils/prefs.utils.ts
+++ b/src/electron/utils/prefs.utils.ts
@@ -4,12 +4,56 @@ import { dialog } from 'electron';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { createHash } from 'node:crypto';
 
 import { startAutoUpdateChecks, stopAutoUpdateChecks } from '../autoUpdater.js';
 import { getUserPreferences, setUserPreferences } from '../commands/userPreferences.js';
 import { getDefaultDirs } from './platform.utils.js';
 
 const loadedPrefs: UserPreferences | null = null;
+type CachedPrefs = {
+    value: UserPreferences;
+    hash: string;
+};
+
+const prefsCache = new Map<string, CachedPrefs>();
+const writeQueue = new Map<string, Promise<void>>();
+
+function clonePrefs<T>(prefs: T): T {
+    return JSON.parse(JSON.stringify(prefs));
+}
+
+function hashPrefs(prefs: UserPreferences): string {
+    return createHash('md5').update(JSON.stringify(prefs)).digest('hex');
+}
+
+async function waitForPendingWrite(prefsPath: string): Promise<void> {
+    const pending = writeQueue.get(prefsPath);
+    if (!pending) {
+        return;
+    }
+
+    try {
+        await pending;
+    } catch (error) {
+        logger.error('Failed to persist user preferences', error);
+    }
+}
+
+function enqueueWrite(prefsPath: string, action: () => Promise<void>): Promise<void> {
+    const previous = writeQueue.get(prefsPath) ?? Promise.resolve();
+    const finalPromise = previous
+        .catch(() => undefined)
+        .then(action)
+        .finally(() => {
+            if (writeQueue.get(prefsPath) === finalPromise) {
+                writeQueue.delete(prefsPath);
+            }
+        });
+
+    writeQueue.set(prefsPath, finalPromise);
+    return finalPromise;
+}
 
 export async function getPrefsPath(): Promise<string> {
     const defaultPaths = getDefaultDirs();
@@ -45,16 +89,25 @@ export async function getDefaultPrefs(): Promise<UserPreferences> {
 }
 
 export async function readPrefsFromDisk(prefsPath: string, defaultPrefs: UserPreferences): Promise<UserPreferences> {
+    await waitForPendingWrite(prefsPath);
+
+    const cached = prefsCache.get(prefsPath);
+    if (cached) {
+        return clonePrefs(cached.value);
+    }
+
     if (!fs.existsSync(prefsPath)) {
-        // load defaults
-        return defaultPrefs;
+        const cachedDefaults = clonePrefs(defaultPrefs);
+        prefsCache.set(prefsPath, { value: cachedDefaults, hash: hashPrefs(cachedDefaults) });
+        return clonePrefs(cachedDefaults);
     }
 
     // Read prefs from disk
     const prefsData = await fs.promises.readFile(prefsPath, 'utf-8');
+    let mergedPrefs = clonePrefs(defaultPrefs);
     try {
         const prefs = JSON.parse(prefsData);
-        return { ...defaultPrefs, ...prefs };
+        mergedPrefs = { ...defaultPrefs, ...prefs };
     } catch (e) {
         logger.debug('Could not parse user preferences, using defaults', e);
         // todo: translate message to all locales
@@ -64,14 +117,32 @@ export async function readPrefsFromDisk(prefsPath: string, defaultPrefs: UserPre
             message: 'Could not parse user preferences. Using default preferences.',
             buttons: ['OK'],
         });
-        return defaultPrefs;
     }
+
+    const cachedPrefs = clonePrefs(mergedPrefs);
+    prefsCache.set(prefsPath, { value: cachedPrefs, hash: hashPrefs(cachedPrefs) });
+    return clonePrefs(cachedPrefs);
 }
 
 export async function writePrefsToDisk(prefsPath: string, prefs: UserPreferences): Promise<void> {
+    const existing = prefsCache.get(prefsPath);
+    const normalizedPrefs = clonePrefs(prefs);
+    const newHash = hashPrefs(normalizedPrefs);
+
+    if (existing && existing.hash === newHash) {
+        await waitForPendingWrite(prefsPath);
+        return;
+    }
+
+    prefsCache.set(prefsPath, { value: normalizedPrefs, hash: newHash });
+
     // Write prefs to disk
-    const prefsData = JSON.stringify(prefs, null, 4);
-    await fs.promises.writeFile(prefsPath, prefsData, 'utf-8');
+    const prefsData = JSON.stringify(normalizedPrefs, null, 4);
+    const writePromise = enqueueWrite(prefsPath, async () => {
+        await fs.promises.writeFile(prefsPath, prefsData, 'utf-8');
+    });
+
+    await writePromise;
 }
 
 export async function getLoadedPrefs(): Promise<UserPreferences> {
@@ -99,4 +170,9 @@ export async function setAutoCheckUpdates(enabled: boolean): Promise<boolean> {
 
     return enabled;
 
+}
+
+export function __resetPrefsCacheForTesting(): void {
+    prefsCache.clear();
+    writeQueue.clear();
 }


### PR DESCRIPTION
This pull request introduces a caching mechanism and write queue for user preferences in the Electron app, improving performance and consistency when reading and writing preferences. It also adds test utilities for cache management and updates tests to ensure proper cache clearing between runs.

**User preferences caching and write queue:**

* Added a `prefsCache` map to cache user preferences by file path, reducing unnecessary disk reads and ensuring up-to-date values are returned. (`src/electron/utils/prefs.utils.ts`) [[1]](diffhunk://#diff-744726f3a09b998514c5365e9c4b4cfdbb0bb6c35be81dca92f995d023033650R7-R56) [[2]](diffhunk://#diff-744726f3a09b998514c5365e9c4b4cfdbb0bb6c35be81dca92f995d023033650R92-R145)
* Implemented a `writeQueue` to serialize writes to the preferences file, preventing race conditions and ensuring data integrity. (`src/electron/utils/prefs.utils.ts`) [[1]](diffhunk://#diff-744726f3a09b998514c5365e9c4b4cfdbb0bb6c35be81dca92f995d023033650R7-R56) [[2]](diffhunk://#diff-744726f3a09b998514c5365e9c4b4cfdbb0bb6c35be81dca92f995d023033650R92-R145)
* Updated `readPrefsFromDisk` and `writePrefsToDisk` to use the cache and queue, and to avoid redundant writes if the preferences have not changed. (`src/electron/utils/prefs.utils.ts`)

**Testing improvements:**

* Added `__resetPrefsCacheForTesting` to clear the cache and write queue for reliable test isolation. (`src/electron/utils/prefs.utils.ts`)
* Updated test setup to call `__resetPrefsCacheForTesting` after each test, ensuring no cache leakage between tests. (`src/electron/utils/prefs.util.test.ts`) [[1]](diffhunk://#diff-a78f173f5f8255d186c991cdc2e67d0dba6c88194c6bf2f53f4dbcbf826aede0L3-R4) [[2]](diffhunk://#diff-a78f173f5f8255d186c991cdc2e67d0dba6c88194c6bf2f53f4dbcbf826aede0R85-R87)
* Fixed a test to properly await asynchronous preference writing. (`src/electron/utils/prefs.util.test.ts`)