### PR TITLE
feat(projects): add project renaming functionality

### DIFF
--- a/locales/de/menus.json
+++ b/locales/de/menus.json
@@ -13,6 +13,8 @@
     },
     "project": {
         "openProjectFolder": "Projektordner öffnen",
+        "launchEditor": "In Godot bearbeiten",
+        "projectSettings": "Projekteinstellungen",
         "openEditorSettingsFolder": "Editor-Einstellungsordner öffnen",
         "openWindowed": "Fenstermodus verwenden",
         "openWindowedTooltip": "Wenn diese Option aktiviert ist, wird Godot im Fenstermodus gestartet.",

--- a/locales/de/projects.json
+++ b/locales/de/projects.json
@@ -86,6 +86,43 @@
       "differentMajorVersion": "Es kann keine andere Hauptversion des Editors verwendet werden\nZum Schutz Ihres Projekts siehe offiziellen Migrationsleitfaden auf https://godotengine.org"
     }
   },
+  "editProject": {
+    "title": "Projekteinstellungen",
+    "description": "Aktualisiere die Namenseinstellungen des Projekts.",
+    "fields": {
+      "name": {
+        "label": "Projektname",
+        "help": "Name, der in Godot Launcher angezeigt wird.",
+        "placeholder": "Mein Projekt"
+      },
+      "path": {
+        "label": "Projektordner"
+      }
+    },
+    "godot": {
+      "renameLabel": "Godot-Projekt ebenfalls umbenennen",
+      "loading": "Godot-Projekt wird geprüft...",
+      "currentName": "Aktueller Godot-Projektname: {{name}}",
+      "unavailable": "project.godot ist nicht verfügbar. Nur der Launcher-Name kann geändert werden."
+    },
+    "actions": {
+      "update": "Aktualisieren",
+      "updating": "Wird aktualisiert..."
+    },
+    "validation": {
+      "required": "Projektname ist erforderlich.",
+      "invalidName": "Projektname darf keine Zeilenumbrüche oder Steuerzeichen enthalten."
+    },
+    "updateFailed": "Projekt konnte nicht aktualisiert werden."
+  },
+  "renameProject": {
+    "errors": {
+      "projectNotFound": "Projekt nicht gefunden",
+      "nameRequired": "Projektname ist erforderlich.",
+      "invalidName": "Projektname darf keine Zeilenumbrüche oder Steuerzeichen enthalten.",
+      "nameExists": "Projekt mit dem Namen '{{name}}' existiert bereits."
+    }
+  },
   "initGit": {
     "errors": {
       "projectNotFound": "Projekt nicht gefunden",

--- a/locales/en/menus.json
+++ b/locales/en/menus.json
@@ -13,6 +13,8 @@
     },
     "project": {
         "openProjectFolder": "Open Project Folder",
+        "launchEditor": "Edit in Godot",
+        "projectSettings": "Project Settings",
         "openEditorSettingsFolder": "Open Editor Settings Folder",
         "openWindowed": "Use Windowed Mode",
         "openWindowedTooltip": "When this option is checked, Godot will launch in windowed mode.",

--- a/locales/en/projects.json
+++ b/locales/en/projects.json
@@ -86,6 +86,43 @@
       "invalidProjectDefinition": "Unable to determine editor settings template for this Godot version."
     }
   },
+  "editProject": {
+    "title": "Project Settings",
+    "description": "Update project naming settings.",
+    "fields": {
+      "name": {
+        "label": "Project name",
+        "help": "Name shown in Godot Launcher.",
+        "placeholder": "My Project"
+      },
+      "path": {
+        "label": "Project folder"
+      }
+    },
+    "godot": {
+      "renameLabel": "Also rename Godot project",
+      "loading": "Checking Godot project...",
+      "currentName": "Current Godot project name: {{name}}",
+      "unavailable": "project.godot is unavailable. Only the launcher name can be changed."
+    },
+    "actions": {
+      "update": "Update",
+      "updating": "Updating..."
+    },
+    "validation": {
+      "required": "Project name is required.",
+      "invalidName": "Project name cannot contain line breaks or control characters."
+    },
+    "updateFailed": "Could not update the project."
+  },
+  "renameProject": {
+    "errors": {
+      "projectNotFound": "Project not found",
+      "nameRequired": "Project name is required.",
+      "invalidName": "Project name cannot contain line breaks or control characters.",
+      "nameExists": "Project with name '{{name}}' already exists."
+    }
+  },
   "initGit": {
     "errors": {
       "projectNotFound": "Project not found",

--- a/locales/es/menus.json
+++ b/locales/es/menus.json
@@ -13,6 +13,8 @@
     },
     "project": {
         "openProjectFolder": "Abrir carpeta del proyecto",
+        "launchEditor": "Editar en Godot",
+        "projectSettings": "Configuración del proyecto",
         "openEditorSettingsFolder": "Abrir carpeta de configuración del editor",
         "openWindowed": "Usar modo ventana",
         "openWindowedTooltip": "Cuando esta opción está marcada, Godot se iniciará en modo ventana.",

--- a/locales/es/projects.json
+++ b/locales/es/projects.json
@@ -86,6 +86,43 @@
       "invalidProjectDefinition": "No se pudo determinar la plantilla de configuración del editor para esta versión de Godot."
     }
   },
+  "editProject": {
+    "title": "Configuración del proyecto",
+    "description": "Actualiza la configuración del nombre del proyecto.",
+    "fields": {
+      "name": {
+        "label": "Nombre del proyecto",
+        "help": "Nombre mostrado en Godot Launcher.",
+        "placeholder": "Mi proyecto"
+      },
+      "path": {
+        "label": "Carpeta del proyecto"
+      }
+    },
+    "godot": {
+      "renameLabel": "Renombrar también el proyecto de Godot",
+      "loading": "Comprobando proyecto de Godot...",
+      "currentName": "Nombre actual del proyecto de Godot: {{name}}",
+      "unavailable": "project.godot no está disponible. Solo se puede cambiar el nombre del launcher."
+    },
+    "actions": {
+      "update": "Actualizar",
+      "updating": "Actualizando..."
+    },
+    "validation": {
+      "required": "El nombre del proyecto es obligatorio.",
+      "invalidName": "El nombre del proyecto no puede contener saltos de línea ni caracteres de control."
+    },
+    "updateFailed": "No se pudo actualizar el proyecto."
+  },
+  "renameProject": {
+    "errors": {
+      "projectNotFound": "Proyecto no encontrado",
+      "nameRequired": "El nombre del proyecto es obligatorio.",
+      "invalidName": "El nombre del proyecto no puede contener saltos de línea ni caracteres de control.",
+      "nameExists": "Ya existe un proyecto con el nombre '{{name}}'."
+    }
+  },
   "initGit": {
     "errors": {
       "projectNotFound": "Proyecto no encontrado",

--- a/locales/fr/menus.json
+++ b/locales/fr/menus.json
@@ -13,6 +13,8 @@
     },
     "project": {
         "openProjectFolder": "Ouvrir le dossier du projet",
+        "launchEditor": "Modifier dans Godot",
+        "projectSettings": "Paramètres du projet",
         "openEditorSettingsFolder": "Ouvrir le dossier des paramètres de l'éditeur",
         "openWindowed": "Utiliser le mode fenêtré",
         "openWindowedTooltip": "Lorsque cette option est cochée, Godot se lancera en mode fenêtré.",

--- a/locales/fr/projects.json
+++ b/locales/fr/projects.json
@@ -86,6 +86,43 @@
       "invalidProjectDefinition": "Impossible de déterminer le modèle de paramètres de l'éditeur pour cette version de Godot."
     }
   },
+  "editProject": {
+    "title": "Paramètres du projet",
+    "description": "Mettre à jour les paramètres de nom du projet.",
+    "fields": {
+      "name": {
+        "label": "Nom du projet",
+        "help": "Nom affiché dans Godot Launcher.",
+        "placeholder": "Mon projet"
+      },
+      "path": {
+        "label": "Dossier du projet"
+      }
+    },
+    "godot": {
+      "renameLabel": "Renommer aussi le projet Godot",
+      "loading": "Vérification du projet Godot...",
+      "currentName": "Nom actuel du projet Godot : {{name}}",
+      "unavailable": "project.godot est indisponible. Seul le nom dans le launcher peut être modifié."
+    },
+    "actions": {
+      "update": "Mettre à jour",
+      "updating": "Mise à jour..."
+    },
+    "validation": {
+      "required": "Le nom du projet est requis.",
+      "invalidName": "Le nom du projet ne peut pas contenir de sauts de ligne ni de caractères de contrôle."
+    },
+    "updateFailed": "Impossible de mettre à jour le projet."
+  },
+  "renameProject": {
+    "errors": {
+      "projectNotFound": "Projet introuvable",
+      "nameRequired": "Le nom du projet est requis.",
+      "invalidName": "Le nom du projet ne peut pas contenir de sauts de ligne ni de caractères de contrôle.",
+      "nameExists": "Un projet nommé '{{name}}' existe déjà."
+    }
+  },
   "initGit": {
     "errors": {
       "projectNotFound": "Projet introuvable",

--- a/locales/it/menus.json
+++ b/locales/it/menus.json
@@ -13,6 +13,8 @@
     },
     "project": {
         "openProjectFolder": "Apri cartella progetto",
+        "launchEditor": "Modifica in Godot",
+        "projectSettings": "Impostazioni progetto",
         "openEditorSettingsFolder": "Apri cartella impostazioni editor",
         "openWindowed": "Usa modalità finestra",
         "openWindowedTooltip": "Quando questa opzione è selezionata, Godot verrà avviato in modalità finestra.",

--- a/locales/it/projects.json
+++ b/locales/it/projects.json
@@ -86,6 +86,43 @@
       "invalidProjectDefinition": "Impossibile determinare il modello di impostazioni dell'editor per questa versione di Godot."
     }
   },
