### PR TITLE
feat(json-store): add atomic JSON store module

### DIFF
--- a/main/src/json-store/atomic-json-file.adapter.test.ts
+++ b/main/src/json-store/atomic-json-file.adapter.test.ts
@@ -1,0 +1,51 @@
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { AtomicJsonFileAdapter } from './atomic-json-file.adapter.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+    await Promise.all(
+        temporaryDirectories.splice(0).map((directory) =>
+            fs.rm(directory, {
+                recursive: true,
+                force: true,
+            }),
+        ),
+    );
+});
+
+describe('AtomicJsonFileAdapter', () => {
+    it('returns undefined when the file does not exist', async () => {
+        const directory = await createTemporaryDirectory();
+        const adapter = new AtomicJsonFileAdapter();
+
+        await expect(
+            adapter.read(path.join(directory, 'missing.json')),
+        ).resolves.toBeUndefined();
+    });
+
+    it('creates parent directories and atomically replaces the file', async () => {
+        const directory = await createTemporaryDirectory();
+        const filePath = path.join(directory, 'nested', 'catalog.json');
+        const adapter = new AtomicJsonFileAdapter();
+
+        await adapter.write(filePath, '{"version":1}');
+        await adapter.write(filePath, '{"version":2}');
+
+        await expect(adapter.read(filePath)).resolves.toBe('{"version":2}');
+        await expect(fs.readdir(path.dirname(filePath))).resolves.toEqual([
+            'catalog.json',
+        ]);
+    });
+});
+
+async function createTemporaryDirectory(): Promise<string> {
+    const directory = await fs.mkdtemp(
+        path.join(os.tmpdir(), 'launcher-json-store-'),
+    );
+    temporaryDirectories.push(directory);
+    return directory;
+}

--- a/main/src/json-store/atomic-json-file.adapter.ts
+++ b/main/src/json-store/atomic-json-file.adapter.ts
@@ -1,0 +1,60 @@
+import { randomUUID } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { Injectable } from '@mariodebono/di';
+
+/** Reads JSON files and replaces them without exposing partial writes. */
+@Injectable()
+export class AtomicJsonFileAdapter {
+    /**
+     * Reads a UTF-8 file.
+     *
+     * @param {stirng} filePath The path of the file to read.
+     * @returns {string} The file contents, or `undefined` when the file does not exist.
+     */
+    async read(filePath: string): Promise<string | undefined> {
+        try {
+            return await fs.readFile(filePath, 'utf-8');
+        } catch (error) {
+            if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+                return undefined;
+            }
+
+            throw error;
+        }
+    }
+
+    /**
+     * Writes through a temporary file and then replaces the target file.
+     *
+     * @param {string} filePath - The path of the file to replace.
+     * @param {string} contents - The complete UTF-8 contents to write.
+     * @returns A promise that resolves after the target file is replaced.
+     */
+    async write(filePath: string, contents: string): Promise<void> {
+        const directory = path.dirname(filePath);
+        const temporaryPath = path.join(
+            directory,
+            `.${path.basename(filePath)}.${process.pid}.${randomUUID()}.tmp`,
+        );
+
+        await fs.mkdir(directory, { recursive: true });
+
+        let handle: Awaited<ReturnType<typeof fs.open>> | undefined;
+        try {
+            // The temporary file is in the same directory so rename stays on
+            // the same file system.
+            handle = await fs.open(temporaryPath, 'wx');
+            await handle.writeFile(contents, 'utf-8');
+            await handle.sync();
+            await handle.close();
+            handle = undefined;
+            await fs.rename(temporaryPath, filePath);
+        } catch (error) {
+            // Cleanup must not hide the original write error.
+            await handle?.close().catch(() => undefined);
+            await fs.unlink(temporaryPath).catch(() => undefined);
+            throw error;
+        }
+    }
+}

