### PR TITLE
ci: update manifest path for winget validation

### DIFF
--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -100,6 +100,11 @@ jobs:
             exit $LASTEXITCODE
           }
 
+          $manifestPath = Join-Path $manifestDir "manifests\g\GodotLauncher\Launcher\$version"
+          if (-not (Test-Path -LiteralPath $manifestPath -PathType Container)) {
+            throw "WingetCreate did not generate the expected manifest directory '$manifestPath'."
+          }
+
           if (-not (Get-Command winget.exe -ErrorAction SilentlyContinue)) {
             Install-PackageProvider -Name NuGet -Force | Out-Null
             Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
@@ -108,7 +113,7 @@ jobs:
             Repair-WinGetPackageManager -AllUsers
           }
 
-          winget validate --manifest $manifestDir --disable-interactivity
+          winget validate --manifest $manifestPath --disable-interactivity
 
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
@@ -121,7 +126,7 @@ jobs:
           }
 
           winget install `
-            --manifest $manifestDir `
+            --manifest $manifestPath `
             --architecture x64 `
             --silent `
             --accept-package-agreements `
@@ -145,7 +150,7 @@ jobs:
           .\wingetcreate.exe submit `
             --prtitle "Submitting Godot Launcher $version" `
             --no-open `
-            $manifestDir
+            $manifestPath
 
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE


### PR DESCRIPTION
This pull request updates the `.github/workflows/publish-winget.yml` workflow to improve the handling and validation of the generated manifest path for the Winget package submission process. The changes ensure that operations are performed on the specific versioned manifest directory and add a check to verify its existence.

Manifest path handling and validation:

* Added a check to ensure the expected manifest directory (`$manifestPath`) exists after generation, throwing an error if not found.
* Updated all subsequent commands (`winget validate`, `winget install`, and `wingetcreate.exe submit`) to use the specific `$manifestPath` instead of the broader `$manifestDir`, ensuring operations target the correct manifest files. [[1]](diffhunk://#diff-2bc11091236b20a416a2ad26734b266a0055d1306160564e925a332bb8aba7c0L111-R116) [[2]](diffhunk://#diff-2bc11091236b20a416a2ad26734b266a0055d1306160564e925a332bb8aba7c0L124-R129) [[3]](diffhunk://#diff-2bc11091236b20a416a2ad26734b266a0055d1306160564e925a332bb8aba7c0L148-R153)