+  "editProject": {
+    "title": "Impostazioni progetto",
+    "description": "Aggiorna le impostazioni del nome del progetto.",
+    "fields": {
+      "name": {
+        "label": "Nome progetto",
+        "help": "Nome mostrato in Godot Launcher.",
+        "placeholder": "Il mio progetto"
+      },
+      "path": {
+        "label": "Cartella progetto"
+      }
+    },
+    "godot": {
+      "renameLabel": "Rinomina anche il progetto Godot",
+      "loading": "Controllo del progetto Godot...",
+      "currentName": "Nome attuale del progetto Godot: {{name}}",
+      "unavailable": "project.godot non è disponibile. Puoi modificare solo il nome nel launcher."
+    },
+    "actions": {
+      "update": "Aggiorna",
+      "updating": "Aggiornamento..."
+    },
+    "validation": {
+      "required": "Il nome del progetto è obbligatorio.",
+      "invalidName": "Il nome del progetto non può contenere interruzioni di riga o caratteri di controllo."
+    },
+    "updateFailed": "Impossibile aggiornare il progetto."
+  },
+  "renameProject": {
+    "errors": {
+      "projectNotFound": "Progetto non trovato",
+      "nameRequired": "Il nome del progetto è obbligatorio.",
+      "invalidName": "Il nome del progetto non può contenere interruzioni di riga o caratteri di controllo.",
+      "nameExists": "Esiste già un progetto con il nome '{{name}}'."
+    }
+  },
   "initGit": {
     "errors": {
       "projectNotFound": "Progetto non trovato",

--- a/locales/ja/menus.json
+++ b/locales/ja/menus.json
@@ -13,6 +13,8 @@
     },
     "project": {
         "openProjectFolder": "プロジェクトフォルダを開く",
+        "launchEditor": "Godotで編集",
+        "projectSettings": "プロジェクト設定",
         "openEditorSettingsFolder": "エディタ設定フォルダを開く",
         "openWindowed": "ウィンドウモードを使用",
         "openWindowedTooltip": "このオプションをオンにすると、Godotがウィンドウモードで起動します。",

--- a/locales/ja/projects.json
+++ b/locales/ja/projects.json
@@ -86,6 +86,43 @@
       "invalidProjectDefinition": "この Godot バージョンのエディター設定テンプレートを特定できませんでした。"
     }
   },
+  "editProject": {
+    "title": "プロジェクト設定",
+    "description": "プロジェクト名の設定を更新します。",
+    "fields": {
+      "name": {
+        "label": "プロジェクト名",
+        "help": "Godot Launcher に表示される名前です。",
+        "placeholder": "マイプロジェクト"
+      },
+      "path": {
+        "label": "プロジェクトフォルダー"
+      }
+    },
+    "godot": {
+      "renameLabel": "Godot プロジェクト名も変更する",
+      "loading": "Godot プロジェクトを確認中...",
+      "currentName": "現在の Godot プロジェクト名: {{name}}",
+      "unavailable": "project.godot が利用できません。Launcher の名前のみ変更できます。"
+    },
+    "actions": {
+      "update": "更新",
+      "updating": "更新中..."
+    },
+    "validation": {
+      "required": "プロジェクト名は必須です。",
+      "invalidName": "プロジェクト名に改行や制御文字は使用できません。"
+    },
+    "updateFailed": "プロジェクトを更新できませんでした。"
+  },
+  "renameProject": {
+    "errors": {
+      "projectNotFound": "プロジェクトが見つかりません",
+      "nameRequired": "プロジェクト名は必須です。",
+      "invalidName": "プロジェクト名に改行や制御文字は使用できません。",
+      "nameExists": "'{{name}}' という名前のプロジェクトは既に存在します。"
+    }
+  },
   "initGit": {
     "errors": {
       "projectNotFound": "プロジェクトが見つかりません",

--- a/locales/mt/menus.json
+++ b/locales/mt/menus.json
@@ -13,6 +13,8 @@
     },
     "project": {
         "openProjectFolder": "Iftaħ Folder tal-Proġett",
+        "launchEditor": "Editja f'Godot",
+        "projectSettings": "Settings tal-Proġett",
         "openEditorSettingsFolder": "Iftaħ Folder tas-Settings tal-Editur",
         "openWindowed": "Uża window mode",
         "openWindowedTooltip": "Meta din l-għażla hija magħżula, Godot se jinħoloq f'window mode.",

--- a/locales/mt/projects.json
+++ b/locales/mt/projects.json
@@ -86,6 +86,43 @@
       "invalidProjectDefinition": "Ma stajniex niddeterminaw il-mudell tas-settings tal-editur għal din il-verżjoni ta' Godot."
     }
   },
+  "editProject": {
+    "title": "Settings tal-Proġett",
+    "description": "Aġġorna s-settings tal-isem tal-proġett.",
+    "fields": {
+      "name": {
+        "label": "Isem tal-proġett",
+        "help": "Isem muri f'Godot Launcher.",
+        "placeholder": "Il-Proġett Tiegħi"
+      },
+      "path": {
+        "label": "Folder tal-proġett"
+      }
+    },
+    "godot": {
+      "renameLabel": "Ibdel ukoll l-isem tal-proġett Godot",
+      "loading": "Qed jiġi ċċekkjat il-proġett Godot...",
+      "currentName": "Isem attwali tal-proġett Godot: {{name}}",
+      "unavailable": "project.godot mhux disponibbli. Jista' jinbidel biss l-isem fil-launcher."
+    },
+    "actions": {
+      "update": "Aġġorna",
+      "updating": "Qed jiġi aġġornat..."
+    },
+    "validation": {
+      "required": "L-isem tal-proġett huwa meħtieġ.",
+      "invalidName": "L-isem tal-proġett ma jistax ikollu line breaks jew control characters."
+    },
+    "updateFailed": "Ma setax jiġi aġġornat il-proġett."
+  },
+  "renameProject": {
+    "errors": {
+      "projectNotFound": "Proġett ma nstabx",
+      "nameRequired": "L-isem tal-proġett huwa meħtieġ.",
+      "invalidName": "L-isem tal-proġett ma jistax ikollu line breaks jew control characters.",
+      "nameExists": "Diġà jeżisti proġett bl-isem '{{name}}'."
+    }
+  },
   "initGit": {
     "errors": {
       "projectNotFound": "Il-proġett ma nstabx",

--- a/locales/pl/menus.json
+++ b/locales/pl/menus.json
@@ -13,6 +13,8 @@
     },
     "project": {
         "openProjectFolder": "Otwórz folder projektu",
+        "launchEditor": "Edytuj w Godot",
+        "projectSettings": "Ustawienia projektu",
         "openEditorSettingsFolder": "Otwórz folder ustawień edytora",
         "openWindowed": "Użyj trybu okienkowego",
         "openWindowedTooltip": "Gdy ta opcja jest zaznaczona, Godot uruchomi się w trybie okienkowym.",

--- a/locales/pl/projects.json
+++ b/locales/pl/projects.json
@@ -86,6 +86,43 @@
       "invalidProjectDefinition": "Nie można ustalić szablonu ustawień edytora dla tej wersji Godot."
     }
   },
+  "editProject": {
+    "title": "Ustawienia projektu",
+    "description": "Zaktualizuj ustawienia nazwy projektu.",
+    "fields": {
+      "name": {
+        "label": "Nazwa projektu",
+        "help": "Nazwa wyświetlana w Godot Launcher.",
+        "placeholder": "Mój projekt"
+      },
+      "path": {
+        "label": "Folder projektu"
+      }
+    },
+    "godot": {
+      "renameLabel": "Zmień także nazwę projektu Godot",
+      "loading": "Sprawdzanie projektu Godot...",
+      "currentName": "Aktualna nazwa projektu Godot: {{name}}",
+      "unavailable": "project.godot jest niedostępny. Można zmienić tylko nazwę w launcherze."
+    },
+    "actions": {
+      "update": "Aktualizuj",
+      "updating": "Aktualizowanie..."
+    },
+    "validation": {
+      "required": "Nazwa projektu jest wymagana.",
+      "invalidName": "Nazwa projektu nie może zawierać znaków nowej linii ani znaków sterujących."
+    },
+    "updateFailed": "Nie udało się zaktualizować projektu."
+  },
+  "renameProject": {
+    "errors": {
+      "projectNotFound": "Projekt nie znaleziony",
+      "nameRequired": "Nazwa projektu jest wymagana.",
+      "invalidName": "Nazwa projektu nie może zawierać znaków nowej linii ani znaków sterujących.",
+      "nameExists": "Projekt o nazwie '{{name}}' już istnieje."
+    }
+  },
   "initGit": {
     "errors": {
       "projectNotFound": "Nie znaleziono projektu",

--- a/locales/pt-BR/menus.json
+++ b/locales/pt-BR/menus.json
@@ -13,6 +13,8 @@
     },
     "project": {
         "openProjectFolder": "Abrir pasta do projeto",
+        "launchEditor": "Editar no Godot",
+        "projectSettings": "Configurações do projeto",
         "openEditorSettingsFolder": "Abrir pasta de configurações do editor",
         "openWindowed": "Usar modo janela",
         "openWindowedTooltip": "Quando esta opção está marcada, o Godot será iniciado no modo janela.",

--- a/locales/pt-BR/projects.json
+++ b/locales/pt-BR/projects.json
@@ -86,6 +86,43 @@
       "invalidProjectDefinition": "Não foi possível determinar o modelo de configurações do editor para esta versão do Godot."
     }
   },
+  "editProject": {
+    "title": "Configurações do projeto",
+    "description": "Atualize as configurações de nome do projeto.",
+    "fields": {
+      "name": {
+        "label": "Nome do projeto",
+        "help": "Nome exibido no Godot Launcher.",
+        "placeholder": "Meu projeto"
+      },
+      "path": {
+        "label": "Pasta do projeto"
+      }
+    },
+    "godot": {
+      "renameLabel": "Também renomear o projeto Godot",
+      "loading": "Verificando projeto Godot...",
+      "currentName": "Nome atual do projeto Godot: {{name}}",
+      "unavailable": "project.godot está indisponível. Apenas o nome no launcher pode ser alterado."
+    },
+    "actions": {
+      "update": "Atualizar",
+      "updating": "Atualizando..."
+    },
+    "validation": {
+      "required": "O nome do projeto é obrigatório.",
+      "invalidName": "O nome do projeto não pode conter quebras de linha nem caracteres de controle."
+    },
+    "updateFailed": "Não foi possível atualizar o projeto."
+  },
+  "renameProject": {
+    "errors": {
+      "projectNotFound": "Projeto não encontrado",
+      "nameRequired": "O nome do projeto é obrigatório.",
+      "invalidName": "O nome do projeto não pode conter quebras de linha nem caracteres de controle.",
+      "nameExists": "Já existe um projeto com o nome '{{name}}'."
+    }
+  },
   "initGit": {
     "errors": {
       "projectNotFound": "Projeto não encontrado",

--- a/locales/pt/menus.json
+++ b/locales/pt/menus.json
@@ -13,6 +13,8 @@
     },
     "project": {
         "openProjectFolder": "Abrir pasta do projeto",
+        "launchEditor": "Editar no Godot",
+        "projectSettings": "Definições do projeto",
         "openEditorSettingsFolder": "Abrir pasta das definições do editor",
         "openWindowed": "Usar modo de janela",
         "openWindowedTooltip": "Quando esta opção está ativa, o Godot inicia em modo de janela.",

--- a/locales/pt/projects.json
+++ b/locales/pt/projects.json
@@ -86,6 +86,43 @@
       "invalidProjectDefinition": "Não foi possível determinar o modelo de definições do editor para esta versão do Godot."
     }
   },