--- a/main/src/json-store/json-file.store.test.ts
+++ b/main/src/json-store/json-file.store.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import type { AtomicJsonFileAdapter } from './atomic-json-file.adapter.js';
+import { JsonFileStore } from './json-file.store.js';
+import { JsonStoreCoordinatorService } from './json-store-coordinator.service.js';
+
+interface CatalogState {
+    releases: string[];
+}
+
+class TestCatalogStore extends JsonFileStore<CatalogState> {
+    constructor(coordinator: JsonStoreCoordinatorService) {
+        super(coordinator, {
+            pathProvider: () => '/virtual/editor-catalog.json',
+            defaultValue: () => ({ releases: [] }),
+        });
+    }
+
+    async list(): Promise<string[]> {
+        return (await this.readValue()).value.releases;
+    }
+
+    async add(release: string): Promise<void> {
+        await this.updateValue((catalog) => ({
+            releases: [...catalog.releases, release],
+        }));
+    }
+}
+
+describe('JsonFileStore', () => {
+    it('lets a feature store expose only domain operations', async () => {
+        let contents: string | undefined;
+        const adapter = {
+            read: async () => contents,
+            write: async (_path: string, nextContents: string) => {
+                contents = nextContents;
+            },
+        } as AtomicJsonFileAdapter;
+        const coordinator = new JsonStoreCoordinatorService(adapter);
+        const store = new TestCatalogStore(coordinator);
+
+        await store.add('4.5.0');
+
+        await expect(store.list()).resolves.toEqual(['4.5.0']);
+        expect(JSON.parse(contents ?? '')).toEqual({ releases: ['4.5.0'] });
+    });
+});

--- a/main/src/json-store/json-file.store.ts
+++ b/main/src/json-store/json-file.store.ts
@@ -1,0 +1,76 @@
+import type {
+    JsonStoreDefinition,
+    JsonStoreSnapshot,
+    JsonStoreWriteOptions,
+    MaybePromise,
+} from './json-store.types.js';
+import type { JsonStoreCoordinatorService } from './json-store-coordinator.service.js';
+
+/** Base class for a feature-owned JSON store with domain-specific methods. */
+export abstract class JsonFileStore<T> {
+    /**
+     * Registers the store definition without reading or writing the file.
+     *
+     * @param {JsonStoreCoordinatorService} coordinator The service that coordinates file operations.
+     * @param {JsonStoreDefinition<T>} definition The rules for this store.
+     */
+    protected constructor(
+        private readonly coordinator: JsonStoreCoordinatorService,
+        private readonly definition: JsonStoreDefinition<T>,
+    ) {}
+
+    /**
+     * Reads the current value and version.
+     *
+     * @returns A safe copy of the current value and version.
+     */
+    protected readValue(): Promise<JsonStoreSnapshot<T>> {
+        return this.coordinator.read(this.definition);
+    }
+
+    /**
+     * Replaces the complete value.
+     *
+     * @param value - The complete value to write.
+     * @param options - Optional checks for the write.
+     * @returns A safe copy of the persisted value and version.
+     */
+    protected replaceValue(
+        value: T,
+        options?: JsonStoreWriteOptions,
+    ): Promise<JsonStoreSnapshot<T>> {
+        return this.coordinator.write(this.definition, value, options);
+    }
+
+    /**
+     * Updates the value in the shared per-path queue.
+     *
+     * @param mutator - A function that returns the next value.
+     * @param options - Optional checks for the write.
+     * @returns A safe copy of the persisted value and version.
+     */
+    protected updateValue(
+        mutator: (current: T) => MaybePromise<T>,
+        options?: JsonStoreWriteOptions,
+    ): Promise<JsonStoreSnapshot<T>> {
+        return this.coordinator.update(this.definition, mutator, options);
+    }
+
+    /**
+     * Clears the cache and reads the file again.
+     *
+     * @returns A safe copy of the refreshed value and version.
+     */
+    protected refreshValue(): Promise<JsonStoreSnapshot<T>> {
+        return this.coordinator.refresh(this.definition);
+    }
+
+    /**
+     * Clears the cache without reading the file again.
+     *
+     * @returns A promise that resolves after the cache is cleared.
+     */
+    protected clearCachedValue(): Promise<void> {
+        return this.coordinator.clearCache(this.definition);
+    }
+}

