### PR TITLE
chore(winget): add winget manifest files for 1.7.0

### DIFF
--- a/manifests/g/GodotLauncher/Launcher/1.7.0/GodotLauncher.Launcher.installer.yaml
+++ b/manifests/g/GodotLauncher/Launcher/1.7.0/GodotLauncher.Launcher.installer.yaml
@@ -1,0 +1,22 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: GodotLauncher.Launcher
+PackageVersion: 1.7.0
+InstallerType: nullsoft
+Installers:
+    - Architecture: arm64
+      InstallerUrl: https://github.com/godotlauncher/launcher/releases/download/v1.7.0/Godot_Launcher-1.7.0-win_arm64.exe
+      InstallerSha256: e0a81b2931714ff03994cf594ba98ac696c3dbfb7b8a4b5b4daacd175be82098
+    - Architecture: x64
+      InstallerUrl: https://github.com/godotlauncher/launcher/releases/download/v1.7.0/Godot_Launcher-1.7.0-win_x64.exe
+      InstallerSha256: 497ffcece2cee37a78d9b206693e2602b9a8dcde4236476277c3259b379272a8
+    - Architecture: x86
+      InstallerUrl: https://github.com/godotlauncher/launcher/releases/download/v1.7.0/Godot_Launcher-1.7.0-win_ia32.exe
+      InstallerSha256: 876cfac36f2c6ba6e9bf66efbcec3a8c405990de9b1de2a7f8301efed0cbfc78
+    - Architecture: neutral
+      InstallerUrl: https://github.com/godotlauncher/launcher/releases/download/v1.7.0/Godot_Launcher-1.7.0-win.exe
+      InstallerSha256: 884d5adc3d233a3e292942f3abd948c15509b0e62ed086f4f82c5beef85ab0d0
+ManifestType: installer
+ManifestVersion: 1.10.0
+ReleaseDate: 2025-11-07

--- a/manifests/g/GodotLauncher/Launcher/1.7.0/GodotLauncher.Launcher.locale.en-US.yaml
+++ b/manifests/g/GodotLauncher/Launcher/1.7.0/GodotLauncher.Launcher.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: GodotLauncher.Launcher
+PackageVersion: 1.7.0
+PackageLocale: en-US
+Publisher: Mario Debono - godotlauncher.org
+PublisherUrl: https://github.com/godotlauncher
+PublisherSupportUrl: https://github.com/godotlauncher/launcher/issues
+PackageName: Godot Launcher
+PackageUrl: https://github.com/godotlauncher/launcher
+License: MIT
+Copyright: Copyright © 2025 Mario Debono - godotlauncher.org
+ShortDescription: Godot Launcher is a companion app for managing Godot projects with per-project editor settings.
+Tags:
+- godot-engine
+- godot-launcher
+- godot-launcher-app
+- godot
+- game-development
+- gdscript
+ReleaseNotesUrl: https://github.com/godotlauncher/launcher/releases/tag/v1.7.0
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/g/GodotLauncher/Launcher/1.7.0/GodotLauncher.Launcher.yaml
+++ b/manifests/g/GodotLauncher/Launcher/1.7.0/GodotLauncher.Launcher.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: GodotLauncher.Launcher
+PackageVersion: 1.7.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
This pull request adds a new manifest for version 1.7.0 of the `Godot Launcher` application to the Windows Package Manager (winget) repository. The manifest includes installer metadata, localization details, and version information to support automated installation and discovery of the app.

Manifest addition for new application version:

* Added `GodotLauncher.Launcher.installer.yaml` with installer details for multiple architectures (arm64, x64, x86, neutral), including download URLs and SHA256 hashes.
* Added `GodotLauncher.Launcher.locale.en-US.yaml` providing localization, publisher, license, and descriptive metadata for the application.
* Added `GodotLauncher.Launcher.yaml` specifying the version and default locale for the manifest.