### PR TITLE
chore: update Node.js version to 24 and improve changelog command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '23'
+          node-version: '24'
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -109,7 +109,7 @@ jobs:
         id: release_notes
         shell: bash
         run: |
-          NOTES=$(PNPM_LOG_LEVEL=error pnpm run changelog --stdout --starting-version "${VERSION}" --ending-version "${VERSION}" --hide-credit --template ./auto-changelog-release.hbs)
+          NOTES=$(PNPM_LOG_LEVEL=error pnpm --silent run changelog --stdout --starting-version "${VERSION}" --ending-version "${VERSION}" --hide-credit --template ./auto-changelog-release.hbs)
           {
             echo "notes<<EOF"
             echo "${NOTES}"


### PR DESCRIPTION
This pull request makes minor updates to the release workflow configuration to improve compatibility and reduce log output noise.

* Node.js version update:
  * Changed the `node-version` in `.github/workflows/release.yml` from `23` to `24` to ensure the workflow uses the latest stable Node.js.

* Changelog command improvement:
  * Added the `--silent` flag to the `pnpm run changelog` command in `.github/workflows/release.yml` to suppress unnecessary log output during changelog generation.