--- a/main/src/json-store/json-store-coordinator.service.test.ts
+++ b/main/src/json-store/json-store-coordinator.service.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { AtomicJsonFileAdapter } from './atomic-json-file.adapter.js';
+import {
+    JsonStoreConflictError,
+    type JsonStoreDefinition,
+} from './json-store.types.js';
+import { JsonStoreCoordinatorService } from './json-store-coordinator.service.js';
+
+interface TestState {
+    values: string[];
+}
+
+const storePath = '/virtual/catalog.json';
+
+function createDefinition(): JsonStoreDefinition<TestState> {
+    return {
+        pathProvider: () => storePath,
+        defaultValue: () => ({ values: [] }),
+        normalize: (value) => ({
+            values: [...new Set(value.values)].sort(),
+        }),
+    };
+}
+
+function createFileAdapter(initial?: string): AtomicJsonFileAdapter & {
+    contents: string | undefined;
+} {
+    const adapter = {
+        contents: initial,
+        read: vi.fn(async () => adapter.contents),
+        write: vi.fn(async (_path: string, contents: string) => {
+            adapter.contents = contents;
+        }),
+    };
+
+    return adapter as unknown as AtomicJsonFileAdapter & {
+        contents: string | undefined;
+    };
+}
+
+describe('JsonStoreCoordinatorService', () => {
+    it('loads defaults without creating a file and returns defensive copies', async () => {
+        const adapter = createFileAdapter();
+        const coordinator = new JsonStoreCoordinatorService(adapter);
+        const definition = createDefinition();
+
+        const first = await coordinator.read(definition);
+        first.value.values.push('changed-outside-store');
+        const second = await coordinator.read(definition);
+
+        expect(second.value).toEqual({ values: [] });
+        expect(adapter.write).not.toHaveBeenCalled();
+    });
+
+    it('persists a default value when it is explicitly written', async () => {
+        const adapter = createFileAdapter();
+        const coordinator = new JsonStoreCoordinatorService(adapter);
+        const definition = createDefinition();
+        const current = await coordinator.read(definition);
+
+        await coordinator.write(definition, current.value);
+
+        expect(adapter.write).toHaveBeenCalledOnce();
+        expect(JSON.parse(adapter.contents ?? '')).toEqual({ values: [] });
+    });
+
+    it('serializes concurrent updates for the same path', async () => {
+        const adapter = createFileAdapter();
+        const coordinator = new JsonStoreCoordinatorService(adapter);
+        const definition = createDefinition();
+
+        await Promise.all([
+            coordinator.update(definition, async (current) => {
+                await Promise.resolve();
+                current.values.push('first');
+                return current;
+            }),
+            coordinator.update(definition, (current) => {
+                current.values.push('second');
+                return current;
+            }),
+        ]);
+
+        await expect(coordinator.read(definition)).resolves.toMatchObject({
+            value: { values: ['first', 'second'] },
+        });
+        expect(adapter.write).toHaveBeenCalledTimes(2);
+    });
+
+    it('rejects stale writes without touching the file', async () => {
+        const adapter = createFileAdapter('{"values":[]}');
+        const coordinator = new JsonStoreCoordinatorService(adapter);
+        const definition = createDefinition();
+
+        await coordinator.read(definition);
+
+        await expect(
+            coordinator.write(
+                definition,
+                { values: ['new'] },
+                { expectedVersion: 'stale-version' },
+            ),
+        ).rejects.toBeInstanceOf(JsonStoreConflictError);
+        expect(adapter.write).not.toHaveBeenCalled();
+    });
+
+    it('surfaces invalid JSON instead of silently replacing it', async () => {
+        const adapter = createFileAdapter('{not-json');
+        const coordinator = new JsonStoreCoordinatorService(adapter);
+
+        await expect(coordinator.read(createDefinition())).rejects.toThrow();
+        expect(adapter.write).not.toHaveBeenCalled();
+    });
+
+    it('keeps the last persisted value cached when a write fails', async () => {
+        const adapter = createFileAdapter('{"values":["persisted"]}');
+        const coordinator = new JsonStoreCoordinatorService(adapter);
+        const definition = createDefinition();
+        await coordinator.read(definition);
+        vi.spyOn(adapter, 'write').mockRejectedValueOnce(
+            new Error('disk unavailable'),
+        );
+
+        await expect(
+            coordinator.write(definition, { values: ['not-persisted'] }),
+        ).rejects.toThrow('disk unavailable');
+
+        await expect(coordinator.read(definition)).resolves.toMatchObject({
+            value: { values: ['persisted'] },
+        });
+    });
+
+    it('refreshes the cache from disk', async () => {
+        const adapter = createFileAdapter('{"values":["first"]}');
+        const coordinator = new JsonStoreCoordinatorService(adapter);
+        const definition = createDefinition();
+
+        await coordinator.read(definition);
+        adapter.contents = '{"values":["second"]}';
+
+        await expect(coordinator.refresh(definition)).resolves.toMatchObject({
+            value: { values: ['second'] },
+        });
+    });
+});

