### PR TITLE
ci: update GitHub release step to use gh CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,15 +131,24 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: v${{ env.VERSION }}
-          name: v${{ env.VERSION }}
-          body: ${{ steps.release_notes.outputs.notes }}
-          draft: true
-          prerelease: ${{ inputs.prerelease }}
+        shell: bash
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_NOTES: ${{ steps.release_notes.outputs.notes }}
+          PRERELEASE: ${{ inputs.prerelease }}
+        run: |
+          set -euo pipefail
+
+          notes_file="$RUNNER_TEMP/release-notes.md"
+          printf '%s\n' "$RELEASE_NOTES" > "$notes_file"
+
+          args=(--title "v${VERSION}" --notes-file "$notes_file" --draft)
+
+          if [[ "$PRERELEASE" == "true" ]]; then
+            args+=(--prerelease)
+          fi
+
+          gh release create "v${VERSION}" "${args[@]}"
 
   sign-windows:
     needs:


### PR DESCRIPTION
This pull request updates the GitHub release step in the `.github/workflows/release.yml` workflow to use the `gh` CLI directly instead of the `softprops/action-gh-release` action. This change provides more control over the release creation process and improves environment variable handling.

**Release process update:**

* Replaces the `softprops/action-gh-release` action with a manual `gh release create` command, allowing for custom argument handling and improved flexibility.
* Updates environment variables to use `GH_TOKEN` instead of `GITHUB_TOKEN`, and passes release notes and prerelease status explicitly.
* Writes release notes to a temporary file and uses the `--notes-file` flag for better formatting and reliability.
* Adds logic to include the `--prerelease` flag only when needed, making the workflow more robust for both stable and prerelease versions.