### PR TITLE
ci: update winget workflow for versioning and validation

### DIFF
--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -17,6 +17,8 @@ concurrency:
 env:
   MANIFEST_DIR: winget-manifests
   PACKAGE_IDENTIFIER: GodotLauncher.Launcher
+  WINGETCREATE_VERSION: 1.12.8.0
+  WINGETCREATE_SHA256: 8bd738851b524885410112678e3771b341c5c716de60fbbecb88ab0a363ed85d
 
 jobs:
   publish-winget:
@@ -30,7 +32,7 @@ jobs:
       WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_CREATE_GITHUB_TOKEN }}
     steps:
       - name: Setup .NET for WingetCreate
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
           dotnet-version: '6.0.x'
 
@@ -40,9 +42,13 @@ jobs:
           $ErrorActionPreference = 'Stop'
           $ProgressPreference = 'SilentlyContinue'
 
+          if ([string]::IsNullOrWhiteSpace($env:WINGET_CREATE_GITHUB_TOKEN)) {
+            throw 'The WINGET_CREATE_GITHUB_TOKEN repository secret is not configured.'
+          }
+
           $tag = $env:INPUT_TAG.Trim()
-          if (-not $tag.StartsWith('v')) {
-            throw "Expected a v-prefixed release tag, for example v1.10.0. Got '$tag'."
+          if ($tag -notmatch '^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$') {
+            throw "Expected a v-prefixed semantic version tag, for example v1.10.0. Got '$tag'."
           }
 
           $version = $tag.Substring(1)
@@ -76,7 +82,13 @@ jobs:
           $x64Url = Get-ReleaseAssetUrl -Name "Godot_Launcher-$version-win_x64.exe"
           $arm64Url = Get-ReleaseAssetUrl -Name "Godot_Launcher-$version-win_arm64.exe"
 
-          curl.exe -JLO https://aka.ms/wingetcreate/latest
+          $wingetCreateUrl = "https://github.com/microsoft/winget-create/releases/download/v$env:WINGETCREATE_VERSION/wingetcreate.exe"
+          Invoke-WebRequest -Uri $wingetCreateUrl -OutFile wingetcreate.exe
+
+          $wingetCreateHash = (Get-FileHash -Path wingetcreate.exe -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($wingetCreateHash -ne $env:WINGETCREATE_SHA256) {
+            throw "WingetCreate checksum mismatch. Expected '$env:WINGETCREATE_SHA256', got '$wingetCreateHash'."
+          }
 
           $manifestDir = Join-Path $PWD $env:MANIFEST_DIR
           .\wingetcreate.exe update $env:PACKAGE_IDENTIFIER `
@@ -110,6 +122,7 @@ jobs:
 
           winget install `
             --manifest $manifestDir `
+            --architecture x64 `
             --silent `
             --accept-package-agreements `
             --accept-source-agreements `
@@ -121,6 +134,7 @@ jobs:
 
           winget uninstall `
             --id $env:PACKAGE_IDENTIFIER `
+            --exact `
             --silent `
             --disable-interactivity
 
@@ -136,3 +150,11 @@ jobs:
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
           }
+
+      - name: Upload generated WinGet manifests
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: winget-manifests-${{ inputs.tag }}
+          path: ${{ env.MANIFEST_DIR }}
+          if-no-files-found: warn


### PR DESCRIPTION
This pull request improves the security and reliability of the WinGet publishing workflow by pinning tool versions, adding verification steps, and enhancing error handling. It also ensures that generated manifests are always uploaded for inspection.

**Security and Reliability Improvements:**

* The workflow now downloads a specific version of `wingetcreate.exe` and verifies its SHA256 checksum before use, instead of always downloading the latest version. This prevents unexpected changes and ensures integrity. [[1]](diffhunk://#diff-2bc11091236b20a416a2ad26734b266a0055d1306160564e925a332bb8aba7c0R20-R21) [[2]](diffhunk://#diff-2bc11091236b20a416a2ad26734b266a0055d1306160564e925a332bb8aba7c0L79-R91)
* The `actions/setup-dotnet` and `actions/upload-artifact` actions are now pinned to specific commit SHAs for improved supply chain security. [[1]](diffhunk://#diff-2bc11091236b20a416a2ad26734b266a0055d1306160564e925a332bb8aba7c0L33-R35) [[2]](diffhunk://#diff-2bc11091236b20a416a2ad26734b266a0055d1306160564e925a332bb8aba7c0R153-R160)

**Validation and Error Handling Enhancements:**

* The workflow checks that the `WINGET_CREATE_GITHUB_TOKEN` secret is set, and throws an explicit error if not.
* The release tag validation is now stricter, requiring a full semantic version (e.g., `v1.10.0`).

**WinGet Command Improvements:**

* The `winget install` and `winget uninstall` commands now explicitly specify architecture (`--architecture x64`) and exact package matching (`--exact`) for more reliable package management. [[1]](diffhunk://#diff-2bc11091236b20a416a2ad26734b266a0055d1306160564e925a332bb8aba7c0R125) [[2]](diffhunk://#diff-2bc11091236b20a416a2ad26734b266a0055d1306160564e925a332bb8aba7c0R137)

**Artifact Handling:**

* Generated WinGet manifests are now always uploaded as workflow artifacts, even if previous steps fail, to aid in debugging and traceability.