--- a/main/src/json-store/json-store-coordinator.service.ts
+++ b/main/src/json-store/json-store-coordinator.service.ts
@@ -1,0 +1,337 @@
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+import { Injectable } from '@mariodebono/di';
+// biome-ignore lint/style/useImportType: Required for DI constructor metadata
+import { AtomicJsonFileAdapter } from './atomic-json-file.adapter.js';
+import type {
+    JsonStoreDefinition,
+    JsonStoreSnapshot,
+    JsonStoreWriteOptions,
+    MaybePromise,
+} from './json-store.types.js';
+import { JsonStoreConflictError } from './json-store.types.js';
+
+interface CachedEntry {
+    value: unknown;
+    version: string;
+    // A default or normalized value may not match the file on disk yet.
+    needsPersistence: boolean;
+}
+
+/** Coordinates cached JSON file access inside one application process. */
+@Injectable()
+export class JsonStoreCoordinatorService {
+    private readonly cache = new Map<string, CachedEntry>();
+    private readonly operationQueues = new Map<string, Promise<void>>();
+
+    /**
+     * Creates the coordinator.
+     *
+     * @param fileAdapter - The adapter used for file reads and atomic writes.
+     */
+    constructor(private readonly fileAdapter: AtomicJsonFileAdapter) {}
+
+    /**
+     * Reads a store after any queued write for the same path finishes.
+     *
+     * @param definition - The rules for the store.
+     * @returns A safe copy of the current value and version.
+     */
+    async read<T>(
+        definition: JsonStoreDefinition<T>,
+    ): Promise<JsonStoreSnapshot<T>> {
+        const filePath = await this.resolvePath(definition);
+        await this.waitForPendingOperation(filePath);
+        return this.load(filePath, definition);
+    }
+
+    /**
+     * Replaces a store value.
+     *
+     * @param definition - The rules for the store.
+     * @param value - The complete value to write.
+     * @param options - Optional checks for the write.
+     * @returns A safe copy of the persisted value and version.
+     */
+    async write<T>(
+        definition: JsonStoreDefinition<T>,
+        value: T,
+        options?: JsonStoreWriteOptions,
+    ): Promise<JsonStoreSnapshot<T>> {
+        const filePath = await this.resolvePath(definition);
+        return this.enqueue(filePath, () =>
+            this.persist(filePath, definition, value, options),
+        );
+    }
+
+    /**
+     * Updates a store value inside its per-path operation queue.
+     *
+     * @param definition - The rules for the store.
+     * @param mutator - A function that returns the next value.
+     * @param options - Optional checks for the write.
+     * @returns A safe copy of the persisted value and version.
+     */
+    async update<T>(
+        definition: JsonStoreDefinition<T>,
+        mutator: (current: T) => MaybePromise<T>,
+        options?: JsonStoreWriteOptions,
+    ): Promise<JsonStoreSnapshot<T>> {
+        const filePath = await this.resolvePath(definition);
+        return this.enqueue(filePath, async () => {
+            const current = await this.load(filePath, definition);
+            const nextValue = await mutator(cloneJson(current.value));
+
+            return this.persist(filePath, definition, nextValue, {
+                expectedVersion: current.version,
+                ...options,
+            });
+        });
+    }
+
+    /**
+     * Drops the cached value and reads the file again.
+     *
+     * @param definition - The rules for the store.
+     * @returns A safe copy of the refreshed value and version.
+     */
+    async refresh<T>(
+        definition: JsonStoreDefinition<T>,
+    ): Promise<JsonStoreSnapshot<T>> {
+        const filePath = await this.resolvePath(definition);
+        await this.waitForPendingOperation(filePath);
+        this.cache.delete(filePath);
+        return this.load(filePath, definition);
+    }
+
+    /**
+     * Drops the cached value without reading the file again.
+     *
+     * @param definition - The rules for the store.
+     * @returns A promise that resolves after the cache is cleared.
+     */
+    async clearCache<T>(definition: JsonStoreDefinition<T>): Promise<void> {
+        const filePath = await this.resolvePath(definition);
+        await this.waitForPendingOperation(filePath);
+        this.cache.delete(filePath);
+    }
+
+    /**
+     * Resolves and checks a store path.
+     *
+     * @param definition - The rules that provide the store path.
+     * @returns The absolute store path.
+     */
+    private async resolvePath<T>(
+        definition: JsonStoreDefinition<T>,
+    ): Promise<string> {
+        const filePath = await definition.pathProvider();
+        if (!filePath.trim()) {
+            throw new Error('JSON store pathProvider returned an empty path');
+        }
+
+        return path.resolve(filePath);
+    }
+
+    /**
+     * Loads a value from the cache or file.
+     *
+     * @param filePath - The resolved store path.
+     * @param definition - The rules used to parse and normalize the value.
+     * @returns A safe copy of the loaded value and version.
+     */
+    private async load<T>(
+        filePath: string,
+        definition: JsonStoreDefinition<T>,
+    ): Promise<JsonStoreSnapshot<T>> {
+        const cached = this.cache.get(filePath);
+        if (cached) {
+            return snapshot<T>(cached);
+        }
+
+        const raw = await this.fileAdapter.read(filePath);
+        const parsed =
+            raw === undefined
+                ? await definition.defaultValue()
+                : await (definition.parse ?? defaultParse<T>)(raw);
+        const normalized = await this.normalize(definition, parsed);
+        const entry = createEntry(
+            normalized,
+            raw === undefined || versionOf(parsed) !== versionOf(normalized),
+        );
+        this.cache.set(filePath, entry);
+        return snapshot<T>(entry);
+    }
+
+    /**
+     * Normalizes and writes a complete value.
+     *
+     * @param filePath - The resolved store path.
+     * @param definition - The rules used to normalize and serialize the value.
+     * @param value - The complete value to write.
+     * @param options - Optional checks for the write.
+     * @returns A safe copy of the persisted value and version.
+     */
+    private async persist<T>(
+        filePath: string,
+        definition: JsonStoreDefinition<T>,
+        value: T,
+        options?: JsonStoreWriteOptions,
+    ): Promise<JsonStoreSnapshot<T>> {
+        const normalized = await this.normalize(definition, value);
+        const nextEntry = createEntry(normalized, false);
+        const current = this.cache.get(filePath);
+
+        if (
+            options?.expectedVersion !== undefined &&
+            current?.version !== options.expectedVersion
+        ) {
+            throw new JsonStoreConflictError(filePath);
+        }
+
+        if (
+            current?.version === nextEntry.version &&
+            !current.needsPersistence
+        ) {
+            return snapshot<T>(current);
+        }
+
+        const serialize = definition.serialize ?? defaultSerialize<T>;
+        const contents = await serialize(cloneJson(normalized));
+        await this.fileAdapter.write(filePath, contents);
+        // Only publish the new cache entry after the file replacement succeeds.
+        this.cache.set(filePath, nextEntry);
+        return snapshot<T>(nextEntry);
+    }
+
+    /**
+     * Clones and normalizes a value.
+     *
+     * @param definition - The rules that may normalize the value.
+     * @param value - The value to normalize.
+     * @returns A safe copy of the normalized value.
+     */
+    private async normalize<T>(
+        definition: JsonStoreDefinition<T>,
+        value: T,
+    ): Promise<T> {
+        const candidate = cloneJson(value);
+        const normalized = definition.normalize
+            ? await definition.normalize(candidate)
+            : candidate;
+        return cloneJson(normalized);
+    }
+
+    /**
+     * Waits for the current operation on one path.
+     *
+     * @param filePath - The resolved store path.
+     * @returns A promise that resolves when the current operation ends.
+     */
+    private async waitForPendingOperation(filePath: string): Promise<void> {
+        await this.operationQueues.get(filePath);
+    }
+
+    /**
+     * Adds an operation to the queue for one path.
+     *
+     * @param filePath - The resolved store path.
+     * @param operation - The operation to run after earlier work finishes.
+     * @returns The result of the queued operation.
+     */
+    private enqueue<T>(
+        filePath: string,
+        operation: () => Promise<T>,
+    ): Promise<T> {
+        const previous =
+            this.operationQueues.get(filePath) ?? Promise.resolve();
+        // A failed operation must not prevent the next queued operation.
+        const result = previous.catch(() => undefined).then(operation);
+        const queued = result
+            .then(() => undefined)
+            .catch(() => undefined)
+            .finally(() => {
+                if (this.operationQueues.get(filePath) === queued) {
+                    this.operationQueues.delete(filePath);
+                }
+            });
+
+        this.operationQueues.set(filePath, queued);
+        return result;
+    }
+}
+
+/**
+ * Parses standard JSON text.
+ *
+ * @param raw - The JSON text to parse.
+ * @returns The parsed value.
+ */
+function defaultParse<T>(raw: string): T {
+    return JSON.parse(raw) as T;
+}
+
+/**
+ * Formats a value as standard JSON text.
+ *
+ * @param value - The value to format.
+ * @returns Formatted JSON text.
+ */
+function defaultSerialize<T>(value: T): string {
+    return JSON.stringify(value, null, 4);
+}
+
+/**
+ * Creates a JSON-safe copy of a value.
+ *
+ * @param value - The value to copy.
+ * @returns A copy that does not share nested objects with the input.
+ */
+function cloneJson<T>(value: T): T {
+    if (value === undefined || value === null) {
+        return value;
+    }
+
+    return JSON.parse(JSON.stringify(value)) as T;
+}
+
+/**
+ * Creates a stable version for one JSON value.
+ *
+ * @param value - The value to hash.
+ * @returns A SHA-256 version string.
+ */
+function versionOf<T>(value: T): string {
+    return createHash('sha256')
+        .update(JSON.stringify(cloneJson(value)))
+        .digest('hex');
+}
+
+/**
+ * Creates an internal cache entry.
+ *
+ * @param value - The value to cache.
+ * @param needsPersistence - Whether the value still needs to be written.
+ * @returns The new cache entry.
+ */
+function createEntry<T>(value: T, needsPersistence: boolean): CachedEntry {
+    const cachedValue = cloneJson(value);
+    return {
+        value: cachedValue,
+        version: versionOf(cachedValue),
+        needsPersistence,
+    };
+}
+
+/**
+ * Creates a safe public snapshot from a cache entry.
+ *
+ * @param entry - The internal cache entry.
+ * @returns A safe copy of the value and version.
+ */
+function snapshot<T>(entry: CachedEntry): JsonStoreSnapshot<T> {
+    return {
+        value: cloneJson(entry.value as T),
+        version: entry.version,
+    };
+}

