### PR TITLE
chore: update version to 1.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "godot-launcher",
-    "version": "1.10.0-beta.2",
+    "version": "1.10.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "godot-launcher",
-            "version": "1.10.0-beta.2",
+            "version": "1.10.0",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "godot-launcher",
     "private": true,
-    "version": "1.10.0-beta.2",
+    "version": "1.10.0",
     "packageManager": "npm@11.16.0",
     "description": "Godot Launcher is the companion app for managing Godot projects with per-project editor settings.",
     "keywords": [


### PR DESCRIPTION
This pull request updates the version of the `godot-launcher` package from `1.10.0-beta.2` to the stable release `1.10.0` in the `package.json` file.