+  "editProject": {
+    "title": "Definições do projeto",
+    "description": "Atualiza as definições do nome do projeto.",
+    "fields": {
+      "name": {
+        "label": "Nome do projeto",
+        "help": "Nome apresentado no Godot Launcher.",
+        "placeholder": "O meu projeto"
+      },
+      "path": {
+        "label": "Pasta do projeto"
+      }
+    },
+    "godot": {
+      "renameLabel": "Mudar também o nome do projeto Godot",
+      "loading": "A verificar o projeto Godot...",
+      "currentName": "Nome atual do projeto Godot: {{name}}",
+      "unavailable": "project.godot não está disponível. Apenas o nome no launcher pode ser alterado."
+    },
+    "actions": {
+      "update": "Atualizar",
+      "updating": "A atualizar..."
+    },
+    "validation": {
+      "required": "O nome do projeto é obrigatório.",
+      "invalidName": "O nome do projeto não pode conter quebras de linha nem caracteres de controlo."
+    },
+    "updateFailed": "Não foi possível atualizar o projeto."
+  },
+  "renameProject": {
+    "errors": {
+      "projectNotFound": "Projeto não encontrado",
+      "nameRequired": "O nome do projeto é obrigatório.",
+      "invalidName": "O nome do projeto não pode conter quebras de linha nem caracteres de controlo.",
+      "nameExists": "Já existe um projeto com o nome '{{name}}'."
+    }
+  },
   "initGit": {
     "errors": {
       "projectNotFound": "Projeto não encontrado",

--- a/locales/ru/menus.json
+++ b/locales/ru/menus.json
@@ -13,6 +13,8 @@
     },
     "project": {
         "openProjectFolder": "Открыть папку проекта",
+        "launchEditor": "Редактировать в Godot",
+        "projectSettings": "Настройки проекта",
         "openEditorSettingsFolder": "Открыть папку настроек редактора",
         "openWindowed": "Использовать оконный режим",
         "openWindowedTooltip": "Когда эта опция включена, Godot запустится в оконном режиме.",

--- a/locales/ru/projects.json
+++ b/locales/ru/projects.json
@@ -86,6 +86,43 @@
       "invalidProjectDefinition": "Не удалось определить шаблон настроек редактора для этой версии Godot."
     }
   },
+  "editProject": {
+    "title": "Настройки проекта",
+    "description": "Обновите настройки имени проекта.",
+    "fields": {
+      "name": {
+        "label": "Имя проекта",
+        "help": "Имя, отображаемое в Godot Launcher.",
+        "placeholder": "Мой проект"
+      },
+      "path": {
+        "label": "Папка проекта"
+      }
+    },
+    "godot": {
+      "renameLabel": "Также переименовать проект Godot",
+      "loading": "Проверка проекта Godot...",
+      "currentName": "Текущее имя проекта Godot: {{name}}",
+      "unavailable": "project.godot недоступен. Можно изменить только имя в лаунчере."
+    },
+    "actions": {
+      "update": "Обновить",
+      "updating": "Обновление..."
+    },
+    "validation": {
+      "required": "Имя проекта обязательно.",
+      "invalidName": "Имя проекта не может содержать переносы строк или управляющие символы."
+    },
+    "updateFailed": "Не удалось обновить проект."
+  },
+  "renameProject": {
+    "errors": {
+      "projectNotFound": "Проект не найден",
+      "nameRequired": "Имя проекта обязательно.",
+      "invalidName": "Имя проекта не может содержать переносы строк или управляющие символы.",
+      "nameExists": "Проект с именем '{{name}}' уже существует."
+    }
+  },
   "initGit": {
     "errors": {
       "projectNotFound": "Проект не найден",

--- a/locales/tr/menus.json
+++ b/locales/tr/menus.json
@@ -13,6 +13,8 @@
     },
     "project": {
         "openProjectFolder": "Proje Klasörünü Aç",
+        "launchEditor": "Godot'ta düzenle",
+        "projectSettings": "Proje ayarları",
         "openEditorSettingsFolder": "Editör Ayarları Klasörünü Aç",
         "openWindowed": "Pencere modunu kullan",
         "openWindowedTooltip": "Bu seçenek işaretlendiğinde, Godot pencere modunda başlatılacaktır.",

--- a/locales/tr/projects.json
+++ b/locales/tr/projects.json
@@ -86,6 +86,43 @@
       "invalidProjectDefinition": "Bu Godot sürümü için düzenleyici ayarları şablonu belirlenemedi."
     }
   },
+  "editProject": {
+    "title": "Proje ayarları",
+    "description": "Proje adı ayarlarını güncelle.",
+    "fields": {
+      "name": {
+        "label": "Proje adı",
+        "help": "Godot Launcher'da gösterilen ad.",
+        "placeholder": "Projem"
+      },
+      "path": {
+        "label": "Proje klasörü"
+      }
+    },
+    "godot": {
+      "renameLabel": "Godot projesini de yeniden adlandır",
+      "loading": "Godot projesi denetleniyor...",
+      "currentName": "Geçerli Godot proje adı: {{name}}",
+      "unavailable": "project.godot kullanılamıyor. Yalnızca launcher adı değiştirilebilir."
+    },
+    "actions": {
+      "update": "Güncelle",
+      "updating": "Güncelleniyor..."
+    },
+    "validation": {
+      "required": "Proje adı gereklidir.",
+      "invalidName": "Proje adı satır sonları veya kontrol karakterleri içeremez."
+    },
+    "updateFailed": "Proje güncellenemedi."
+  },
+  "renameProject": {
+    "errors": {
+      "projectNotFound": "Proje bulunamadı",
+      "nameRequired": "Proje adı gereklidir.",
+      "invalidName": "Proje adı satır sonları veya kontrol karakterleri içeremez.",
+      "nameExists": "'{{name}}' adlı proje zaten var."
+    }
+  },
   "initGit": {
     "errors": {
       "projectNotFound": "Proje bulunamadı",

--- a/locales/zh-CN/menus.json
+++ b/locales/zh-CN/menus.json
@@ -13,6 +13,8 @@
     },
     "project": {
         "openProjectFolder": "打开项目文件夹",
+        "launchEditor": "在 Godot 中编辑",
+        "projectSettings": "项目设置",
         "openEditorSettingsFolder": "打开编辑器设置文件夹",
         "openWindowed": "使用窗口模式",
         "openWindowedTooltip": "选中此选项时，Godot 将以窗口模式启动。",

--- a/locales/zh-CN/projects.json
+++ b/locales/zh-CN/projects.json
@@ -86,6 +86,43 @@
       "invalidProjectDefinition": "无法确定此 Godot 版本的编辑器设置模板。"
     }
   },
+  "editProject": {
+    "title": "项目设置",
+    "description": "更新项目命名设置。",
+    "fields": {
+      "name": {
+        "label": "项目名称",
+        "help": "显示在 Godot Launcher 中的名称。",
+        "placeholder": "我的项目"
+      },
+      "path": {
+        "label": "项目文件夹"
+      }
+    },
+    "godot": {
+      "renameLabel": "同时重命名 Godot 项目",
+      "loading": "正在检查 Godot 项目...",
+      "currentName": "当前 Godot 项目名称：{{name}}",
+      "unavailable": "project.godot 不可用。只能更改启动器中的名称。"
+    },
+    "actions": {
+      "update": "更新",
+      "updating": "正在更新..."
+    },
+    "validation": {
+      "required": "项目名称为必填项。",
+      "invalidName": "项目名称不能包含换行符或控制字符。"
+    },
+    "updateFailed": "无法更新项目。"
+  },
+  "renameProject": {
+    "errors": {
+      "projectNotFound": "未找到项目",
+      "nameRequired": "项目名称为必填项。",
+      "invalidName": "项目名称不能包含换行符或控制字符。",
+      "nameExists": "名为 '{{name}}' 的项目已存在。"
+    }
+  },
   "initGit": {
     "errors": {
       "projectNotFound": "未找到项目",

--- a/locales/zh-TW/menus.json
+++ b/locales/zh-TW/menus.json
@@ -13,6 +13,8 @@
     },
     "project": {
         "openProjectFolder": "開啟專案資料夾",
+        "launchEditor": "在 Godot 中編輯",
+        "projectSettings": "專案設定",
         "openEditorSettingsFolder": "開啟編輯器設定資料夾",
         "openWindowed": "使用視窗模式",
         "openWindowedTooltip": "勾選此選項時，Godot 將以視窗模式啟動。",

--- a/locales/zh-TW/projects.json
+++ b/locales/zh-TW/projects.json
@@ -86,6 +86,43 @@
       "invalidProjectDefinition": "無法判定此 Godot 版本的編輯器設定範本。"
     }
   },