--- a/main/src/json-store/json-store.module.test.ts
+++ b/main/src/json-store/json-store.module.test.ts
@@ -1,0 +1,30 @@
+import 'reflect-metadata';
+import { createApplication, Injectable, Module } from '@mariodebono/di';
+import { describe, expect, it } from 'vitest';
+import { JsonStoreModule } from './json-store.module.js';
+import { JsonStoreCoordinatorService } from './json-store-coordinator.service.js';
+
+describe('JsonStoreModule', () => {
+    it('exports its coordinator to an importing feature module', async () => {
+        @Injectable()
+        class TestCatalogStore {
+            constructor(readonly coordinator: JsonStoreCoordinatorService) {}
+        }
+
+        @Module({
+            imports: [JsonStoreModule],
+            providers: [TestCatalogStore],
+        })
+        class TestCatalogModule {}
+
+        const application = await createApplication(TestCatalogModule, {
+            logger: false,
+        });
+
+        expect(application.get(TestCatalogStore).coordinator).toBeInstanceOf(
+            JsonStoreCoordinatorService,
+        );
+
+        await application.destroyAsync();
+    });
+});

--- a/main/src/json-store/json-store.module.ts
+++ b/main/src/json-store/json-store.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@mariodebono/di';
+import { AtomicJsonFileAdapter } from './atomic-json-file.adapter.js';
+import { JsonStoreCoordinatorService } from './json-store-coordinator.service.js';
+
+/** Provides JSON file coordination to feature modules that import it. */
+@Module({
+    providers: [AtomicJsonFileAdapter, JsonStoreCoordinatorService],
+    exports: [JsonStoreCoordinatorService],
+})
+export class JsonStoreModule {}

