### PR TITLE
Ci/signpath release

### DIFF
--- a/.github/workflows/release-build-signpath.yml
+++ b/.github/workflows/release-build-signpath.yml
@@ -1,0 +1,396 @@
+name: Release Build (SignPath)
+
+on:
+  workflow_dispatch:
+    inputs:
+      prerelease:
+        description: 'Mark GitHub release as prerelease'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Sync npm version
+        run: npm install --global npm@11.16.0
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run lint
+        run: npx biome check --reporter summary
+
+      - name: Run build:sources
+        run: npm run build:sources
+
+      - name: Run unit tests
+        run: npm run test:unit
+
+  tag-release:
+    needs: checks
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Read package version
+        id: get_version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          git tag -a "v${{ steps.get_version.outputs.version }}" -m "Release v${{ steps.get_version.outputs.version }}"
+          git push origin "v${{ steps.get_version.outputs.version }}"
+
+  create-release:
+    needs: tag-release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      VERSION: ${{ needs.tag-release.outputs.version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Sync npm version
+        run: npm install --global npm@11.16.0
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Extract release notes
+        id: release_notes
+        shell: bash
+        run: |
+          NOTES=$(npm run --silent changelog -- --stdout --starting-version "${VERSION}" --ending-version "${VERSION}" --hide-credit --template ./auto-changelog-release.hbs)
+          {
+            echo "notes<<EOF"
+            echo "${NOTES}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create draft GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ env.VERSION }}
+          name: v${{ env.VERSION }}
+          body: ${{ steps.release_notes.outputs.notes }}
+          draft: true
+          prerelease: ${{ inputs.prerelease }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-windows:
+    needs:
+      - tag-release
+      - create-release
+    runs-on: windows-latest
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      signing_request_id: ${{ steps.submit_signpath.outputs.signing-request-id }}
+      signing_request_web_url: ${{ steps.submit_signpath.outputs.signing-request-web-url }}
+    env:
+      CSC_IDENTITY_AUTO_DISCOVERY: false
+      SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
+      SIGNPATH_ORGANIZATION_ID: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+      SIGNPATH_PROJECT_SLUG: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+      VERSION: ${{ needs.tag-release.outputs.version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Sync npm version
+        run: npm install --global npm@11.16.0
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build unsigned Windows artifacts
+        run: npm run dist:win -- --publish never
+
+      - name: Upload Windows dist artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-dist-windows
+          path: |
+            dist/Godot_Launcher-${{ env.VERSION }}-win_*
+            dist/latest.yml
+          if-no-files-found: error
+
+      - name: Prepare SignPath input
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path signpath-unsigned | Out-Null
+          $installers = Get-ChildItem -Path dist -Filter "Godot_Launcher-$env:VERSION-win_*.exe" -File
+          if ($installers.Count -eq 0) {
+              throw "No Windows installers found for version $env:VERSION."
+          }
+          foreach ($installer in $installers) {
+              Copy-Item -LiteralPath $installer.FullName -Destination (Join-Path signpath-unsigned $installer.Name)
+          }
+
+      - name: Upload SignPath input
+        id: upload_unsigned
+        uses: actions/upload-artifact@v7
+        with:
+          name: signpath-unsigned-windows
+          path: signpath-unsigned/*.exe
+          if-no-files-found: error
+
+      - name: Submit Windows SignPath request
+        id: submit_signpath
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+          signing-policy-slug: ${{ vars.SIGNPATH_WINDOWS_POLICY_SLUG }}
+          artifact-configuration-slug: ${{ vars.SIGNPATH_WINDOWS_ARTIFACT_CONFIGURATION_SLUG }}
+          github-artifact-id: ${{ steps.upload_unsigned.outputs.artifact-id }}
+          wait-for-completion: false
+
+  build-linux:
+    needs:
+      - tag-release
+      - create-release
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      signing_request_id: ${{ steps.submit_signpath.outputs.signing-request-id }}
+      signing_request_web_url: ${{ steps.submit_signpath.outputs.signing-request-web-url }}
+    env:
+      SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
+      SIGNPATH_ORGANIZATION_ID: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+      SIGNPATH_PROJECT_SLUG: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+      VERSION: ${{ needs.tag-release.outputs.version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Sync npm version
+        run: npm install --global npm@11.16.0
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build unsigned Linux artifacts
+        run: npm run dist:linux -- --publish never
+
+      - name: Upload Linux dist artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-dist-linux
+          path: |
+            dist/Godot_Launcher-${{ env.VERSION }}-linux_*
+            dist/latest-linux*.yml
+          if-no-files-found: error
+
+      - name: Prepare SignPath input
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p signpath-unsigned
+          shopt -s nullglob
+          artifacts=(
+            dist/Godot_Launcher-"${VERSION}"-linux_*.AppImage
+            dist/Godot_Launcher-"${VERSION}"-linux_*.deb
+            dist/Godot_Launcher-"${VERSION}"-linux_*.rpm
+          )
+          if [ "${#artifacts[@]}" -eq 0 ]; then
+            echo "No Linux artifacts found for version ${VERSION}." >&2
+            exit 1
+          fi
+          cp "${artifacts[@]}" signpath-unsigned/
+
+      - name: Upload SignPath input
+        id: upload_unsigned
+        uses: actions/upload-artifact@v7
+        with:
+          name: signpath-unsigned-linux
+          path: signpath-unsigned/*
+          if-no-files-found: error
+
+      - name: Submit Linux SignPath request
+        id: submit_signpath
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+          signing-policy-slug: ${{ vars.SIGNPATH_LINUX_POLICY_SLUG }}
+          artifact-configuration-slug: ${{ vars.SIGNPATH_LINUX_ARTIFACT_CONFIGURATION_SLUG }}
+          github-artifact-id: ${{ steps.upload_unsigned.outputs.artifact-id }}
+          wait-for-completion: false
+
+  build-macos:
+    needs:
+      - tag-release
+      - create-release
+    runs-on: macos-latest
+    env:
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      CSC_NAME: ${{ vars.MACOS_CERTIFICATE_SUBJECT_NAME }}
+      FORCE_MAC_CODE_SIGNING: true
+      SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
+      SIGNPATH_ORGANIZATION_ID: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+      SIGNPATH_PROJECT_SLUG: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+      SIGNPATH_SIGNING_POLICY_SLUG: ${{ vars.SIGNPATH_MACOS_POLICY_SLUG }}
+      VERSION: ${{ needs.tag-release.outputs.version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Fetch tags
+        run: git fetch --tags --force
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Sync npm version
+        run: npm install --global npm@11.16.0
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install SignPath CryptoTokenKit
+        shell: bash
+        run: |
+          set -euo pipefail
+          dmg_path="${RUNNER_TEMP}/SignPathCryptoTokenKit.dmg"
+          mount_path="${RUNNER_TEMP}/signpath-ctk"
+          ctk_url="${SIGNPATH_MACOS_CRYPTOTOKENKIT_DMG_URL:-https://download.signpath.io/cryptoproviders/macos-cryptotokenkit/2-latest/SignPathCryptoTokenKit.dmg}"
+
+          mkdir -p "${mount_path}"
+          curl --fail --location --show-error --output "${dmg_path}" "${ctk_url}"
+          hdiutil attach "${dmg_path}" -mountroot "${mount_path}" -quiet
+
+          ctk_app="$(find "${mount_path}" -maxdepth 3 -name 'SignPathCryptoTokenKit.app' -print -quit)"
+          if [ -z "${ctk_app}" ]; then
+            echo "SignPathCryptoTokenKit.app was not found." >&2
+            exit 1
+          fi
+
+          open "${ctk_app}" --args \
+            --organization-id "${SIGNPATH_ORGANIZATION_ID}" \
+            --project-slug "${SIGNPATH_PROJECT_SLUG}" \
+            --signing-policy-slug "${SIGNPATH_SIGNING_POLICY_SLUG}"
+
+          sleep 20
+          security find-identity -v -p codesigning
+        env:
+          SIGNPATH_MACOS_CRYPTOTOKENKIT_DMG_URL: ${{ vars.SIGNPATH_MACOS_CRYPTOTOKENKIT_DMG_URL }}
+
+      - name: Build signed and notarized macOS artifacts
+        run: npm run dist:mac -- --publish never
+
+      - name: Upload macOS dist artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-dist-macos
+          path: |
+            dist/Godot_Launcher-${{ env.VERSION }}-mac_*
+            dist/latest-mac.*
+          if-no-files-found: error
+
+  upload-manifest:
+    needs:
+      - tag-release
+      - build-windows
+      - build-linux
+      - build-macos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write SignPath release manifest
+        shell: bash
+        run: |
+          cat > signpath-release-manifest.json <<JSON
+          {
+            "version": "${{ needs.tag-release.outputs.version }}",
+            "tag": "v${{ needs.tag-release.outputs.version }}",
+            "buildRunId": "${{ github.run_id }}",
+            "requests": {
+              "windows": {
+                "id": "${{ needs.build-windows.outputs.signing_request_id }}",
+                "webUrl": "${{ needs.build-windows.outputs.signing_request_web_url }}"
+              },
+              "linux": {
+                "id": "${{ needs.build-linux.outputs.signing_request_id }}",
+                "webUrl": "${{ needs.build-linux.outputs.signing_request_web_url }}"
+              }
+            }
+          }
+          JSON
+          cat signpath-release-manifest.json
+
+      - name: Upload SignPath release manifest
+        uses: actions/upload-artifact@v7
+        with:
+          name: signpath-release-manifest
+          path: signpath-release-manifest.json
+          if-no-files-found: error

--- a/.github/workflows/release-publish-signpath.yml
+++ b/.github/workflows/release-publish-signpath.yml
@@ -1,0 +1,313 @@
+name: Release Publish (SignPath)
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_run_id:
+        description: 'Run ID from Release Build (SignPath)'
+        required: true
+        type: string
+      publish_release:
+        description: 'Publish the draft release after uploading assets'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  actions: read
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
+      SIGNPATH_CONNECTOR_URL: ${{ vars.SIGNPATH_CONNECTOR_URL || 'https://githubactions.connectors.signpath.io' }}
+      SIGNPATH_ORGANIZATION_ID: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Sync npm version
+        run: npm install --global npm@11.16.0
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download build workflow artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh run download "${{ inputs.build_run_id }}" --name signpath-release-manifest --dir release-input
+          gh run download "${{ inputs.build_run_id }}" --name release-dist-windows --dir dist/windows
+          gh run download "${{ inputs.build_run_id }}" --name release-dist-linux --dir dist/linux
+          gh run download "${{ inputs.build_run_id }}" --name release-dist-macos --dir dist/macos
+
+      - name: Read release manifest
+        id: manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+          node <<'NODE' >> "$GITHUB_OUTPUT"
+          const manifest = require('./release-input/signpath-release-manifest.json');
+          console.log(`version=${manifest.version}`);
+          console.log(`tag=${manifest.tag}`);
+          console.log(`windows_request_id=${manifest.requests.windows.id}`);
+          console.log(`linux_request_id=${manifest.requests.linux.id}`);
+          NODE
+
+      - name: Download signed Windows and Linux artifacts
+        shell: bash
+        env:
+          WINDOWS_REQUEST_ID: ${{ steps.manifest.outputs.windows_request_id }}
+          LINUX_REQUEST_ID: ${{ steps.manifest.outputs.linux_request_id }}
+        run: |
+          set -euo pipefail
+
+          download_signed_artifact() {
+            local request_id="$1"
+            local target_zip="$2"
+            local target_dir="$3"
+            local base_url="${SIGNPATH_CONNECTOR_URL%/}"
+            local url="${base_url}/${SIGNPATH_ORGANIZATION_ID}/SigningRequests/${request_id}/SignedArtifact?api-version=1.0"
+
+            mkdir -p "${target_dir}"
+            curl --fail --location --show-error \
+              --header "Authorization: Bearer ${SIGNPATH_API_TOKEN}" \
+              --output "${target_zip}" \
+              "${url}"
+            unzip -o "${target_zip}" -d "${target_dir}"
+          }
+
+          download_signed_artifact "${WINDOWS_REQUEST_ID}" signed-windows.zip signed/windows
+          download_signed_artifact "${LINUX_REQUEST_ID}" signed-linux.zip signed/linux
+
+      - name: Replace unsigned artifacts with signed artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          windows_count=0
+          while IFS= read -r -d '' file; do
+            cp "${file}" "dist/windows/$(basename "${file}")"
+            windows_count=$((windows_count + 1))
+          done < <(find signed/windows -type f -name '*.exe' -print0)
+
+          linux_count=0
+          while IFS= read -r -d '' file; do
+            cp "${file}" "dist/linux/$(basename "${file}")"
+            linux_count=$((linux_count + 1))
+          done < <(find signed/linux -type f -print0)
+
+          if [ "${windows_count}" -eq 0 ]; then
+            echo "No signed Windows artifacts were found." >&2
+            exit 1
+          fi
+
+          if [ "${linux_count}" -eq 0 ]; then
+            echo "No signed Linux artifacts were found." >&2
+            exit 1
+          fi
+
+      - name: Regenerate Windows updater metadata
+        shell: bash
+        env:
+          VERSION: ${{ steps.manifest.outputs.version }}
+        run: |
+          set -euo pipefail
+          rm -f dist/windows/*.blockmap dist/windows/*.yml
+
+          node <<'NODE'
+          const fs = require('fs/promises');
+          const path = require('path');
+          const crypto = require('crypto');
+          const yaml = require('js-yaml');
+          const { createReadStream } = require('fs');
+          const { executeAppBuilderAsJson } = require('app-builder-lib/out/util/appBuilder');
+
+          function hashFile(file) {
+            return new Promise((resolve, reject) => {
+              const hash = crypto.createHash('sha512');
+              createReadStream(file)
+                .on('data', chunk => hash.update(chunk))
+                .on('error', reject)
+                .on('end', () => resolve(hash.digest('base64')));
+            });
+          }
+
+          function order(name) {
+            if (name.includes('_x64.')) return 0;
+            if (name.includes('_arm64.')) return 1;
+            return 2;
+          }
+
+          async function main() {
+            const version = process.env.VERSION;
+            const distDir = path.resolve('dist/windows');
+            const artifacts = (await fs.readdir(distDir))
+              .filter(name => name.startsWith(`Godot_Launcher-${version}-win_`) && name.endsWith('.exe'))
+              .sort((a, b) => order(a) - order(b) || a.localeCompare(b));
+
+            if (artifacts.length === 0) {
+              throw new Error(`No signed Windows installers found for ${version}`);
+            }
+
+            const files = [];
+            for (const name of artifacts) {
+              const artifactPath = path.join(distDir, name);
+              const blockMapPath = `${artifactPath}.blockmap`;
+              await executeAppBuilderAsJson(['blockmap', '--input', artifactPath, '--output', blockMapPath]);
+
+              const [artifactStat, blockMapStat, sha512] = await Promise.all([
+                fs.stat(artifactPath),
+                fs.stat(blockMapPath),
+                hashFile(artifactPath),
+              ]);
+
+              files.push({
+                url: name,
+                sha512,
+                size: artifactStat.size,
+                blockMapSize: blockMapStat.size,
+              });
+            }
+
+            await fs.writeFile(path.join(distDir, 'latest.yml'), yaml.dump({
+              version,
+              files,
+              path: files[0].url,
+              sha512: files[0].sha512,
+              releaseDate: new Date().toISOString(),
+            }, { lineWidth: -1 }), 'utf8');
+          }
+
+          main().catch(error => {
+            console.error(error);
+            process.exit(1);
+          });
+          NODE
+
+      - name: Regenerate Linux updater metadata
+        shell: bash
+        env:
+          VERSION: ${{ steps.manifest.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          node <<'NODE'
+          const fs = require('fs/promises');
+          const path = require('path');
+          const crypto = require('crypto');
+          const yaml = require('js-yaml');
+          const { createReadStream } = require('fs');
+
+          function hashFile(file) {
+            return new Promise((resolve, reject) => {
+              const hash = crypto.createHash('sha512');
+              createReadStream(file)
+                .on('data', chunk => hash.update(chunk))
+                .on('error', reject)
+                .on('end', () => resolve(hash.digest('base64')));
+            });
+          }
+
+          function artifactOrder(name) {
+            if (name.endsWith('.AppImage')) return 0;
+            if (name.endsWith('.deb')) return 1;
+            if (name.endsWith('.rpm')) return 2;
+            return 3;
+          }
+
+          async function readYaml(file) {
+            try {
+              return yaml.load(await fs.readFile(file, 'utf8')) || {};
+            } catch (error) {
+              if (error.code === 'ENOENT') return {};
+              throw error;
+            }
+          }
+
+          async function writeUpdateInfo(fileName, arch) {
+            const version = process.env.VERSION;
+            const distDir = path.resolve('dist/linux');
+            const updateFile = path.join(distDir, fileName);
+            const existing = await readYaml(updateFile);
+            const existingFiles = new Map((existing.files || []).map(file => [file.url || file.path, file]));
+            const artifacts = (await fs.readdir(distDir))
+              .filter(name => name.startsWith(`Godot_Launcher-${version}-linux_${arch}.`))
+              .filter(name => name.endsWith('.AppImage') || name.endsWith('.deb') || name.endsWith('.rpm'))
+              .sort((a, b) => artifactOrder(a) - artifactOrder(b) || a.localeCompare(b));
+
+            if (artifacts.length === 0) return;
+
+            const files = [];
+            for (const name of artifacts) {
+              const artifactPath = path.join(distDir, name);
+              const [artifactStat, sha512] = await Promise.all([
+                fs.stat(artifactPath),
+                hashFile(artifactPath),
+              ]);
+              files.push({
+                ...(existingFiles.get(name) || {}),
+                url: name,
+                sha512,
+                size: artifactStat.size,
+              });
+            }
+
+            await fs.writeFile(updateFile, yaml.dump({
+              ...existing,
+              version,
+              files,
+              path: files[0].url,
+              sha512: files[0].sha512,
+              releaseDate: new Date().toISOString(),
+            }, { lineWidth: -1 }), 'utf8');
+          }
+
+          async function main() {
+            await writeUpdateInfo('latest-linux.yml', 'x64');
+            await writeUpdateInfo('latest-linux-arm64.yml', 'arm64');
+          }
+
+          main().catch(error => {
+            console.error(error);
+            process.exit(1);
+          });
+          NODE
+
+      - name: Collect release assets
+        shell: bash
+        env:
+          VERSION: ${{ steps.manifest.outputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p release-assets
+
+          find dist/windows -maxdepth 1 -type f \( -name "Godot_Launcher-${VERSION}-win_*" -o -name 'latest.yml' \) -exec cp {} release-assets/ \;
+          find dist/linux -maxdepth 1 -type f \( -name "Godot_Launcher-${VERSION}-linux_*" -o -name 'latest-linux*.yml' \) -exec cp {} release-assets/ \;
+          find dist/macos -maxdepth 1 -type f \( -name "Godot_Launcher-${VERSION}-mac_*" -o -name 'latest-mac.*' \) -exec cp {} release-assets/ \;
+
+          find release-assets -maxdepth 1 -type f -print | sort
+
+      - name: Upload release assets
+        shell: bash
+        env:
+          TAG: ${{ steps.manifest.outputs.tag }}
+        run: |
+          set -euo pipefail
+          gh release upload "${TAG}" release-assets/* --clobber
+
+      - name: Publish draft release
+        if: ${{ inputs.publish_release }}
+        shell: bash
+        env:
+          TAG: ${{ steps.manifest.outputs.tag }}
+        run: gh release edit "${TAG}" --draft=false

--- a/.github/workflows/signpath-test.yml
+++ b/.github/workflows/signpath-test.yml
@@ -4,37 +4,35 @@ on:
   workflow_dispatch:
     inputs:
       signing_policy_slug:
-        description: 'SignPath test signing policy slug'
+        description: "SignPath test signing policy slug"
         required: true
-        default: 'test-signing'
+        default: "test-signing"
         type: string
-      artifact_configuration_slug:
-        description: 'SignPath artifact configuration slug'
-        required: true
-        default: 'initial'
+      windows_artifact_configuration_slug:
+        description: "SignPath Windows artifact configuration slug; falls back to SIGNPATH_WINDOWS_ARTIFACT_CONFIGURATION_SLUG"
+        required: false
+        default: ""
         type: string
-      arch:
-        description: 'Windows installer architecture to test sign'
-        required: true
-        default: 'x64'
-        type: choice
-        options:
-          - x64
-          - arm64
+      linux_artifact_configuration_slug:
+        description: "SignPath Linux artifact configuration slug; falls back to SIGNPATH_LINUX_ARTIFACT_CONFIGURATION_SLUG"
+        required: false
+        default: ""
+        type: string
 
 permissions:
   actions: read
   contents: read
 
 jobs:
-  signpath-test:
-    name: Build and submit Windows installers
+  build-windows:
+    name: Build and test sign Windows artifacts
     runs-on: windows-latest
     env:
       CSC_IDENTITY_AUTO_DISCOVERY: false
       SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
       SIGNPATH_ORGANIZATION_ID: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
       SIGNPATH_PROJECT_SLUG: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+      SIGNPATH_ARTIFACT_CONFIGURATION_SLUG: ${{ inputs.windows_artifact_configuration_slug || vars.SIGNPATH_WINDOWS_ARTIFACT_CONFIGURATION_SLUG }}
     steps:
       - name: Validate SignPath configuration
         shell: pwsh
@@ -44,7 +42,8 @@ jobs:
           foreach ($name in @(
               'SIGNPATH_API_TOKEN',
               'SIGNPATH_ORGANIZATION_ID',
-              'SIGNPATH_PROJECT_SLUG'
+              'SIGNPATH_PROJECT_SLUG',
+              'SIGNPATH_ARTIFACT_CONFIGURATION_SLUG'
           )) {
               if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($name))) {
                   $missing += $name
@@ -61,8 +60,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
-          cache: 'npm'
+          node-version: "24"
+          cache: "npm"
 
       - name: Sync npm version
         run: npm install --global npm@11.16.0
@@ -77,69 +76,67 @@ jobs:
           $version = node -p "require('./package.json').version"
           "version=$version" >> $env:GITHUB_OUTPUT
 
-      - name: Build unsigned Windows installers
+      - name: Build unsigned Windows artifacts
         run: npm run dist:win -- --publish never
 
-      - name: Prepare SignPath input artifact
-        id: prepare_unsigned_artifact
-        shell: pwsh
-        run: |
-          $version = "${{ steps.package_version.outputs.version }}"
-          $arch = "${{ inputs.arch }}"
-          $unsignedDir = Join-Path $env:GITHUB_WORKSPACE 'signpath-unsigned'
-
-          New-Item -ItemType Directory -Force -Path $unsignedDir | Out-Null
-
-          $installers = Get-ChildItem -Path 'dist' -Filter "Godot_Launcher-$version-win_$arch.exe" -File
-          if ($installers.Count -eq 0) {
-              throw "No Windows $arch installer found for version $version."
-          }
-
-          if ($installers.Count -gt 1) {
-              throw "Expected one Windows $arch installer for version $version, found $($installers.Count)."
-          }
-
-          $unsignedInstaller = Join-Path $unsignedDir $installers[0].Name
-          Copy-Item -LiteralPath $installers[0].FullName -Destination $unsignedInstaller
-          "unsigned_installer=$unsignedInstaller" >> $env:GITHUB_OUTPUT
-
-          Write-Host "Prepared unsigned artifact file: $($installers[0].Name)"
-
-      - name: Upload unsigned artifact
-        id: upload_unsigned_artifact
+      - name: Upload Windows dist artifacts
         uses: actions/upload-artifact@v7
         with:
-          path: ${{ steps.prepare_unsigned_artifact.outputs.unsigned_installer }}
+          name: signpath-test-dist-windows-${{ steps.package_version.outputs.version }}
+          path: |
+            dist/Godot_Launcher-${{ steps.package_version.outputs.version }}-win_*
+            dist/latest.yml
           if-no-files-found: error
-          archive: false
 
-      - name: Submit SignPath test signing request
-        id: submit_signpath_request
+      - name: Prepare SignPath input
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path signpath-unsigned | Out-Null
+          $installers = Get-ChildItem -Path dist -Filter "Godot_Launcher-${{ steps.package_version.outputs.version }}-win_*.exe" -File
+
+          if ($installers.Count -eq 0) {
+              throw "No Windows installers found for version ${{ steps.package_version.outputs.version }}."
+          }
+
+          foreach ($installer in $installers) {
+              Copy-Item -LiteralPath $installer.FullName -Destination (Join-Path signpath-unsigned $installer.Name)
+              Write-Host "Prepared unsigned artifact file: $($installer.Name)"
+          }
+
+      - name: Upload SignPath input
+        id: upload_unsigned
+        uses: actions/upload-artifact@v7
+        with:
+          name: signpath-test-unsigned-windows-${{ steps.package_version.outputs.version }}
+          path: signpath-unsigned/*.exe
+          if-no-files-found: error
+
+      - name: Submit Windows SignPath test signing request
+        id: submit_signpath
         uses: signpath/github-action-submit-signing-request@v2
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
           organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
           project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
           signing-policy-slug: ${{ inputs.signing_policy_slug }}
-          artifact-configuration-slug: ${{ inputs.artifact_configuration_slug }}
-          github-artifact-id: ${{ steps.upload_unsigned_artifact.outputs['artifact-id'] }}
+          artifact-configuration-slug: ${{ env.SIGNPATH_ARTIFACT_CONFIGURATION_SLUG }}
+          github-artifact-id: ${{ steps.upload_unsigned.outputs.artifact-id }}
           wait-for-completion: true
           output-artifact-directory: ${{ github.workspace }}\signpath-signed
-          skip-decompress: true
 
       - name: Show SignPath request
         shell: pwsh
         run: |
-          Write-Host "SignPath request: ${{ steps.submit_signpath_request.outputs['signing-request-web-url'] }}"
+          Write-Host "SignPath request: ${{ steps.submit_signpath.outputs.signing-request-web-url }}"
 
-      - name: Inspect signed artifacts
+      - name: Inspect signed Windows artifacts
         shell: pwsh
         run: |
           $signedDir = Join-Path $env:GITHUB_WORKSPACE 'signpath-signed'
           $signedInstallers = Get-ChildItem -Path $signedDir -Filter '*.exe' -Recurse -File
 
           if ($signedInstallers.Count -eq 0) {
-              throw "SignPath completed, but no signed EXE files were downloaded."
+              throw "SignPath completed, but no signed Windows EXE files were downloaded."
           }
 
           foreach ($installer in $signedInstallers) {
@@ -150,9 +147,270 @@ jobs:
               Write-Host "  Signer thumbprint: $($signature.SignerCertificate.Thumbprint)"
           }
 
-      - name: Upload signed artifact
+      - name: Upload signed Windows artifact
         uses: actions/upload-artifact@v7
         with:
-          name: signpath-signed-windows-${{ steps.package_version.outputs.version }}
+          name: signpath-test-signed-windows-${{ steps.package_version.outputs.version }}
           path: signpath-signed/**
+          if-no-files-found: error
+
+  build-linux:
+    name: Build and test sign Linux artifacts
+    runs-on: ubuntu-latest
+    env:
+      SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
+      SIGNPATH_ORGANIZATION_ID: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+      SIGNPATH_PROJECT_SLUG: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+      SIGNPATH_ARTIFACT_CONFIGURATION_SLUG: ${{ inputs.linux_artifact_configuration_slug || vars.SIGNPATH_LINUX_ARTIFACT_CONFIGURATION_SLUG }}
+    steps:
+      - name: Validate SignPath configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=()
+
+          for name in \
+            SIGNPATH_API_TOKEN \
+            SIGNPATH_ORGANIZATION_ID \
+            SIGNPATH_PROJECT_SLUG \
+            SIGNPATH_ARTIFACT_CONFIGURATION_SLUG; do
+            if [ -z "${!name:-}" ]; then
+              missing+=("${name}")
+            fi
+          done
+
+          if [ "${#missing[@]}" -gt 0 ]; then
+            printf 'Missing GitHub secret/variable(s): %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Sync npm version
+        run: npm install --global npm@11.16.0
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Read package version
+        id: package_version
+        shell: bash
+        run: |
+          version="$(node -p "require('./package.json').version")"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Build unsigned Linux artifacts
+        run: npm run dist:linux -- --publish never
+
+      - name: Upload Linux dist artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: signpath-test-dist-linux-${{ steps.package_version.outputs.version }}
+          path: |
+            dist/Godot_Launcher-${{ steps.package_version.outputs.version }}-linux_*
+            dist/latest-linux*.yml
+          if-no-files-found: error
+
+      - name: Prepare SignPath input
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p signpath-unsigned
+          shopt -s nullglob
+          artifacts=(
+            dist/Godot_Launcher-"${{ steps.package_version.outputs.version }}"-linux_*.AppImage
+            dist/Godot_Launcher-"${{ steps.package_version.outputs.version }}"-linux_*.deb
+            dist/Godot_Launcher-"${{ steps.package_version.outputs.version }}"-linux_*.rpm
+          )
+
+          if [ "${#artifacts[@]}" -eq 0 ]; then
+            echo "No Linux artifacts found for version ${{ steps.package_version.outputs.version }}." >&2
+            exit 1
+          fi
+
+          cp "${artifacts[@]}" signpath-unsigned/
+          printf 'Prepared unsigned artifact files:\n'
+          printf '  %s\n' "${artifacts[@]##*/}"
+
+      - name: Upload SignPath input
+        id: upload_unsigned
+        uses: actions/upload-artifact@v7
+        with:
+          name: signpath-test-unsigned-linux-${{ steps.package_version.outputs.version }}
+          path: signpath-unsigned/*
+          if-no-files-found: error
+
+      - name: Submit Linux SignPath test signing request
+        id: submit_signpath
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+          signing-policy-slug: ${{ inputs.signing_policy_slug }}
+          artifact-configuration-slug: ${{ env.SIGNPATH_ARTIFACT_CONFIGURATION_SLUG }}
+          github-artifact-id: ${{ steps.upload_unsigned.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: ${{ github.workspace }}/signpath-signed
+
+      - name: Show SignPath request
+        shell: bash
+        run: |
+          echo "SignPath request: ${{ steps.submit_signpath.outputs.signing-request-web-url }}"
+
+      - name: Inspect signed Linux artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ ! -d signpath-signed ]; then
+            echo "SignPath completed, but no signed Linux artifact directory was downloaded." >&2
+            exit 1
+          fi
+
+          mapfile -t signed_artifacts < <(find signpath-signed -type f \( -name '*.AppImage' -o -name '*.deb' -o -name '*.rpm' \) | sort)
+          if [ "${#signed_artifacts[@]}" -eq 0 ]; then
+            echo "SignPath completed, but no signed Linux artifacts were downloaded." >&2
+            exit 1
+          fi
+
+          printf 'Signed Linux artifacts:\n'
+          printf '  %s\n' "${signed_artifacts[@]}"
+
+      - name: Upload signed Linux artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: signpath-test-signed-linux-${{ steps.package_version.outputs.version }}
+          path: signpath-signed/**
+          if-no-files-found: error
+
+  build-macos:
+    name: Build macOS artifacts with test SignPath policy
+    runs-on: macos-latest
+    env:
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      CSC_NAME: ${{ vars.MACOS_CERTIFICATE_SUBJECT_NAME }}
+      FORCE_MAC_CODE_SIGNING: true
+      SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
+      SIGNPATH_ORGANIZATION_ID: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+      SIGNPATH_PROJECT_SLUG: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+      SIGNPATH_SIGNING_POLICY_SLUG: ${{ inputs.signing_policy_slug }}
+    steps:
+      - name: Validate SignPath and Apple configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=()
+
+          for name in \
+            APPLE_ID \
+            APPLE_APP_SPECIFIC_PASSWORD \
+            APPLE_TEAM_ID \
+            CSC_NAME \
+            SIGNPATH_API_TOKEN \
+            SIGNPATH_ORGANIZATION_ID \
+            SIGNPATH_PROJECT_SLUG \
+            SIGNPATH_SIGNING_POLICY_SLUG; do
+            if [ -z "${!name:-}" ]; then
+              missing+=("${name}")
+            fi
+          done
+
+          if [ "${#missing[@]}" -gt 0 ]; then
+            printf 'Missing GitHub secret/variable(s): %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Fetch tags
+        run: git fetch --tags --force
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Sync npm version
+        run: npm install --global npm@11.16.0
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Read package version
+        id: package_version
+        shell: bash
+        run: |
+          version="$(node -p "require('./package.json').version")"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Install SignPath CryptoTokenKit
+        shell: bash
+        run: |
+          set -euo pipefail
+          dmg_path="${RUNNER_TEMP}/SignPathCryptoTokenKit.dmg"
+          mount_path="${RUNNER_TEMP}/signpath-ctk"
+          ctk_url="${SIGNPATH_MACOS_CRYPTOTOKENKIT_DMG_URL:-https://download.signpath.io/cryptoproviders/macos-cryptotokenkit/2-latest/SignPathCryptoTokenKit.dmg}"
+
+          mkdir -p "${mount_path}"
+          curl --fail --location --show-error --output "${dmg_path}" "${ctk_url}"
+          hdiutil attach "${dmg_path}" -mountroot "${mount_path}" -quiet
+
+          ctk_app="$(find "${mount_path}" -maxdepth 3 -name 'SignPathCryptoTokenKit.app' -print -quit)"
+          if [ -z "${ctk_app}" ]; then
+            echo "SignPathCryptoTokenKit.app was not found." >&2
+            exit 1
+          fi
+
+          open "${ctk_app}" --args \
+            --organization-id "${SIGNPATH_ORGANIZATION_ID}" \
+            --project-slug "${SIGNPATH_PROJECT_SLUG}" \
+            --signing-policy-slug "${SIGNPATH_SIGNING_POLICY_SLUG}"
+
+          sleep 20
+          security find-identity -v -p codesigning
+        env:
+          SIGNPATH_MACOS_CRYPTOTOKENKIT_DMG_URL: ${{ vars.SIGNPATH_MACOS_CRYPTOTOKENKIT_DMG_URL }}
+
+      - name: Build signed and notarized macOS artifacts
+        run: npm run dist:mac -- --publish never
+
+      - name: Inspect macOS artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          artifacts=(
+            dist/Godot_Launcher-"${{ steps.package_version.outputs.version }}"-mac_*
+            dist/latest-mac.*
+          )
+
+          if [ "${#artifacts[@]}" -eq 0 ]; then
+            echo "No macOS artifacts found for version ${{ steps.package_version.outputs.version }}." >&2
+            exit 1
+          fi
+
+          printf 'Built macOS artifacts:\n'
+          printf '  %s\n' "${artifacts[@]}"
+
+      - name: Upload macOS dist artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: signpath-test-dist-macos-${{ steps.package_version.outputs.version }}
+          path: |
+            dist/Godot_Launcher-${{ steps.package_version.outputs.version }}-mac_*
+            dist/latest-mac.*
           if-no-files-found: error


### PR DESCRIPTION
This pull request introduces a new, robust release automation pipeline using GitHub Actions, focused on secure and verifiable multi-platform builds with SignPath signing and improved artifact handling. It also updates the SignPath test workflow for greater flexibility and clarity.

**Release automation and signing:**

* Added `.github/workflows/release-build-signpath.yml` to automate building, testing, tagging, and preparing release artifacts for Windows, Linux, and macOS, including integration with SignPath for code signing and notarization. The workflow also generates a release manifest to coordinate signed artifact publishing.
* Added `.github/workflows/release-publish-signpath.yml` to automate downloading unsigned and signed artifacts, replacing unsigned with signed ones, regenerating updater metadata, and publishing assets to a GitHub draft release, with an option to publish the release.

**SignPath test workflow improvements:**

* Updated `.github/workflows/signpath-test.yml` to separate Windows and Linux artifact configuration slugs, making them optional and allowing fallback to repository variables. Also removed the architecture input for simplification.
* Ensured SignPath test jobs validate the presence of the new artifact configuration environment variables for better error reporting and configuration safety.

These changes enable a more reliable, automated, and secure release process, especially around artifact signing and cross-platform distribution.