+  "editProject": {
+    "title": "專案設定",
+    "description": "更新專案命名設定。",
+    "fields": {
+      "name": {
+        "label": "專案名稱",
+        "help": "顯示在 Godot Launcher 中的名稱。",
+        "placeholder": "我的專案"
+      },
+      "path": {
+        "label": "專案資料夾"
+      }
+    },
+    "godot": {
+      "renameLabel": "同時重新命名 Godot 專案",
+      "loading": "正在檢查 Godot 專案...",
+      "currentName": "目前的 Godot 專案名稱：{{name}}",
+      "unavailable": "project.godot 無法使用。只能變更啟動器中的名稱。"
+    },
+    "actions": {
+      "update": "更新",
+      "updating": "正在更新..."
+    },
+    "validation": {
+      "required": "專案名稱為必填。",
+      "invalidName": "專案名稱不能包含換行或控制字元。"
+    },
+    "updateFailed": "無法更新專案。"
+  },
+  "renameProject": {
+    "errors": {
+      "projectNotFound": "找不到專案",
+      "nameRequired": "專案名稱為必填。",
+      "invalidName": "專案名稱不能包含換行或控制字元。",
+      "nameExists": "名為 '{{name}}' 的專案已存在。"
+    }
+  },
   "initGit": {
     "errors": {
       "projectNotFound": "找不到專案",

--- a/main/src/app.ts
+++ b/main/src/app.ts
@@ -4,6 +4,7 @@ import type {
     CustomEngineManifest,
     InstalledRelease,
     ProjectDetails,
+    RenameProjectOptions,
     RendererType,
     UserPreferences,
 } from '@shared';
@@ -31,10 +32,12 @@ import {
 } from './commands/projectEditorSettings.js';
 import {
     checkProjectIsValid,
+    getProjectGodotName,
     getProjectsDetails,
     initializeProjectGit,
     launchProject,
     removeProject,
+    renameProject,
     setProjectVSCode,
     setProjectWindowed,
 } from './commands/projects.js';
@@ -292,6 +295,18 @@ export function registerHandlers() {
     ipcMainHandler(
         'remove-project',
         async (_, project: ProjectDetails) => await removeProject(project),
+    );
+
+    ipcMainHandler(
+        'rename-project',
+        async (_, project: ProjectDetails, options: RenameProjectOptions) =>
+            await renameProject(project, options),
+    );
+
+    ipcMainHandler(
+        'get-project-godot-name',
+        async (_, project: ProjectDetails) =>
+            await getProjectGodotName(project),
     );
 
     ipcMainHandler(

--- a/main/src/commands/projects.test.ts
+++ b/main/src/commands/projects.test.ts
@@ -4,9 +4,11 @@ import type { ProjectDetails } from '@shared';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { JsonStoreConflictError } from '../utils/jsonStore.js';
 import {
+    getProjectGodotName,
     initializeProjectGit,
     launchProject,
     removeProject,
+    renameProject,
     setProjectVSCode,
 } from './projects.js';
 
@@ -58,6 +60,8 @@ vi.mock('../utils/godot.utils.js', () => godotUtilsMocks);
 
 const godotProjectMocks = vi.hoisted(() => ({
     createNewEditorSettings: vi.fn(),
+    readGodotProjectName: vi.fn(),
+    updateGodotProjectName: vi.fn(),
     updateEditorSettings: vi.fn(),
 }));
 
@@ -197,7 +201,12 @@ const { getDefaultDirs } = platformMocks;
 const { getProjectsSnapshot, removeProjectFromList, storeProjectsList } =
     projectUtilsMocks;
 const { getProjectDefinition, removeProjectEditor } = godotUtilsMocks;
-const { createNewEditorSettings, updateEditorSettings } = godotProjectMocks;
+const {
+    createNewEditorSettings,
+    readGodotProjectName,
+    updateGodotProjectName,
+    updateEditorSettings,
+} = godotProjectMocks;
 const {
     updateVSCodeSettings,
     addVSCodeNETLaunchConfig,
@@ -341,6 +350,194 @@ describe('removeProject', () => {
             path.resolve('/config', 'projects.json'),
             '/projects/demo',
         );
+    });
+});
+
+describe('renameProject', () => {
+    const createProject = (overrides: Partial<ProjectDetails> = {}) =>
+        ({
+            name: 'Demo',
+            path: '/projects/demo',
+            version: '4.2',
+            version_number: 4.2,
+            renderer: 'FORWARD_PLUS',
+            editor_settings_path: '/launcher/editors/Demo/editor_data',
+            editor_settings_file:
+                '/launcher/editors/Demo/editor_data/editor_settings-4.2.tres',
+            last_opened: null,
+            open_windowed: false,
+            release: {
+                version: '4.2',
+                version_number: 4.2,
+                install_path: '/godot',
+                editor_path: '/godot/godot.exe',
+                platform: 'win32',
+                arch: 'x86_64',
+                mono: false,
+                prerelease: false,
+                config_version: 5,
+                published_at: null,
+                valid: true,
+            },
+            launch_path: '/launcher/editors/Demo/godot.exe',
+            config_version: 5,
+            withVSCode: false,
+            withGit: false,
+            valid: true,
+            ...overrides,
+        }) satisfies ProjectDetails;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        getDefaultDirs.mockReturnValue({ configDir: '/config' });
+        windowMock = { webContents: {} };
+        getMainWindow.mockReturnValue(windowMock);
+        updateGodotProjectName.mockResolvedValue(undefined);
+        storeProjectsList.mockImplementation(
+            async (_path, projects, _options) => projects,
+        );
+    });
+
+    it('renames the launcher project name by path', async () => {
+        const project = createProject();
+        getProjectsSnapshot.mockResolvedValue({
+            projects: [project],
+            version: 'v1',
+        });
+
+        const result = await renameProject(project, {
+            name: ' Renamed Demo ',
+            renameGodotProject: false,
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.project).toEqual(
+            expect.objectContaining({
+                name: 'Renamed Demo',
+                path: '/projects/demo',
+                launch_path: '/launcher/editors/Demo/godot.exe',
+                editor_settings_path: '/launcher/editors/Demo/editor_data',
+                editor_settings_file:
+                    '/launcher/editors/Demo/editor_data/editor_settings-4.2.tres',
+            }),
+        );
+        expect(updateGodotProjectName).not.toHaveBeenCalled();
+        expect(storeProjectsList).toHaveBeenCalledWith(
+            path.resolve('/config', 'projects.json'),
+            expect.arrayContaining([
+                expect.objectContaining({
+                    name: 'Renamed Demo',
+                    path: '/projects/demo',
+                }),
+            ]),
+            expect.objectContaining({ expectedVersion: 'v1' }),
+        );
+        expect(ipcWebContentsSend).toHaveBeenCalledWith(
+            'projects-updated',
+            windowMock.webContents,
+            expect.any(Array),
+        );
+    });
+
+    it('renames the launcher and Godot project names together', async () => {
+        const project = createProject();
+        getProjectsSnapshot.mockResolvedValue({
+            projects: [project],
+            version: 'v1',
+        });
+
+        const result = await renameProject(project, {
+            name: 'Renamed Demo',
+            renameGodotProject: true,
+        });
+
+        expect(result.success).toBe(true);
+        expect(updateGodotProjectName).toHaveBeenCalledWith(
+            '/projects/demo',
+            'Renamed Demo',
+        );
+        expect(result.project?.name).toBe('Renamed Demo');
+    });
+
+    it('rejects duplicate launcher names from other project paths', async () => {
+        const project = createProject();
+        getProjectsSnapshot.mockResolvedValue({
+            projects: [
+                project,
+                createProject({
+                    name: 'Existing Name',
+                    path: '/projects/existing',
+                }),
+            ],
+            version: 'v1',
+        });
+
+        const result = await renameProject(project, {
+            name: 'Existing Name',
+            renameGodotProject: true,
+        });
+
+        expect(result).toEqual(
+            expect.objectContaining({
+                success: false,
+                errorField: 'name',
+            }),
+        );
+        expect(updateGodotProjectName).not.toHaveBeenCalled();
+        expect(storeProjectsList).not.toHaveBeenCalled();
+    });
+
+    it('reports Godot project rename failures on the Godot field', async () => {
+        const project = createProject();
+        getProjectsSnapshot.mockResolvedValue({
+            projects: [project],
+            version: 'v1',
+        });
+        updateGodotProjectName.mockRejectedValue(
+            new Error('Cannot write file'),
+        );
+
+        const result = await renameProject(project, {
+            name: 'Renamed Demo',
+            renameGodotProject: true,
+        });
+
+        expect(result).toEqual({
+            success: false,
+            error: 'Cannot write file',
+            errorField: 'godot',
+        });
+        expect(storeProjectsList).not.toHaveBeenCalled();
+    });
+
+    it('retries when the project list changes while renaming', async () => {
+        const project = createProject();
+        getProjectsSnapshot
+            .mockResolvedValueOnce({ projects: [project], version: 'v1' })
+            .mockResolvedValueOnce({ projects: [project], version: 'v2' });
+        storeProjectsList
+            .mockRejectedValueOnce(
+                new JsonStoreConflictError('/config/projects.json'),
+            )
+            .mockImplementationOnce(
+                async (_path, projects, _options) => projects,
+            );
+
+        const result = await renameProject(project, {
+            name: 'Renamed Demo',
+            renameGodotProject: false,
+        });
+
+        expect(result.success).toBe(true);
+        expect(storeProjectsList).toHaveBeenCalledTimes(2);
+    });
+
+    it('reads the current Godot project name', async () => {
+        const project = createProject();
+        readGodotProjectName.mockResolvedValue('Demo');
+
+        await expect(getProjectGodotName(project)).resolves.toBe('Demo');
+        expect(readGodotProjectName).toHaveBeenCalledWith('/projects/demo');
     });
 });
 

--- a/main/src/commands/projects.ts
+++ b/main/src/commands/projects.ts
@@ -5,7 +5,12 @@ import {
 } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import type { ProjectDetails, SetProjectVSCodeResult } from '@shared';
+import type {
+    ProjectDetails,
+    RenameProjectOptions,
+    RenameProjectResult,
+    SetProjectVSCodeResult,
+} from '@shared';
 import { app } from 'electron';
 import logger from 'electron-log';
 import { checkProjectValid } from '../checks.js';
@@ -23,7 +28,9 @@ import {
 } from '../utils/godot.utils.js';
 import {
     createNewEditorSettings,
+    readGodotProjectName,
     updateEditorSettings,
+    updateGodotProjectName,
 } from '../utils/godotProject.utils.js';
 import { JsonStoreConflictError } from '../utils/jsonStore.js';
 import { getDefaultDirs } from '../utils/platform.utils.js';
@@ -286,6 +293,137 @@ export async function setProjectWindowed(
     );
 
     return updatedProject;
+}
+
+function validateProjectName(name: string): RenameProjectResult | null {
+    if (name.length === 0) {
+        return {
+            success: false,
+            error: t('projects:renameProject.errors.nameRequired'),
+            errorField: 'name',
+        };
+    }
+
+    if (hasControlCharacters(name)) {
+        return {
+            success: false,
+            error: t('projects:renameProject.errors.invalidName'),
+            errorField: 'name',
+        };
+    }
+
+    return null;
+}
+
+function hasControlCharacters(value: string): boolean {
+    return Array.from(value).some((character) => {
+        const codePoint = character.codePointAt(0) ?? 0;
+        return codePoint <= 31 || codePoint === 127;
+    });
+}
+
+export async function getProjectGodotName(
+    project: ProjectDetails,
+): Promise<string | null> {
+    return await readGodotProjectName(project.path);
+}
+
+export async function renameProject(
+    project: ProjectDetails,
+    options: RenameProjectOptions,
+): Promise<RenameProjectResult> {
+    const projectListPath = resolveProjectListPath();
+    const newName = options.name.trim();
+    const validationError = validateProjectName(newName);
+
+    if (validationError) {
+        return validationError;
+    }
+
+    for (let attempt = 0; attempt < PROJECT_WRITE_MAX_ATTEMPTS; attempt++) {
+        const { projects, version } =
+            await getProjectsSnapshot(projectListPath);
+        const projectIndex = projects.findIndex((p) => p.path === project.path);
+
+        if (projectIndex === -1) {
+            return {
+                success: false,
+                error: t('projects:renameProject.errors.projectNotFound'),
+            };
+        }
+
+        const duplicateProject = projects.find(
+            (p) => p.path !== project.path && p.name === newName,
+        );
+
+        if (duplicateProject) {
+            return {
+                success: false,
+                error: t('projects:renameProject.errors.nameExists', {
+                    name: newName,
+                }),
+                errorField: 'name',
+            };
+        }
+
+        if (options.renameGodotProject) {
+            try {
+                await updateGodotProjectName(
+                    projects[projectIndex].path,
+                    newName,
+                );
+            } catch (error) {
+                return {
+                    success: false,
+                    error:
+                        error instanceof Error ? error.message : String(error),
+                    errorField: 'godot',
+                };
+            }
+        }
+
+        const updatedProject: ProjectDetails = {
+            ...projects[projectIndex],
+            name: newName,
+        };
+        const updatedProjects = [...projects];
+        updatedProjects[projectIndex] = updatedProject;
+
+        try {
+            const storedProjects = await storeProjectsList(
+                projectListPath,
+                updatedProjects,
+                { expectedVersion: version },
+            );
+            const latestProject =
+                storedProjects.find((p) => p.path === updatedProject.path) ??
+                updatedProject;
+
+            project.name = latestProject.name;
+
+            ipcWebContentsSend(
+                'projects-updated',
+                getMainWindow()?.webContents,
+                storedProjects,
+            );
+
+            return {
+                success: true,
+                project: latestProject,
+                projects: storedProjects,
+            };
+        } catch (error) {
+            if (
+                error instanceof JsonStoreConflictError &&
+                attempt < PROJECT_WRITE_MAX_ATTEMPTS - 1
+            ) {
+                continue;
+            }
+            throw error;
+        }
+    }
+
+    throw new Error('Failed to rename project due to concurrent modifications');
 }
 
 export async function setProjectVSCode(

--- a/main/src/commands/setProjectEditor.test.ts
+++ b/main/src/commands/setProjectEditor.test.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import type { InstalledRelease, ProjectDetails } from '@shared';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { setProjectEditor } from './setProjectEditor.js';
@@ -278,6 +279,19 @@ describe('setProjectEditor', () => {
         expect(result.success).toBe(true);
         expect(createNewEditorSettings).toHaveBeenCalledTimes(1);
         expect(updateEditorSettings).not.toHaveBeenCalled();
+    });
+
+    it('should reuse the existing editor folder when the project name changes', async () => {
+        mockProject.name = 'Renamed Project';
+
+        const result = await setProjectEditor(mockProject, mockNewRelease);
+
+        expect(result.success).toBe(true);
+        expect(SetProjectEditorRelease).toHaveBeenCalledWith(
+            path.dirname('/fake/launch/old'),
+            mockNewRelease,
+            mockOldRelease,
+        );
     });
 
     it('should update existing editor settings when they exist', async () => {

--- a/main/src/commands/setProjectEditor.ts
+++ b/main/src/commands/setProjectEditor.ts
@@ -40,6 +40,25 @@ import { getUserPreferences } from './userPreferences.js';
 
 const PROJECT_EDITOR_MAX_ATTEMPTS = 2;
 
+function resolveProjectEditorPath(
+    project: ProjectDetails,
+    installLocation: string,
+): string {
+    if (project.launch_path) {
+        return path.dirname(project.launch_path);
+    }
+
+    if (project.editor_settings_file) {
+        return path.dirname(path.dirname(project.editor_settings_file));
+    }
+
+    if (project.editor_settings_path) {
+        return path.dirname(project.editor_settings_path);
+    }
+
+    return path.resolve(installLocation, EDITOR_CONFIG_DIRNAME, project.name);
+}
+
 export async function setProjectEditor(
     project: ProjectDetails,
     newRelease: InstalledRelease,
@@ -99,10 +118,9 @@ export async function setProjectEditor(
             };
         }
 
-        const projectEditorPath = path.resolve(
+        const projectEditorPath = resolveProjectEditorPath(
+            currentProject,
             installLocation,
-            EDITOR_CONFIG_DIRNAME,
-            currentProject.name,
         );
 
         const newLaunchPath = await SetProjectEditorRelease(

--- a/main/src/preload.cts
+++ b/main/src/preload.cts
@@ -7,6 +7,7 @@ import type {
     InstalledRelease,
     ProjectDetails,
     ReleaseSummary,
+    RenameProjectOptions,
     RendererType,
     UserPreferences,
 } from '@shared';
@@ -107,6 +108,10 @@ electron.contextBridge.exposeInMainWorld('electron', {
     getProjectsDetails: () => ipcInvoke('get-projects-details'),
     removeProject: (project: ProjectDetails) =>
         ipcInvoke('remove-project', project),
+    renameProject: (project: ProjectDetails, options: RenameProjectOptions) =>
+        ipcInvoke('rename-project', project, options),
+    getProjectGodotName: (project: ProjectDetails) =>
+        ipcInvoke('get-project-godot-name', project),
     addProject: (projectPath: string, options?: AddProjectOptions) =>
         ipcInvoke('add-project', projectPath, options),
     setProjectEditor: (project: ProjectDetails, release: InstalledRelease) =>

--- a/main/src/utils/godotProject.utils.test.ts
+++ b/main/src/utils/godotProject.utils.test.ts
@@ -5,6 +5,8 @@ import { describe, expect, test } from 'vitest';
 import {
     getProjectIconUrlFromParsed,
     parseGodotProjectFile,
+    replaceGodotProjectNameInContent,
+    updateGodotProjectName,
 } from './godotProject.utils.js';
 
 describe('decode project.godot file', () => {
@@ -177,5 +179,80 @@ config/icon="res://missing.svg"
 `),
             ),
         ).toBeUndefined();
+    });
+});
+
+describe('update Godot project name', () => {
+    test('updates only application config/name and preserves surrounding content', () => {
+        const projectFile = `config_version=5
+
+; keep this comment
+[application]
+config/name="Old Name" ; inline comment
+config/features=PackedStringArray("4.4")
+
+[rendering]
+renderer/rendering_method="mobile"
+`;
+
+        const updated = replaceGodotProjectNameInContent(
+            projectFile,
+            'New "Name"',
+        );
+
+        expect(updated).toContain(
+            'config/name="New \\"Name\\"" ; inline comment',
+        );
+        expect(updated).toContain('; keep this comment');
+        expect(updated).toContain('config/features=PackedStringArray("4.4")');
+        expect(updated).toContain('[rendering]');
+        expect(updated).toContain('renderer/rendering_method="mobile"');
+    });
+
+    test('preserves CRLF line endings', () => {
+        const projectFile =
+            'config_version=5\r\n\r\n[application]\r\nconfig/name="Old"\r\n';
+
+        const updated = replaceGodotProjectNameInContent(projectFile, 'New');
+
+        expect(updated).toBe(
+            'config_version=5\r\n\r\n[application]\r\nconfig/name="New"\r\n',
+        );
+    });
+
+    test('throws when application section is missing', () => {
+        expect(() =>
+            replaceGodotProjectNameInContent(
+                'config_version=5\n[rendering]\n',
+                'New',
+            ),
+        ).toThrow('Could not find [application] section in project.godot');
+    });
+
+    test('throws when application config name is missing', () => {
+        expect(() =>
+            replaceGodotProjectNameInContent(
+                'config_version=5\n[application]\nconfig/icon="res://icon.svg"\n',
+                'New',
+            ),
+        ).toThrow('Could not find application config/name in project.godot');
+    });
+
+    test('writes the updated project file through a temporary file', async () => {
+        const projectDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), 'godot-project-rename-'),
+        );
+        const projectFilePath = path.join(projectDir, 'project.godot');
+        fs.writeFileSync(
+            projectFilePath,
+            'config_version=5\n\n[application]\nconfig/name="Old"\n',
+            'utf-8',
+        );
+
+        await updateGodotProjectName(projectDir, 'New');
+
+        expect(fs.readFileSync(projectFilePath, 'utf-8')).toBe(
+            'config_version=5\n\n[application]\nconfig/name="New"\n',
+        );
     });
 });

--- a/main/src/utils/godotProject.utils.ts
+++ b/main/src/utils/godotProject.utils.ts
@@ -215,6 +215,106 @@ function cleanGodotStringValue(value: string): string {
     return value.replace(/^"+|"+$/g, '').trim();
 }
 
+function quoteGodotStringValue(value: string): string {
+    return JSON.stringify(value);
+}
+
+function splitLinesPreservingEndings(content: string): string[] {
+    const lines = content.match(/[^\r\n]*(?:\r\n|\n|\r|$)/g) ?? [''];
+
+    if (lines.length > 1 && lines[lines.length - 1] === '') {
+        lines.pop();
+    }
+
+    return lines;
+}
+
+export function replaceGodotProjectNameInContent(
+    content: string,
+    newName: string,
+): string {
+    const lines = splitLinesPreservingEndings(content);
+    let currentSection = 'ROOT';
+    let foundApplicationSection = false;
+    let replacedName = false;
+
+    const updatedLines = lines.map((line) => {
+        const lineEndingMatch = line.match(/(\r\n|\n|\r)$/);
+        const lineEnding = lineEndingMatch?.[0] ?? '';
+        const body = lineEnding ? line.slice(0, -lineEnding.length) : line;
+        const sectionMatch = body.trim().match(/^\[([^\]]+)\](?:\s*[;#].*)?$/);
+
+        if (sectionMatch) {
+            currentSection = sectionMatch[1].trim();
+            if (currentSection === 'application') {
+                foundApplicationSection = true;
+            }
+            return line;
+        }
+
+        if (currentSection !== 'application' || replacedName) {
+            return line;
+        }
+
+        const nameMatch = body.match(
+            /^(\s*config\/name\s*=\s*)(?:"(?:\\.|[^"\\])*"|[^;#]*?)(\s*(?:[;#].*)?)$/,
+        );
+
+        if (!nameMatch) {
+            return line;
+        }
+
+        replacedName = true;
+        return `${nameMatch[1]}${quoteGodotStringValue(newName)}${nameMatch[2]}${lineEnding}`;
+    });
+
+    if (!foundApplicationSection) {
+        throw new Error(
+            'Could not find [application] section in project.godot',
+        );
+    }
+
+    if (!replacedName) {
+        throw new Error(
+            'Could not find application config/name in project.godot',
+        );
+    }
+
+    return updatedLines.join('');
+}
+
+export async function readGodotProjectName(
+    projectDir: string,
+): Promise<string | null> {
+    const projectFilePath = path.resolve(projectDir, 'project.godot');
+
+    if (!fs.existsSync(projectFilePath)) {
+        return null;
+    }
+
+    const projectFile = await fs.promises.readFile(projectFilePath, 'utf-8');
+    const parsedProject = parseGodotProjectFile(projectFile);
+    const rawName = parsedProject.get('application')?.get('config/name');
+
+    return rawName ? cleanGodotStringValue(rawName) : null;
+}
+
+export async function updateGodotProjectName(
+    projectDir: string,
+    newName: string,
+): Promise<void> {
+    const projectFilePath = path.resolve(projectDir, 'project.godot');
+    const projectFile = await fs.promises.readFile(projectFilePath, 'utf-8');
+    const updatedProjectFile = replaceGodotProjectNameInContent(
+        projectFile,
+        newName,
+    );
+    const tmpPath = `${projectFilePath}.${process.pid}.${Date.now()}.tmp`;
+
+    await fs.promises.writeFile(tmpPath, updatedProjectFile, 'utf-8');
+    await fs.promises.rename(tmpPath, projectFilePath);
+}
+
 function getImageMimeType(iconPath: string): string | undefined {
     switch (path.extname(iconPath).toLowerCase()) {
         case '.svg':

--- a/renderer/src/hooks/useProjects.tsx
+++ b/renderer/src/hooks/useProjects.tsx
@@ -5,6 +5,8 @@ import type {
     CreateProjectResult,
     InstalledRelease,
     ProjectDetails,
+    RenameProjectOptions,
+    RenameProjectResult,
     RendererType,
     SetProjectVSCodeResult,
 } from '@shared';
@@ -41,6 +43,11 @@ interface ProjectsContext {
     importProjectEditorSettings: (project: ProjectDetails) => Promise<void>;
     openProjectFolder: (project: ProjectDetails) => Promise<void>;
     openProjectEditorFolder: (project: ProjectDetails) => Promise<void>;
+    renameProject: (
+        project: ProjectDetails,
+        options: RenameProjectOptions,
+    ) => Promise<RenameProjectResult>;
+    getProjectGodotName: (project: ProjectDetails) => Promise<string | null>;
     removeProject: (project: ProjectDetails) => Promise<void>;
     launchProject: (
         project: ProjectDetails,
@@ -187,6 +194,21 @@ export const ProjectsProvider: FC<ProjectsProviderProps> = ({ children }) => {
         await window.electron.openShellFolder(project.editor_settings_path);
     };
 
+    const renameProject = async (
+        project: ProjectDetails,
+        options: RenameProjectOptions,
+    ) => {
+        const result = await window.electron.renameProject(project, options);
+        if (result.success && result.projects) {
+            setProjects(result.projects);
+        }
+        return result;
+    };
+
+    const getProjectGodotName = async (project: ProjectDetails) => {
+        return await window.electron.getProjectGodotName(project);
+    };
+
     const removeProject = async (project: ProjectDetails) => {
         const result = await window.electron.removeProject(project);
         setProjects(result);
@@ -239,6 +261,8 @@ export const ProjectsProvider: FC<ProjectsProviderProps> = ({ children }) => {
                 importProjectEditorSettings,
                 openProjectFolder,
                 openProjectEditorFolder,
+                renameProject,
+                getProjectGodotName,
                 removeProject,
                 launchProject,
                 refreshProjects,

--- a/renderer/src/views/projects.view.tsx
+++ b/renderer/src/views/projects.view.tsx
@@ -22,6 +22,7 @@ import {
     getInvalidProjectMessageKey,
 } from './projects/projectsView.model';
 import { CreateProjectSubView } from './subViews/createProject.subview';
+import { ProjectSettingsDrawer } from './subViews/projectSettingsDrawer.subview';
 
 type ProjectsViewProps = {
     createOpen?: boolean;
@@ -47,6 +48,9 @@ export const ProjectsView: React.FC<ProjectsViewProps> = ({
 
     const [changeEditorFor, setChangeEditorFor] =
         useState<ProjectDetails | null>();
+    const [editProjectFor, setEditProjectFor] = useState<ProjectDetails | null>(
+        null,
+    );
     const [addingProject, setAddingProject] = useState<boolean>(false);
 
     const [busyProjects, setBusyProjects] = useState<string[]>([]);
@@ -78,6 +82,8 @@ export const ProjectsView: React.FC<ProjectsViewProps> = ({
         launchProject,
         openProjectFolder,
         openProjectEditorFolder,
+        renameProject,
+        getProjectGodotName,
         removeProject,
         loading,
     } = useProjects();
@@ -274,6 +280,8 @@ export const ProjectsView: React.FC<ProjectsViewProps> = ({
                 hasGit={projectActionsMenu?.hasGit ?? false}
                 t={t}
                 onClose={() => setProjectActionsMenu(null)}
+                onLaunchProject={(project) => void onLaunchProject(project)}
+                onProjectSettings={setEditProjectFor}
                 onOpenProjectFolder={(project) =>
                     runProjectAction(() => openProjectFolder(project))
                 }
@@ -288,6 +296,17 @@ export const ProjectsView: React.FC<ProjectsViewProps> = ({
                 }
                 onImportEditorSettings={handleImportEditorSettings}
                 onRemoveProject={handleRemoveProject}
+            />
+            <ProjectSettingsDrawer
+                project={editProjectFor}
+                open={Boolean(editProjectFor)}
+                onOpenChange={(open) => {
+                    if (!open) {
+                        setEditProjectFor(null);
+                    }
+                }}
+                onRenameProject={renameProject}
+                getProjectGodotName={getProjectGodotName}
             />
             {createOpen && (
                 <CreateProjectSubView

--- a/renderer/src/views/projects/components/projectActionsMenu.component.test.tsx
+++ b/renderer/src/views/projects/components/projectActionsMenu.component.test.tsx
@@ -1,0 +1,78 @@
+import type { ProjectDetails } from '@shared';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import { ProjectActionsMenu } from './projectActionsMenu.component';
+
+const project: ProjectDetails = {
+    name: 'Demo',
+    path: '/projects/demo',
+    version: '4.2',
+    version_number: 4.2,
+    renderer: 'FORWARD_PLUS',
+    editor_settings_path: '/editors/Demo/editor_data',
+    editor_settings_file: '/editors/Demo/editor_data/editor_settings-4.2.tres',
+    last_opened: null,
+    open_windowed: false,
+    release: {
+        version: '4.2',
+        version_number: 4.2,
+        install_path: '/godot',
+        editor_path: '/godot/godot.exe',
+        platform: 'win32',
+        arch: 'x86_64',
+        mono: false,
+        prerelease: false,
+        config_version: 5,
+        published_at: null,
+        valid: true,
+    },
+    launch_path: '/editors/Demo/godot.exe',
+    config_version: 5,
+    withVSCode: false,
+    withGit: false,
+    valid: true,
+};
+
+describe('ProjectActionsMenu', () => {
+    it('renders launch editor and project settings actions', () => {
+        const html = renderToStaticMarkup(
+            <ProjectActionsMenu
+                project={project}
+                anchorRect={{
+                    top: 0,
+                    right: 0,
+                    bottom: 0,
+                    left: 0,
+                    width: 0,
+                    height: 0,
+                }}
+                hasVSCode={false}
+                hasGit={false}
+                t={(key) =>
+                    key === 'project.launchEditor'
+                        ? 'Edit in Godot'
+                        : key === 'project.projectSettings'
+                          ? 'Project Settings'
+                          : key
+                }
+                onClose={vi.fn()}
+                onLaunchProject={vi.fn()}
+                onProjectSettings={vi.fn()}
+                onOpenProjectFolder={vi.fn()}
+                onOpenEditorSettingsFolder={vi.fn()}
+                onToggleWindowed={vi.fn()}
+                onToggleVSCode={vi.fn()}
+                onInitializeGit={vi.fn()}
+                onExportEditorSettings={vi.fn()}
+                onImportEditorSettings={vi.fn()}
+                onRemoveProject={vi.fn()}
+            />,
+        );
+
+        expect(html).toContain('Edit in Godot');
+        expect(html).toContain('Project Settings');
+        expect(html).toContain('lucide-pencil');
+        expect(html).toContain('stroke-info');
+        expect(html).toContain('lucide-square-pen');
+    });
+});

--- a/renderer/src/views/projects/components/projectActionsMenu.component.tsx
+++ b/renderer/src/views/projects/components/projectActionsMenu.component.tsx
@@ -1,5 +1,13 @@
 import type { ProjectDetails } from '@shared';
-import { Download, FolderOpen, PanelTop, Trash2, Upload } from 'lucide-react';
+import {
+    Download,
+    FolderOpen,
+    PanelTop,
+    Pencil,
+    SquarePen,
+    Trash2,
+    Upload,
+} from 'lucide-react';
 import type React from 'react';
 import gitIconColor from '../../../assets/icons/git_icon_color.svg';
 import vscodeIcon from '../../../assets/icons/vscode.svg';
@@ -18,6 +26,8 @@ type ProjectActionsMenuProps = {
     hasGit: boolean;
     t: Translate;
     onClose: () => void;
+    onLaunchProject: (project: ProjectDetails) => void;
+    onProjectSettings: (project: ProjectDetails) => void;
     onOpenProjectFolder: (project: ProjectDetails) => void;
     onOpenEditorSettingsFolder: (project: ProjectDetails) => void;
     onToggleWindowed: (project: ProjectDetails) => void;
@@ -37,6 +47,8 @@ export const ProjectActionsMenu: React.FC<ProjectActionsMenuProps> = ({
     hasGit,
     t,
     onClose,
+    onLaunchProject,
+    onProjectSettings,
     onOpenProjectFolder,
     onOpenEditorSettingsFolder,
     onToggleWindowed,
@@ -48,6 +60,23 @@ export const ProjectActionsMenu: React.FC<ProjectActionsMenuProps> = ({
 }) => {
     const items: ActionMenuItem[] = project
         ? [
+              {
+                  key: 'launch-editor',
+                  label: t('project.launchEditor', { ns: 'menus' }),
+                  icon: <Pencil className={`${iconClassName} stroke-info`} />,
+                  disabled: !project.valid,
+                  onSelect: () => onLaunchProject(project),
+              },
+              {
+                  key: 'project-settings',
+                  label: t('project.projectSettings', { ns: 'menus' }),
+                  icon: <SquarePen className={iconClassName} />,
+                  onSelect: () => onProjectSettings(project),
+              },
+              {
+                  type: 'separator',
+                  key: 'project-primary-separator',
+              },
               {
                   key: 'open-project-folder',
                   label: t('project.openProjectFolder', { ns: 'menus' }),

--- a/renderer/src/views/subViews/projectSettingsDrawer.subview.test.tsx
+++ b/renderer/src/views/subViews/projectSettingsDrawer.subview.test.tsx
@@ -1,0 +1,125 @@
+import type { ProjectDetails } from '@shared';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import {
+    canRenameGodotProject,
+    hasProjectRenameChanges,
+    validateProjectRenameName,
+} from './projectSettingsDrawer/projectSettings.model';
+import { ProjectSettingsDrawer } from './projectSettingsDrawer.subview';
+
+vi.mock('react-i18next', () => {
+    const dictionary: Record<string, string> = {
+        'projects:editProject.title': 'Project Settings',
+        'projects:editProject.fields.name.label': 'Project name',
+        'projects:editProject.fields.name.help':
+            'Name shown in Godot Launcher.',
+        'projects:editProject.fields.name.placeholder': 'My Project',
+        'projects:editProject.fields.path.label': 'Project folder',
+        'projects:editProject.godot.renameLabel': 'Also rename Godot project',
+        'projects:editProject.godot.loading': 'Checking Godot project...',
+        'projects:editProject.godot.unavailable':
+            'project.godot is unavailable.',
+        'projects:editProject.actions.update': 'Update',
+        'projects:editProject.actions.updating': 'Updating...',
+        'common:buttons.cancel': 'Cancel',
+        'common:buttons.copyPath': 'Copy path',
+        'common:success': 'Copied',
+    };
+
+    return {
+        useTranslation: (namespaces?: string[]) => ({
+            t: (key: string, options?: Record<string, unknown>) => {
+                const namespace = Array.isArray(namespaces)
+                    ? namespaces[0]
+                    : namespaces;
+                const dictKey = key.includes(':') ? key : `${namespace}:${key}`;
+                const value = dictionary[dictKey] ?? key;
+                return options
+                    ? value.replace(/\{\{(\w+)\}\}/g, (_, token) =>
+                          String(options[token] ?? ''),
+                      )
+                    : value;
+            },
+        }),
+    };
+});
+
+const project: ProjectDetails = {
+    name: 'Demo',
+    path: '/projects/demo',
+    version: '4.2',
+    version_number: 4.2,
+    renderer: 'FORWARD_PLUS',
+    editor_settings_path: '/editors/Demo/editor_data',
+    editor_settings_file: '/editors/Demo/editor_data/editor_settings-4.2.tres',
+    last_opened: null,
+    open_windowed: false,
+    release: {
+        version: '4.2',
+        version_number: 4.2,
+        install_path: '/godot',
+        editor_path: '/godot/godot.exe',
+        platform: 'win32',
+        arch: 'x86_64',
+        mono: false,
+        prerelease: false,
+        config_version: 5,
+        published_at: null,
+        valid: true,
+    },
+    launch_path: '/editors/Demo/godot.exe',
+    config_version: 5,
+    withVSCode: false,
+    withGit: false,
+    valid: true,
+};
+
+describe('ProjectSettingsDrawer', () => {
+    it('renders the rename form fields and actions', () => {
+        const html = renderToStaticMarkup(
+            <ProjectSettingsDrawer
+                project={project}
+                open
+                onOpenChange={vi.fn()}
+                onRenameProject={vi.fn()}
+                getProjectGodotName={vi.fn()}
+            />,
+        );
+
+        expect(html).toContain('Demo Settings');
+        expect(html).not.toContain('Update project naming settings.');
+        expect(html).toContain('Project name');
+        expect(html).toContain('/projects/demo');
+        expect(html).not.toContain('Project folder');
+        expect(html).toContain('Also rename Godot project');
+        expect(html).toContain('Update');
+        expect(html).toContain('Cancel');
+    });
+
+    it('validates rename names', () => {
+        expect(validateProjectRenameName('')).toBe('required');
+        expect(validateProjectRenameName('   ')).toBe('required');
+        expect(validateProjectRenameName('Bad\nName')).toBe('invalidName');
+        expect(validateProjectRenameName('Good Name')).toBeNull();
+    });
+
+    it('enables Godot rename only when the new name differs from Godot', () => {
+        expect(canRenameGodotProject('Renamed', 'Demo')).toBe(true);
+        expect(canRenameGodotProject('Demo', 'Demo')).toBe(false);
+        expect(canRenameGodotProject('Renamed', null)).toBe(false);
+        expect(canRenameGodotProject('   ', 'Demo')).toBe(false);
+    });
+
+    it('detects launcher and Godot rename changes', () => {
+        expect(hasProjectRenameChanges('Demo', 'Demo', 'Renamed', false)).toBe(
+            true,
+        );
+        expect(hasProjectRenameChanges('Demo', 'Godot', 'Demo', true)).toBe(
+            true,
+        );
+        expect(hasProjectRenameChanges('Demo', 'Demo', 'Demo', true)).toBe(
+            false,
+        );
+    });
+});

--- a/renderer/src/views/subViews/projectSettingsDrawer.subview.tsx
+++ b/renderer/src/views/subViews/projectSettingsDrawer.subview.tsx
@@ -1,0 +1,312 @@
+import type {
+    ProjectDetails,
+    RenameProjectOptions,
+    RenameProjectResult,
+} from '@shared';
+import clsx from 'clsx';
+import type React from 'react';
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { CopyBadge } from '../../components/ui/copyBadge.component';
+import { Drawer } from '../../components/ui/drawer/drawer.component';
+import { TextField } from '../../components/ui/textField.component';
+import {
+    canRenameGodotProject,
+    hasProjectRenameChanges,
+    validateProjectRenameName,
+} from './projectSettingsDrawer/projectSettings.model';
+
+type ProjectSettingsDrawerProps = {
+    project: ProjectDetails | null;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    onRenameProject: (
+        project: ProjectDetails,
+        options: RenameProjectOptions,
+    ) => Promise<RenameProjectResult>;
+    getProjectGodotName: (project: ProjectDetails) => Promise<string | null>;
+};
+
+export const ProjectSettingsDrawer: React.FC<ProjectSettingsDrawerProps> = ({
+    project,
+    open,
+    onOpenChange,
+    onRenameProject,
+    getProjectGodotName,
+}) => {
+    const { t } = useTranslation(['projects', 'common']);
+    const [name, setName] = useState('');
+    const [godotProjectName, setGodotProjectName] = useState<string | null>(
+        null,
+    );
+    const [loadingGodotName, setLoadingGodotName] = useState(false);
+    const [renameGodotProject, setRenameGodotProject] = useState(false);
+    const [nameError, setNameError] = useState<string>();
+    const [godotError, setGodotError] = useState<string>();
+    const [formError, setFormError] = useState<string>();
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    useEffect(() => {
+        if (!open || !project) {
+            return;
+        }
+
+        let disposed = false;
+
+        setName(project.name);
+        setGodotProjectName(null);
+        setRenameGodotProject(false);
+        setNameError(undefined);
+        setGodotError(undefined);
+        setFormError(undefined);
+        setIsSubmitting(false);
+        setLoadingGodotName(true);
+
+        getProjectGodotName(project)
+            .then((currentGodotProjectName) => {
+                if (disposed) {
+                    return;
+                }
+
+                setGodotProjectName(currentGodotProjectName);
+                setRenameGodotProject(false);
+            })
+            .catch(() => {
+                if (!disposed) {
+                    setGodotProjectName(null);
+                }
+            })
+            .finally(() => {
+                if (!disposed) {
+                    setLoadingGodotName(false);
+                }
+            });
+
+        return () => {
+            disposed = true;
+        };
+    }, [getProjectGodotName, open, project]);
+
+    const getValidationMessage = (
+        validationError: ReturnType<typeof validateProjectRenameName>,
+    ): string | undefined => {
+        if (!validationError) {
+            return undefined;
+        }
+
+        return t(`editProject.validation.${validationError}`);
+    };
+
+    const validateNameField = (): boolean => {
+        const validationMessage = getValidationMessage(
+            validateProjectRenameName(name),
+        );
+        setNameError(validationMessage);
+        return !validationMessage;
+    };
+
+    const handleNameChange = (value: string) => {
+        setName(value);
+        setNameError(undefined);
+        setFormError(undefined);
+        setGodotError(undefined);
+
+        if (!canRenameGodotProject(value, godotProjectName)) {
+            setRenameGodotProject(false);
+        }
+    };
+
+    const handleRenameGodotProjectChange = (checked: boolean) => {
+        setRenameGodotProject(checked);
+        setGodotError(undefined);
+        setFormError(undefined);
+    };
+
+    const handleSubmit = async (event: React.FormEvent) => {
+        event.preventDefault();
+
+        if (!project || !validateNameField()) {
+            return;
+        }
+
+        setIsSubmitting(true);
+        setFormError(undefined);
+        setGodotError(undefined);
+
+        try {
+            const result = await onRenameProject(project, {
+                name: name.trim(),
+                renameGodotProject,
+            });
+
+            if (!result.success) {
+                const message = result.error ?? t('editProject.updateFailed');
+                setFormError(message);
+
+                if (result.errorField === 'name') {
+                    setNameError(message);
+                } else if (result.errorField === 'godot') {
+                    setGodotError(message);
+                }
+
+                return;
+            }
+
+            onOpenChange(false);
+        } catch (error) {
+            setFormError(
+                error instanceof Error
+                    ? error.message
+                    : t('editProject.updateFailed'),
+            );
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    const trimmedName = name.trim();
+    const godotProjectAvailable = godotProjectName !== null;
+    const godotRenameEnabled = canRenameGodotProject(name, godotProjectName);
+    const hasChanges =
+        project &&
+        hasProjectRenameChanges(
+            project.name,
+            godotProjectName,
+            name,
+            renameGodotProject,
+        );
+    const saveDisabled =
+        !project ||
+        trimmedName.length === 0 ||
+        !hasChanges ||
+        isSubmitting ||
+        loadingGodotName;
+    const drawerTitle = project
+        ? `${project.name} Settings`
+        : t('editProject.title');
+
+    return (
+        <Drawer
+            open={open && Boolean(project)}
+            onOpenChange={onOpenChange}
+            side="right"
+            ariaLabel={drawerTitle}
+            width={520}
+            panelClassName="max-w-[100vw]"
+        >
+            <Drawer.Header>
+                <div className="flex min-w-0 flex-1 flex-col gap-2">
+                    <Drawer.Title>{drawerTitle}</Drawer.Title>
+                    {project && (
+                        <CopyBadge
+                            value={project.path}
+                            label={t('common:buttons.copyPath')}
+                            copiedLabel={t('common:success')}
+                            className="w-full rounded-lg bg-base-100/80"
+                        />
+                    )}
+                </div>
+                <Drawer.CloseButton />
+            </Drawer.Header>
+            <form
+                className="flex min-h-0 flex-1 flex-col"
+                onSubmit={(event) => void handleSubmit(event)}
+            >
+                <Drawer.Body className="flex flex-col gap-4">
+                    {formError && (
+                        <div className="alert alert-error alert-soft">
+                            {formError}
+                        </div>
+                    )}
+
+                    <TextField
+                        id="projectEditName"
+                        label={t('editProject.fields.name.label')}
+                        help={t('editProject.fields.name.help')}
+                        value={name}
+                        onChange={handleNameChange}
+                        onBlur={validateNameField}
+                        placeholder={t('editProject.fields.name.placeholder')}
+                        error={nameError}
+                    />
+
+                    <label
+                        className={clsx(
+                            'flex items-start gap-3 rounded-lg border p-3',
+                            godotError
+                                ? 'border-error bg-error/5'
+                                : 'border-base-300 bg-base-200/40',
+                            (!godotProjectAvailable ||
+                                loadingGodotName ||
+                                !godotRenameEnabled) &&
+                                'opacity-70',
+                        )}
+                    >
+                        <input
+                            type="checkbox"
+                            className={clsx(
+                                'checkbox checkbox-primary mt-0.5',
+                                godotError && 'checkbox-error',
+                            )}
+                            checked={renameGodotProject}
+                            disabled={
+                                !godotProjectAvailable ||
+                                loadingGodotName ||
+                                !godotRenameEnabled
+                            }
+                            onChange={(event) =>
+                                handleRenameGodotProjectChange(
+                                    event.currentTarget.checked,
+                                )
+                            }
+                        />
+                        <span className="flex min-w-0 flex-col gap-1">
+                            <span className="font-semibold">
+                                {t('editProject.godot.renameLabel')}
+                            </span>
+                            <span className="text-sm text-base-content/70">
+                                {loadingGodotName &&
+                                    t('editProject.godot.loading')}
+                                {!loadingGodotName &&
+                                    godotProjectAvailable &&
+                                    t('editProject.godot.currentName', {
+                                        name: godotProjectName,
+                                    })}
+                                {!loadingGodotName &&
+                                    !godotProjectAvailable &&
+                                    t('editProject.godot.unavailable')}
+                            </span>
+                            {godotError && (
+                                <span className="text-sm text-error">
+                                    {godotError}
+                                </span>
+                            )}
+                        </span>
+                    </label>
+                </Drawer.Body>
+                <Drawer.Footer>
+                    <button
+                        type="button"
+                        className="btn btn-ghost"
+                        onClick={() => onOpenChange(false)}
+                        disabled={isSubmitting}
+                    >
+                        {t('common:buttons.cancel')}
+                    </button>
+                    <button
+                        type="submit"
+                        className="btn btn-primary"
+                        disabled={saveDisabled}
+                    >
+                        {isSubmitting && (
+                            <span className="loading loading-spinner loading-xs" />
+                        )}
+                        {isSubmitting
+                            ? t('editProject.actions.updating')
+                            : t('editProject.actions.update')}
+                    </button>
+                </Drawer.Footer>
+            </form>
+        </Drawer>
+    );
+};

--- a/renderer/src/views/subViews/projectSettingsDrawer/projectSettings.model.ts
+++ b/renderer/src/views/subViews/projectSettingsDrawer/projectSettings.model.ts
@@ -1,0 +1,56 @@
+export type ProjectRenameValidationError = 'required' | 'invalidName';
+
+export function validateProjectRenameName(
+    name: string,
+): ProjectRenameValidationError | null {
+    const trimmedName = name.trim();
+
+    if (trimmedName.length === 0) {
+        return 'required';
+    }
+
+    if (hasControlCharacters(trimmedName)) {
+        return 'invalidName';
+    }
+
+    return null;
+}
+
+function hasControlCharacters(value: string): boolean {
+    return Array.from(value).some((character) => {
+        const codePoint = character.codePointAt(0) ?? 0;
+        return codePoint <= 31 || codePoint === 127;
+    });
+}
+
+export function hasProjectRenameChanges(
+    launcherName: string,
+    godotProjectName: string | null,
+    newName: string,
+    renameGodotProject: boolean,
+): boolean {
+    const trimmedName = newName.trim();
+
+    if (trimmedName !== launcherName) {
+        return true;
+    }
+
+    return (
+        renameGodotProject &&
+        godotProjectName !== null &&
+        trimmedName !== godotProjectName
+    );
+}
+
+export function canRenameGodotProject(
+    newName: string,
+    godotProjectName: string | null,
+): boolean {
+    const trimmedName = newName.trim();
+
+    return (
+        trimmedName.length > 0 &&
+        godotProjectName !== null &&
+        trimmedName !== godotProjectName
+    );
+}

--- a/shared/src/ipc/index.d.ts
+++ b/shared/src/ipc/index.d.ts
@@ -9,6 +9,7 @@ import type {
     ChangeProjectEditorResult,
     CreateProjectResult,
     ProjectDetails,
+    RenameProjectResult,
     SetProjectVSCodeResult,
 } from '../projects/index.js';
 import type {
@@ -62,6 +63,8 @@ export type EventChannelMapping = {
     'create-project': Promise<CreateProjectResult>;
     'get-projects-details': Promise<ProjectDetails[]>;
     'remove-project': Promise<ProjectDetails[]>;
+    'rename-project': Promise<RenameProjectResult>;
+    'get-project-godot-name': Promise<string | null>;
     'add-project': Promise<AddProjectToListResult>;
     'set-project-editor': Promise<ChangeProjectEditorResult>;
     'set-project-windowed': Promise<ProjectDetails>;

--- a/shared/src/projects/index.d.ts
+++ b/shared/src/projects/index.d.ts
@@ -78,6 +78,17 @@ export type SetProjectVSCodeResult = ProjectDetails & {
     recoveredVSCodeConfigFiles?: string[];
 };
 
+export type RenameProjectOptions = {
+    name: string;
+    renameGodotProject: boolean;
+};
+
+export type RenameProjectResult = BackendResult & {
+    project?: ProjectDetails;
+    projects?: ProjectDetails[];
+    errorField?: 'name' | 'godot';
+};
+
 export type RendererType = {
     5: 'FORWARD_PLUS' | 'MOBILE' | 'COMPATIBLE';
 };

--- a/shared/src/renderer/index.d.ts
+++ b/shared/src/renderer/index.d.ts
@@ -10,6 +10,8 @@ import type {
     ChangeProjectEditorResult,
     CreateProjectResult,
     ProjectDetails,
+    RenameProjectOptions,
+    RenameProjectResult,
     RendererType,
     SetProjectVSCodeResult,
 } from '../projects/index.js';
@@ -90,6 +92,11 @@ export type ElectronRendererApi = {
         overwriteProjectPath?: string,
     ) => Promise<CreateProjectResult>;
     removeProject: (project: ProjectDetails) => Promise<ProjectDetails[]>;
+    renameProject: (
+        project: ProjectDetails,
+        options: RenameProjectOptions,
+    ) => Promise<RenameProjectResult>;
+    getProjectGodotName: (project: ProjectDetails) => Promise<string | null>;
     addProject: (
         path: string,
         options?: AddProjectOptions,


### PR DESCRIPTION
- Implemented project renaming with validation.
- Added option to rename associated Godot project.
- Updated UI components to support project settings editing.
- Enhanced tests for project renaming and settings drawer.