--- a/main/src/json-store/json-store.types.ts
+++ b/main/src/json-store/json-store.types.ts
@@ -1,0 +1,40 @@
+export type MaybePromise<T> = T | Promise<T>;
+
+/** Describes how one JSON file is loaded, saved, and normalized. */
+export interface JsonStoreDefinition<T> {
+    /** Returns the file path. The path is resolved before it is used. */
+    pathProvider: () => MaybePromise<string>;
+    /** Returns a new value when the file does not exist. */
+    defaultValue: () => MaybePromise<T>;
+    /** Parses the file contents. The default uses `JSON.parse`. */
+    parse?: (raw: string) => MaybePromise<T>;
+    /** Converts a value to file contents. The default writes formatted JSON. */
+    serialize?: (value: T) => MaybePromise<string>;
+    /** Cleans or validates a value before it enters the cache. */
+    normalize?: (value: T) => MaybePromise<T>;
+}
+
+/** A safe copy of the stored value and its optimistic version. */
+export interface JsonStoreSnapshot<T> {
+    value: T;
+    version: string;
+}
+
+/** Controls an individual write operation. */
+export interface JsonStoreWriteOptions {
+    /** Rejects the write when the cached version is different. */
+    expectedVersion?: string;
+}
+
+/** Raised when a caller tries to write from an old snapshot. */
+export class JsonStoreConflictError extends Error {
+    /**
+     * Creates a conflict error for one store.
+     *
+     * @param path - The path of the store that changed.
+     */
+    constructor(path: string) {
+        super(`JSON store at ${path} changed while writing`);
+        this.name = 'JsonStoreConflictError';
+    }
+}


### PR DESCRIPTION
Adds a reusable JSON store module for main-process features.

- Writes JSON files safely
- Queues operations for each file
- Supports caching, updates, refresh, and version checks
- Provides a base class for feature stores

Existing stores are unchanged. The editor catalog will be the first consumer.