### PR TITLE
fix(manifest): improve validation for custom engine manifest

### DIFF
--- a/main/src/utils/customEngineManifest.utils.test.ts
+++ b/main/src/utils/customEngineManifest.utils.test.ts
@@ -104,6 +104,20 @@ describe('parseCustomEngineManifest', () => {
         expect(release.prerelease).toBe(true);
     });
 
+    it('matches universal platform entries', async () => {
+        fsMocks.readFile.mockResolvedValue(
+            JSON.stringify({
+                ...manifest,
+                platforms: [{ ...manifest.platforms[0], arch: 'universal' }],
+            }),
+        );
+
+        const release = await parseCustomEngineManifest(manifestPath);
+
+        expect(release.editor_path).toBe(editorPath);
+        expect(release.arch).toBe('arm64');
+    });
+
     it('fails when required fields are missing', async () => {
         fsMocks.readFile.mockResolvedValue(
             JSON.stringify({ ...manifest, name: undefined }),
@@ -125,6 +139,45 @@ describe('parseCustomEngineManifest', () => {
 
         fsMocks.readFile.mockResolvedValue(
             JSON.stringify({ ...manifest, flavor: '' }),
+        );
+
+        await expect(parseCustomEngineManifest(manifestPath)).rejects.toThrow(
+            'Invalid custom editor manifest',
+        );
+    });
+
+    it('fails when base_version includes a patch version', async () => {
+        fsMocks.readFile.mockResolvedValue(
+            JSON.stringify({ ...manifest, base_version: '4.6.1' }),
+        );
+
+        await expect(parseCustomEngineManifest(manifestPath)).rejects.toThrow(
+            'Invalid custom editor manifest',
+        );
+    });
+
+    it('fails when config_version is not 5', async () => {
+        fsMocks.readFile.mockResolvedValue(
+            JSON.stringify({ ...manifest, config_version: 4 }),
+        );
+
+        await expect(parseCustomEngineManifest(manifestPath)).rejects.toThrow(
+            'Invalid custom editor manifest',
+        );
+    });
+
+    it('fails when arch is not x64, arm64, or universal', async () => {
+        fsMocks.readFile.mockResolvedValue(
+            JSON.stringify({
+                ...manifest,
+                platforms: [
+                    {
+                        platform: 'macos',
+                        arch: 'ia32',
+                        paths: { editor: './Godot.app' },
+                    },
+                ],
+            }),
         );
 
         await expect(parseCustomEngineManifest(manifestPath)).rejects.toThrow(

--- a/main/src/utils/customEngineManifest.utils.ts
+++ b/main/src/utils/customEngineManifest.utils.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 
 const manifestPlatformSchema = z.object({
     platform: z.enum(['windows', 'linux', 'macos']),
-    arch: z.enum(['x64', 'arm64', 'ia32', 'arm', 'universal']),
+    arch: z.enum(['x64', 'arm64', 'universal']),
     paths: z.object({
         editor: z.string().min(1),
         console: z.string().min(1).optional(),
@@ -18,10 +18,10 @@ const engineManifestSchema = z.object({
     schema_version: z.literal(1),
     version: z.string().min(1),
     name: z.string().min(1),
-    base_version: z.string().regex(/^\d+\.\d+(?:\.\d+)?$/),
+    base_version: z.string().regex(/^\d+\.\d+$/),
     prerelease: z.boolean().optional().default(false),
     flavor: z.string().trim().min(1),
-    config_version: z.union([z.literal(4), z.literal(5)]),
+    config_version: z.literal(5),
     platforms: z.array(manifestPlatformSchema).min(1),
 });
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "godot-launcher",
     "private": true,
     "version": "1.10.0-alpha.1",
-    "packageManager": "npm@11.15.0",
+    "packageManager": "npm@11.16.0",
     "description": "Godot Launcher is a companion app for managing Godot projects with per-project editor settings.",
     "keywords": [
         "godot",

--- a/schemas/v1/engine-manifest.json
+++ b/schemas/v1/engine-manifest.json
@@ -30,7 +30,7 @@
     },
     "base_version": {
       "type": "string",
-      "pattern": "^\\d+\\.\\d+(?:\\.\\d+)?$"
+      "pattern": "^\\d+\\.\\d+$"
     },
     "prerelease": {
       "type": "boolean",
@@ -47,7 +47,7 @@
       "description": "Deprecated compatibility field. The launcher derives mono/.NET behavior from flavor === \"dotnet\"."
     },
     "config_version": {
-      "enum": [4, 5]
+      "const": 5
     },
     "platforms": {
       "type": "array",
@@ -61,7 +61,7 @@
             "enum": ["windows", "linux", "macos"]
           },
           "arch": {
-            "enum": ["x64", "arm64", "ia32", "arm", "universal"]
+            "enum": ["x64", "arm64", "universal"]
           },
           "paths": {
             "type": "object",


### PR DESCRIPTION
This pull request tightens validation for custom engine manifests by making the accepted schema more strict and updating related tests. The main changes enforce stricter rules on version fields and supported architectures, and ensure only the latest config version is accepted.

**Manifest schema validation improvements:**

* The `base_version` field now only accepts major.minor (e.g., `4.6`), disallowing patch versions (e.g., `4.6.1`). [[1]](diffhunk://#diff-98bc7b5cf0e793442e41ca79e43dd40b809157b38caa71ba3172f4b3cef3cb13L33-R33) [[2]](diffhunk://#diff-bdb142616543ffdb409ac797e8bac47112709d5a366bfce5c28e0ebff0914fb8L21-R24)
* The `config_version` field must be exactly `5`; previous support for version `4` is removed. [[1]](diffhunk://#diff-98bc7b5cf0e793442e41ca79e43dd40b809157b38caa71ba3172f4b3cef3cb13L50-R50) [[2]](diffhunk://#diff-bdb142616543ffdb409ac797e8bac47112709d5a366bfce5c28e0ebff0914fb8L21-R24)
* The `arch` field for platforms now only allows `x64`, `arm64`, or `universal`. Support for `ia32` and `arm` is removed. [[1]](diffhunk://#diff-98bc7b5cf0e793442e41ca79e43dd40b809157b38caa71ba3172f4b3cef3cb13L64-R64) [[2]](diffhunk://#diff-bdb142616543ffdb409ac797e8bac47112709d5a366bfce5c28e0ebff0914fb8L9-R9)

**Test updates:**

* Added and updated tests to verify that the stricter schema is enforced, including checks for invalid `base_version`, `config_version`, and unsupported `arch` values. [[1]](diffhunk://#diff-ffc5f4a8a877ddb0bf64a1d6be20e79677ce2893c37c3b62d8371ad47a5b610dR149-R187) [[2]](diffhunk://#diff-ffc5f4a8a877ddb0bf64a1d6be20e79677ce2893c37c3b62d8371ad47a5b610dR107-R120)

**Dependency update:**

* Updated `packageManager` in `package.json` from `npm@11.15.0` to `npm@11.16.0`.