### PR TITLE
feat: add last opened project timestamp handling in launcher config

### DIFF
--- a/main/src/commands/addProject.test.ts
+++ b/main/src/commands/addProject.test.ts
@@ -321,6 +321,49 @@ describe('addProject', () => {
         expect(result.newProject?.release.mono).toBe(false);
     });
 
+    it('restores last opened from .godotlauncher when importing', async () => {
+        const lastOpened = new Date('2024-05-06T07:08:09.000Z');
+        readProjectLauncherConfig.mockResolvedValue({
+            config: { version: 1 },
+            launcher: { version: '1.9.0' },
+            project: {
+                last_opened: lastOpened,
+            },
+            editor: {
+                channel: 'official',
+                flavor: 'gdscript',
+                base_version: '4.3',
+                version: '4.3-stable',
+            },
+        });
+        getInstalledReleases.mockResolvedValue([
+            {
+                version: '4.3-stable',
+                version_number: 4.3,
+                install_path: '/install/4.3',
+                editor_path: '/install/4.3/Godot',
+                platform: process.platform,
+                arch: process.arch,
+                mono: false,
+                prerelease: false,
+                config_version: 5,
+                published_at: null,
+                valid: true,
+            },
+        ]);
+
+        const result = await addProject('/fake/project/project.godot');
+
+        expect(result.success).toBe(true);
+        expect(result.newProject?.last_opened).toBe(lastOpened);
+        expect(writeProjectLauncherConfig).toHaveBeenCalledWith(
+            '/fake/project',
+            expect.objectContaining({ version: '4.3-stable' }),
+            '1.0.0',
+            lastOpened,
+        );
+    });
+
     it('returns a resolution for an official .godotlauncher version with an installed fallback', async () => {
         readProjectLauncherConfig.mockResolvedValue({
             config: { version: 1 },

--- a/main/src/commands/addProject.ts
+++ b/main/src/commands/addProject.ts
@@ -558,7 +558,7 @@ export async function addProject(
             release?.version ?? `${releaseBaseVersion.toFixed(1)} (missing)`,
         version_number: release?.version_number ?? releaseBaseVersion,
         renderer,
-        last_opened: null,
+        last_opened: projectLauncherConfig?.project?.last_opened ?? null,
         launch_path,
         editor_settings_path: editorSettingsFile
             ? path.dirname(editorSettingsFile)
@@ -591,11 +591,20 @@ export async function addProject(
     };
 
     if (shouldWriteProjectLauncherConfig) {
-        await writeProjectLauncherConfig(
-            dirname,
-            project.release,
-            app.getVersion(),
-        );
+        if (project.last_opened) {
+            await writeProjectLauncherConfig(
+                dirname,
+                project.release,
+                app.getVersion(),
+                project.last_opened,
+            );
+        } else {
+            await writeProjectLauncherConfig(
+                dirname,
+                project.release,
+                app.getVersion(),
+            );
+        }
     }
 
     const allProjects = await addProjectToList(projectListPath, project);

--- a/main/src/commands/projects.test.ts
+++ b/main/src/commands/projects.test.ts
@@ -6,6 +6,7 @@ import { JsonStoreConflictError } from '../utils/jsonStore.js';
 import {
     initializeProjectGit,
     launchProject,
+    removeProject,
     setProjectVSCode,
 } from './projects.js';
 
@@ -193,8 +194,9 @@ vi.mock('electron-updater', () => ({
 
 const { existsSync } = fsMocks;
 const { getDefaultDirs } = platformMocks;
-const { getProjectsSnapshot, storeProjectsList } = projectUtilsMocks;
-const { getProjectDefinition } = godotUtilsMocks;
+const { getProjectsSnapshot, removeProjectFromList, storeProjectsList } =
+    projectUtilsMocks;
+const { getProjectDefinition, removeProjectEditor } = godotUtilsMocks;
 const { createNewEditorSettings, updateEditorSettings } = godotProjectMocks;
 const {
     updateVSCodeSettings,
@@ -271,6 +273,7 @@ describe('launchProject', () => {
             '/projects/demo',
             expect.objectContaining({ version: '4.3-stable' }),
             '1.0.0',
+            expect.any(Date),
         );
         expect(storeProjectsList).toHaveBeenCalledWith(
             path.resolve('/config', 'projects.json'),
@@ -281,6 +284,62 @@ describe('launchProject', () => {
                 }),
             ]),
             expect.objectContaining({ expectedVersion: 'v1' }),
+        );
+    });
+});
+
+describe('removeProject', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        getDefaultDirs.mockReturnValue({ configDir: '/config' });
+        removeProjectEditor.mockResolvedValue(undefined);
+        removeProjectFromList.mockResolvedValue([]);
+        writeProjectLauncherConfig.mockResolvedValue(undefined);
+    });
+
+    it('writes last opened to project launcher config before removing a project', async () => {
+        const lastOpened = new Date('2024-05-06T07:08:09.000Z');
+        const project: ProjectDetails = {
+            name: 'Demo',
+            path: '/projects/demo',
+            version: '4.3-stable',
+            version_number: 4.3,
+            renderer: 'FORWARD_PLUS',
+            editor_settings_path: '',
+            editor_settings_file: '',
+            last_opened: lastOpened,
+            open_windowed: false,
+            release: {
+                version: '4.3-stable',
+                version_number: 4.3,
+                install_path: '/godot',
+                editor_path: '/godot/godot',
+                platform: 'darwin',
+                arch: 'arm64',
+                mono: false,
+                prerelease: false,
+                config_version: 5,
+                published_at: null,
+                valid: true,
+            },
+            launch_path: '/project/editor/Godot.app',
+            config_version: 5,
+            withVSCode: false,
+            withGit: false,
+            valid: true,
+        };
+
+        await removeProject(project);
+
+        expect(writeProjectLauncherConfig).toHaveBeenCalledWith(
+            '/projects/demo',
+            expect.objectContaining({ version: '4.3-stable' }),
+            '1.0.0',
+            lastOpened,
+        );
+        expect(removeProjectFromList).toHaveBeenCalledWith(
+            path.resolve('/config', 'projects.json'),
+            '/projects/demo',
         );
     });
 });

--- a/main/src/commands/projects.ts
+++ b/main/src/commands/projects.ts
@@ -75,6 +75,22 @@ export async function removeProject(
     // await removeEditorSymlink(project.launch_path);
     await removeProjectEditor(project);
 
+    if (project.last_opened) {
+        try {
+            await writeProjectLauncherConfig(
+                project.path,
+                project.release,
+                app.getVersion(),
+                project.last_opened,
+            );
+        } catch (error) {
+            logger.warn(
+                `Failed to write project launcher config for '${project.name}' before removing it`,
+                error,
+            );
+        }
+    }
+
     const projects = await removeProjectFromList(projectListPath, project.path);
     if (process.platform === 'linux') {
         await updateLinuxTray();
@@ -138,6 +154,7 @@ export async function launchProject(project: ProjectDetails): Promise<void> {
                 storedProject.path,
                 storedProject.release,
                 app.getVersion(),
+                storedProject.last_opened,
             );
         } catch (error) {
             logger.warn(

--- a/main/src/commands/setProjectEditor.ts
+++ b/main/src/commands/setProjectEditor.ts
@@ -197,11 +197,20 @@ export async function setProjectEditor(
         updatedProjects[projectIndex] = updatedProject;
 
         try {
-            await writeProjectLauncherConfig(
-                updatedProject.path,
-                updatedProject.release,
-                app.getVersion(),
-            );
+            if (updatedProject.last_opened) {
+                await writeProjectLauncherConfig(
+                    updatedProject.path,
+                    updatedProject.release,
+                    app.getVersion(),
+                    updatedProject.last_opened,
+                );
+            } else {
+                await writeProjectLauncherConfig(
+                    updatedProject.path,
+                    updatedProject.release,
+                    app.getVersion(),
+                );
+            }
             const storedProjects = await storeProjectsList(
                 projectListPath,
                 updatedProjects,

--- a/main/src/utils/projectLauncherConfig.utils.test.ts
+++ b/main/src/utils/projectLauncherConfig.utils.test.ts
@@ -65,6 +65,55 @@ version=4.6-custom.1
         });
     });
 
+    it('serializes and parses the optional last opened timestamp', () => {
+        const lastOpened = new Date('2024-05-06T07:08:09.000Z');
+        const config = createProjectLauncherConfig(
+            release,
+            '1.9.0',
+            lastOpened,
+        );
+
+        expect(serializeProjectLauncherConfig(config)).toBe(`[config]
+version=1
+
+[launcher]
+version=1.9.0
+
+[project]
+last_opened=2024-05-06T07:08:09.000Z
+
+[editor]
+channel=official
+flavor=gdscript
+base_version=4.3
+version=4.3-stable
+`);
+
+        expect(
+            parseProjectLauncherConfig(serializeProjectLauncherConfig(config)),
+        ).toEqual(config);
+    });
+
+    it('ignores invalid last opened timestamps', () => {
+        const config = parseProjectLauncherConfig(`[config]
+version=1
+
+[launcher]
+version=1.9.0
+
+[project]
+last_opened=not-a-date
+
+[editor]
+channel=official
+flavor=gdscript
+base_version=4.3
+version=4.3-stable
+`);
+
+        expect(config?.project).toBeUndefined();
+    });
+
     it('ignores unsupported config versions', () => {
         const config = parseProjectLauncherConfig(`[config]
 version=2

--- a/main/src/utils/projectLauncherConfig.utils.ts
+++ b/main/src/utils/projectLauncherConfig.utils.ts
@@ -10,6 +10,9 @@ export type ProjectLauncherConfig = {
     launcher: {
         version: string;
     };
+    project?: {
+        last_opened: Date;
+    };
     editor: {
         channel: EditorChannel;
         flavor: EditorFlavor;
@@ -60,6 +63,15 @@ function isEditorFlavor(value: string | undefined): value is EditorFlavor {
     return Boolean(value?.trim());
 }
 
+function parseOptionalDate(value: string | undefined): Date | null {
+    if (!value) {
+        return null;
+    }
+
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
 export function getReleaseChannel(
     release: Pick<InstalledRelease, 'source'>,
 ): EditorChannel {
@@ -97,6 +109,7 @@ export function getReleaseBaseVersion(
 export function createProjectLauncherConfig(
     release: InstalledRelease,
     launcherVersion: string,
+    lastOpened?: Date | null,
 ): ProjectLauncherConfig {
     return {
         config: {
@@ -105,6 +118,7 @@ export function createProjectLauncherConfig(
         launcher: {
             version: launcherVersion,
         },
+        ...(lastOpened ? { project: { last_opened: lastOpened } } : {}),
         editor: {
             channel: getReleaseChannel(release),
             flavor: getReleaseFlavor(release),
@@ -117,20 +131,33 @@ export function createProjectLauncherConfig(
 export function serializeProjectLauncherConfig(
     config: ProjectLauncherConfig,
 ): string {
-    return [
+    const lines = [
         '[config]',
         `version=${config.config.version}`,
         '',
         '[launcher]',
         `version=${config.launcher.version}`,
         '',
+    ];
+
+    if (config.project?.last_opened) {
+        lines.push(
+            '[project]',
+            `last_opened=${config.project.last_opened.toISOString()}`,
+            '',
+        );
+    }
+
+    lines.push(
         '[editor]',
         `channel=${config.editor.channel}`,
         `flavor=${config.editor.flavor}`,
         `base_version=${config.editor.base_version}`,
         `version=${config.editor.version}`,
         '',
-    ].join('\n');
+    );
+
+    return lines.join('\n');
 }
 
 export function parseProjectLauncherConfig(
@@ -147,6 +174,7 @@ export function parseProjectLauncherConfig(
     const baseVersion = ini.editor?.base_version;
     const editorVersion = ini.editor?.version;
     const launcherVersion = ini.launcher?.version;
+    const lastOpened = parseOptionalDate(ini.project?.last_opened);
 
     if (
         !isEditorChannel(channel) ||
@@ -165,6 +193,7 @@ export function parseProjectLauncherConfig(
         launcher: {
             version: launcherVersion,
         },
+        ...(lastOpened ? { project: { last_opened: lastOpened } } : {}),
         editor: {
             channel,
             flavor,
@@ -199,8 +228,13 @@ export async function writeProjectLauncherConfig(
     projectDir: string,
     release: InstalledRelease,
     launcherVersion: string,
+    lastOpened?: Date | null,
 ): Promise<void> {
-    const config = createProjectLauncherConfig(release, launcherVersion);
+    const config = createProjectLauncherConfig(
+        release,
+        launcherVersion,
+        lastOpened,
+    );
     await fs.promises.writeFile(
         path.resolve(projectDir, PROJECT_LAUNCHER_CONFIG_FILENAME),
         serializeProjectLauncherConfig(config),


### PR DESCRIPTION
This pull request adds support for storing and restoring the "last opened" timestamp for projects in the `.godotlauncher` config, improving project state management across add, launch, edit, and remove operations. The changes ensure that when a project is added, launched, edited, or removed, the last time it was opened is correctly serialized, parsed, and written to the config file. Tests have been updated and added to cover these scenarios.

**Project "last opened" timestamp support:**

* The `ProjectLauncherConfig` type, serialization, and parsing now support an optional `last_opened` timestamp, including robust handling of invalid or missing values. [[1]](diffhunk://#diff-35aff71c48073b7412b14c11b41fdbeee15874193f0a2a92e21689f0aeda4500R13-R15) [[2]](diffhunk://#diff-35aff71c48073b7412b14c11b41fdbeee15874193f0a2a92e21689f0aeda4500R66-R74) [[3]](diffhunk://#diff-35aff71c48073b7412b14c11b41fdbeee15874193f0a2a92e21689f0aeda4500R112) [[4]](diffhunk://#diff-35aff71c48073b7412b14c11b41fdbeee15874193f0a2a92e21689f0aeda4500R121) [[5]](diffhunk://#diff-35aff71c48073b7412b14c11b41fdbeee15874193f0a2a92e21689f0aeda4500L120-R160) [[6]](diffhunk://#diff-35aff71c48073b7412b14c11b41fdbeee15874193f0a2a92e21689f0aeda4500R177) [[7]](diffhunk://#diff-35aff71c48073b7412b14c11b41fdbeee15874193f0a2a92e21689f0aeda4500R196) [[8]](diffhunk://#diff-35aff71c48073b7412b14c11b41fdbeee15874193f0a2a92e21689f0aeda4500R231-R237) [[9]](diffhunk://#diff-d29b26a212736a44a3af8e2dd7d4c902e2ebe2dc3e2ab2c5e81b2d4797f6f731R68-R116)
* The `addProject`, `removeProject`, `launchProject`, and `setProjectEditor` functions now read, propagate, and persist the `last_opened` timestamp in `.godotlauncher`. [[1]](diffhunk://#diff-5113d1c170552b14958b76d257d6f2e88239d362835fe30ef5c6c0dc68c1a392L561-R561) [[2]](diffhunk://#diff-5113d1c170552b14958b76d257d6f2e88239d362835fe30ef5c6c0dc68c1a392R594-R607) [[3]](diffhunk://#diff-8d683dc81371bbad0f2e85a6b332cad300a0d28033608e36b46c03a6efca4d2fR78-R93) [[4]](diffhunk://#diff-8d683dc81371bbad0f2e85a6b332cad300a0d28033608e36b46c03a6efca4d2fR157) [[5]](diffhunk://#diff-c398eb5c6148d29ff99fabccd4c17f5b818c13d2ee0351bca85c16ffb2070833R200-R213)
* Tests have been added or updated to verify correct handling of the `last_opened` field during project import, launch, and removal. [[1]](diffhunk://#diff-9fd836161ccbb7ab4fe6a014f0c463a86579411772ae672d5e06dd6f746856c3R324-R366) [[2]](diffhunk://#diff-36d0432eb7bcef82249dcf91e83a16240ca2b61f73ceed9ac2001312b29e582aR276) [[3]](diffhunk://#diff-36d0432eb7bcef82249dcf91e83a16240ca2b61f73ceed9ac2001312b29e582aR291-R346) [[4]](diffhunk://#diff-d29b26a212736a44a3af8e2dd7d4c902e2ebe2dc3e2ab2c5e81b2d4797f6f731R68-R116)

**Test and mock updates:**

* Mocks and test helpers have been updated to support new and existing test cases involving project removal and config writing. [[1]](diffhunk://#diff-36d0432eb7bcef82249dcf91e83a16240ca2b61f73ceed9ac2001312b29e582aR9) [[2]](diffhunk://#diff-36d0432eb7bcef82249dcf91e83a16240ca2b61f73ceed9ac2001312b29e582aL196-R199)

These changes improve the reliability and traceability of project usage by making sure the "last opened" time is consistently tracked and stored.