### PR TITLE
feat(editor-catalog): add editor catalog module

### DIFF
--- a/main/src/app.module.ts
+++ b/main/src/app.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@mariodebono/di';
-import { ConfigModule } from '@mariodebono/di-config';
+import { ConfigModule, ConfigService } from '@mariodebono/di-config';
 import {
     I18nModule,
     type I18nModuleOptions,
@@ -13,6 +13,8 @@ import {
     AppConfigSchema,
     getCurrentAppConfig,
 } from './config/index.js';
+import { EDITOR_CATALOG_FILENAME } from './constants.js';
+import { EditorCatalogModule } from './editor-catalog/editor-catalog.module.js';
 import {
     DEFAULT_LOCALE,
     I18N_NAMESPACES,
@@ -32,6 +34,13 @@ import { TrayAvailabilityService } from './services/tray-availability.service.js
         }),
         AppMigrationsModule,
         CodeEditorIntegrationModule,
+        EditorCatalogModule.forRootAsync({
+            inject: [ConfigService],
+            useFactory: (configService: ConfigService<AppConfig>) => ({
+                directory: configService.getOrThrow('paths.configDir'),
+                fileName: EDITOR_CATALOG_FILENAME,
+            }),
+        }),
         I18nModule.forRootAsync({
             useFactory: () =>
                 ({

--- a/main/src/constants.ts
+++ b/main/src/constants.ts
@@ -12,6 +12,7 @@ export const RELEASES_FILENAME = 'releases.json';
 export const INSTALLED_RELEASES_FILENAME = 'installed-releases.json';
 export const PRERELEASES_FILENAME = 'prereleases.json';
 export const MIGRATIONS_FILENAME = 'migrations.json';
+export const EDITOR_CATALOG_FILENAME = 'editor-catalog.json';
 export const EDITOR_CONFIG_DIRNAME = '.editor_config';
 export const PROJECT_LAUNCHER_CONFIG_FILENAME = '.godotlauncher';
 

--- a/main/src/editor-catalog/editor-catalog.constants.ts
+++ b/main/src/editor-catalog/editor-catalog.constants.ts
@@ -1,0 +1,49 @@
+import type { EditorCatalogProviderId } from '@shared/contracts';
+
+/** Token used to inject the catalog module options. */
+export const EDITOR_CATALOG_MODULE_OPTIONS = Symbol(
+    'EDITOR_CATALOG_MODULE_OPTIONS',
+);
+/** Current version of the stored catalog format. */
+export const EDITOR_CATALOG_SCHEMA_VERSION = 1 as const;
+/** Time before cached catalog data becomes stale. */
+export const EDITOR_CATALOG_CACHE_TTL_MS = 1000 * 60 * 10;
+/** Oldest supported Godot editor major version. */
+export const EDITOR_CATALOG_MIN_VERSION = 4;
+/** Number of GitHub releases requested on each page. */
+export const EDITOR_CATALOG_PAGE_SIZE = 100;
+/** Highest number of GitHub pages fetched in one refresh. */
+export const EDITOR_CATALOG_PAGE_LIMIT = 100;
+
+/** Provider IDs supported by the catalog. */
+export const EDITOR_CATALOG_PROVIDER_IDS = [
+    'official-stable',
+    'official-prerelease',
+] as const satisfies readonly EditorCatalogProviderId[];
+
+/** Describes one GitHub source used by the catalog. */
+export type EditorCatalogProviderDefinition = {
+    id: EditorCatalogProviderId;
+    owner: string;
+    repository: string;
+    prerelease: boolean;
+};
+
+/** GitHub settings for each catalog provider. */
+export const EDITOR_CATALOG_PROVIDERS: Record<
+    EditorCatalogProviderId,
+    EditorCatalogProviderDefinition
+> = {
+    'official-stable': {
+        id: 'official-stable',
+        owner: 'godotengine',
+        repository: 'godot',
+        prerelease: false,
+    },
+    'official-prerelease': {
+        id: 'official-prerelease',
+        owner: 'godotengine',
+        repository: 'godot-builds',
+        prerelease: true,
+    },
+};

--- a/main/src/editor-catalog/editor-catalog.controller.test.ts
+++ b/main/src/editor-catalog/editor-catalog.controller.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@mariodebono/di-electron', () => ({
+    BridgeController: () => () => undefined,
+    createIpcHandleTyped: () => () => () => undefined,
+}));
+
+import { EditorCatalogController } from './editor-catalog.controller.js';
+import type { EditorCatalogService } from './editor-catalog.service.js';
+
+describe('EditorCatalogController', () => {
+    it('delegates its bridge methods to the catalog service', async () => {
+        const result = { releases: [], providers: [] };
+        const service = {
+            getCatalog: vi.fn(async () => result),
+            getReleaseById: vi.fn(async () => null),
+            refreshCatalog: vi.fn(async () => result),
+        } as unknown as EditorCatalogService;
+        const controller = new EditorCatalogController(service);
+
+        await controller.getCatalog({ refreshIfStale: false });
+        await controller.getReleaseById('official-stable:4.5-stable');
+        await controller.refreshCatalog({ prerelease: false });
+
+        expect(service.getCatalog).toHaveBeenCalledWith({
+            refreshIfStale: false,
+        });
+        expect(service.getReleaseById).toHaveBeenCalledWith(
+            'official-stable:4.5-stable',
+        );
+        expect(service.refreshCatalog).toHaveBeenCalledWith({
+            prerelease: false,
+        });
+    });
+});

--- a/main/src/editor-catalog/editor-catalog.controller.ts
+++ b/main/src/editor-catalog/editor-catalog.controller.ts
@@ -1,0 +1,61 @@
+import {
+    BridgeController,
+    createIpcHandleTyped,
+} from '@mariodebono/di-electron';
+import type {
+    EditorCatalogBridge,
+    EditorCatalogQuery,
+    EditorCatalogRelease,
+    EditorCatalogResult,
+    GetEditorCatalogOptions,
+} from '@shared/contracts';
+// biome-ignore lint/style/useImportType: Required for DI constructor metadata
+import { EditorCatalogService } from './editor-catalog.service.js';
+
+const EditorCatalogHandler = createIpcHandleTyped<EditorCatalogBridge>();
+
+/** Handles catalog requests from the renderer. */
+@BridgeController({ namespace: 'editorCatalog' })
+export class EditorCatalogController implements EditorCatalogBridge {
+    /**
+     * Creates the catalog controller.
+     *
+     * @param service - The service that handles catalog work.
+     */
+    constructor(private readonly service: EditorCatalogService) {}
+
+    /**
+     * Gets catalog releases for the renderer.
+     *
+     * @param options - Optional refresh and filter settings.
+     * @returns The matching releases and provider status.
+     */
+    @EditorCatalogHandler('getCatalog')
+    getCatalog(
+        options?: GetEditorCatalogOptions,
+    ): Promise<EditorCatalogResult> {
+        return this.service.getCatalog(options);
+    }
+
+    /**
+     * Finds one catalog release by its ID.
+     *
+     * @param id - The exact release ID to find.
+     * @returns The release, or null when it does not exist.
+     */
+    @EditorCatalogHandler('getReleaseById')
+    getReleaseById(id: string): Promise<EditorCatalogRelease | null> {
+        return this.service.getReleaseById(id);
+    }
+
+    /**
+     * Refreshes the catalog and returns matching releases.
+     *
+     * @param query - Optional filters for the returned releases.
+     * @returns The refreshed releases and provider status.
+     */
+    @EditorCatalogHandler('refreshCatalog')
+    refreshCatalog(query?: EditorCatalogQuery): Promise<EditorCatalogResult> {
+        return this.service.refreshCatalog(query);
+    }
+}

--- a/main/src/editor-catalog/editor-catalog.module.test.ts
+++ b/main/src/editor-catalog/editor-catalog.module.test.ts
@@ -1,0 +1,100 @@
+import 'reflect-metadata';
+import { createApplication, Module } from '@mariodebono/di';
+import { ConfigModule, ConfigService } from '@mariodebono/di-config';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@mariodebono/di-electron', () => ({
+    BridgeController: () => () => undefined,
+    createIpcHandleTyped: () => () => () => undefined,
+}));
+
+import type { AppConfig } from '../config/index.js';
+import { EDITOR_CATALOG_MODULE_OPTIONS } from './editor-catalog.constants.js';
+import { EditorCatalogModule } from './editor-catalog.module.js';
+import { EditorCatalogService } from './editor-catalog.service.js';
+import type { EditorCatalogModuleOptions } from './editor-catalog.types.js';
+
+describe('EditorCatalogModule', () => {
+    it('registers async options and exports its service', async () => {
+        @Module({
+            imports: [
+                ConfigModule.forRoot<AppConfig>({
+                    cache: true,
+                    isGlobal: true,
+                    loadProcessEnv: false,
+                    load: [createConfig],
+                }),
+                EditorCatalogModule.forRootAsync({
+                    inject: [ConfigService],
+                    useFactory: (configService: ConfigService<AppConfig>) => ({
+                        directory: configService.getOrThrow('paths.configDir'),
+                        fileName: 'editor-catalog.json',
+                    }),
+                }),
+            ],
+        })
+        class TestAppModule {}
+
+        const application = await createApplication(TestAppModule, {
+            logger: false,
+        });
+
+        expect(application.get(EditorCatalogService)).toBeInstanceOf(
+            EditorCatalogService,
+        );
+        expect(
+            application.get<EditorCatalogModuleOptions>(
+                EDITOR_CATALOG_MODULE_OPTIONS,
+            ),
+        ).toEqual({
+            directory: '/config',
+            fileName: 'editor-catalog.json',
+        });
+        await application.destroyAsync();
+    });
+
+    it('rejects an empty directory', () => {
+        expect(() =>
+            EditorCatalogModule.forRoot({
+                directory: '  ',
+                fileName: 'editor-catalog.json',
+            }),
+        ).toThrow('Editor catalog directory must not be empty');
+    });
+
+    it('rejects an empty file name', () => {
+        expect(() =>
+            EditorCatalogModule.forRoot({
+                directory: '/config',
+                fileName: '  ',
+            }),
+        ).toThrow('Editor catalog file name must not be empty');
+    });
+});
+
+/**
+ * Creates app config for the module test.
+ *
+ * @returns App config with fixed test paths.
+ */
+function createConfig(): AppConfig {
+    return {
+        appName: 'Godot Launcher',
+        isDev: true,
+        debugMode: false,
+        disableSandbox: false,
+        disableDevMenu: false,
+        startHidden: false,
+        docsScreenshots: false,
+        paths: {
+            dataDir: '/data',
+            configDir: '/config',
+            projectDir: '/projects',
+            prefsPath: '/config/prefs.json',
+            releaseCachePath: '/config/releases.json',
+            prereleaseCachePath: '/config/prereleases.json',
+            installedReleasesCachePath: '/config/installed-releases.json',
+            migrationStatePath: '/config/migrations.json',
+        },
+    };
+}

--- a/main/src/editor-catalog/editor-catalog.module.ts
+++ b/main/src/editor-catalog/editor-catalog.module.ts
@@ -1,0 +1,103 @@
+import {
+    type DynamicModule,
+    type FactoryProvider,
+    Module,
+} from '@mariodebono/di';
+import { JsonStoreModule } from '../json-store/json-store.module.js';
+import { JsonStoreCoordinatorService } from '../json-store/json-store-coordinator.service.js';
+import { EDITOR_CATALOG_MODULE_OPTIONS } from './editor-catalog.constants.js';
+import { EditorCatalogController } from './editor-catalog.controller.js';
+import { EditorCatalogService } from './editor-catalog.service.js';
+import { EditorCatalogStore } from './editor-catalog.store.js';
+import type { EditorCatalogModuleOptions } from './editor-catalog.types.js';
+import { GithubEditorCatalogAdapter } from './github-editor-catalog.adapter.js';
+
+/** Options used to create catalog module settings through DI. */
+type EditorCatalogModuleAsyncOptions = Pick<
+    FactoryProvider<EditorCatalogModuleOptions>,
+    'inject' | 'useFactory'
+>;
+
+@Module({
+    imports: [JsonStoreModule],
+    providers: [
+        GithubEditorCatalogAdapter,
+        // Build the store here so DI can pass the module options to it.
+        {
+            provide: EditorCatalogStore,
+            inject: [
+                JsonStoreCoordinatorService,
+                EDITOR_CATALOG_MODULE_OPTIONS,
+            ],
+            useFactory: (
+                coordinator: JsonStoreCoordinatorService,
+                options: EditorCatalogModuleOptions,
+            ) => new EditorCatalogStore(coordinator, options),
+        },
+        EditorCatalogService,
+        EditorCatalogController,
+    ],
+    exports: [EditorCatalogService],
+})
+// biome-ignore lint/complexity/noStaticOnlyClass: DI modules use static setup methods
+/** Registers the services used by the editor catalog. */
+export class EditorCatalogModule {
+    /**
+     * Registers the catalog module with fixed storage options.
+     *
+     * @param options - The directory and file name used by the catalog store.
+     * @returns The configured catalog module.
+     */
+    static forRoot(options: EditorCatalogModuleOptions): DynamicModule {
+        return {
+            module: EditorCatalogModule,
+            providers: [
+                {
+                    provide: EDITOR_CATALOG_MODULE_OPTIONS,
+                    useValue: validateOptions(options),
+                },
+            ],
+        };
+    }
+
+    /**
+     * Registers the catalog module with options created by DI.
+     *
+     * @param options - The dependencies and factory used to create the options.
+     * @returns The configured catalog module.
+     */
+    static forRootAsync(
+        options: EditorCatalogModuleAsyncOptions,
+    ): DynamicModule {
+        return {
+            module: EditorCatalogModule,
+            providers: [
+                {
+                    provide: EDITOR_CATALOG_MODULE_OPTIONS,
+                    inject: options.inject,
+                    useFactory: async (...args: unknown[]) =>
+                        validateOptions(await options.useFactory(...args)),
+                },
+            ],
+        };
+    }
+}
+
+/**
+ * Checks that the catalog storage options contain usable values.
+ *
+ * @param options - The options to check.
+ * @returns A copy of the checked options.
+ */
+function validateOptions(
+    options: EditorCatalogModuleOptions,
+): EditorCatalogModuleOptions {
+    if (!options.directory.trim()) {
+        throw new Error('Editor catalog directory must not be empty');
+    }
+    if (!options.fileName.trim()) {
+        throw new Error('Editor catalog file name must not be empty');
+    }
+
+    return { ...options };
+}

--- a/main/src/editor-catalog/editor-catalog.schema.test.ts
+++ b/main/src/editor-catalog/editor-catalog.schema.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import {
+    createEmptyEditorCatalog,
+    normalizeEditorCatalog,
+} from './editor-catalog.schema.js';
+
+describe('editor catalog schema', () => {
+    it('creates both official provider states', () => {
+        expect(createEmptyEditorCatalog()).toEqual({
+            schemaVersion: 1,
+            providers: {
+                'official-stable': {
+                    lastFetchedAt: null,
+                    lastPublishedAt: null,
+                    releases: [],
+                },
+                'official-prerelease': {
+                    lastFetchedAt: null,
+                    lastPublishedAt: null,
+                    releases: [],
+                },
+            },
+        });
+    });
+
+    it('rejects an unsupported schema version', () => {
+        expect(() =>
+            normalizeEditorCatalog({
+                ...createEmptyEditorCatalog(),
+                schemaVersion: 2,
+            }),
+        ).toThrow();
+    });
+});

--- a/main/src/editor-catalog/editor-catalog.schema.ts
+++ b/main/src/editor-catalog/editor-catalog.schema.ts
@@ -1,0 +1,202 @@
+import { z } from 'zod';
+import {
+    EDITOR_CATALOG_PROVIDER_IDS,
+    EDITOR_CATALOG_SCHEMA_VERSION,
+} from './editor-catalog.constants.js';
+import type {
+    EditorCatalogFile,
+    EditorCatalogProviderState,
+} from './editor-catalog.types.js';
+
+const EditorCatalogProviderIdSchema = z.enum(EDITOR_CATALOG_PROVIDER_IDS);
+const EditorCatalogFlavorSchema = z.enum(['gdscript', 'dotnet']);
+const EditorCatalogPlatformSchema = z.enum(['win32', 'darwin', 'linux']);
+const EditorCatalogArchitectureSchema = z.enum(['x64', 'arm64', 'ia32', 'arm']);
+
+const EditorCatalogAssetSchema = z.object({
+    id: z.string().min(1),
+    name: z.string().min(1),
+    downloadUrl: z.url(),
+    platform: EditorCatalogPlatformSchema,
+    architecture: EditorCatalogArchitectureSchema,
+});
+
+const EditorCatalogVariantSchema = z.object({
+    id: z.string().min(1),
+    flavor: EditorCatalogFlavorSchema,
+    assets: z.array(EditorCatalogAssetSchema).min(1),
+});
+
+/** Checks the stored shape of one catalog release. */
+export const EditorCatalogReleaseSchema = z.object({
+    id: z.string().min(1),
+    sourceReleaseId: z.string().min(1),
+    providerId: EditorCatalogProviderIdSchema,
+    tag: z.string().min(1),
+    version: z.string().min(1),
+    baseVersion: z.string().min(1),
+    name: z.string().min(1),
+    publishedAt: z.iso.datetime().nullable(),
+    prerelease: z.boolean(),
+    versionParts: z.object({
+        major: z.number().int().nonnegative(),
+        minor: z.number().int().nonnegative(),
+        patch: z.number().int().nonnegative(),
+        channel: z.string().min(1),
+        iteration: z.number().int().nonnegative(),
+    }),
+    variants: z.array(EditorCatalogVariantSchema).min(1),
+});
+
+const EditorCatalogProviderStateSchema = z.object({
+    lastFetchedAt: z.number().int().nonnegative().nullable(),
+    lastPublishedAt: z.iso.datetime().nullable(),
+    releases: z.array(EditorCatalogReleaseSchema),
+});
+
+/** Checks the full stored catalog file. */
+export const EditorCatalogFileSchema = z.object({
+    schemaVersion: z.literal(EDITOR_CATALOG_SCHEMA_VERSION),
+    providers: z.record(
+        EditorCatalogProviderIdSchema,
+        EditorCatalogProviderStateSchema,
+    ),
+});
+
+/**
+ * Creates a catalog with empty provider data.
+ *
+ * @returns A valid empty catalog.
+ */
+export function createEmptyEditorCatalog(): EditorCatalogFile {
+    return {
+        schemaVersion: EDITOR_CATALOG_SCHEMA_VERSION,
+        providers: {
+            'official-stable': createEmptyProviderState(),
+            'official-prerelease': createEmptyProviderState(),
+        },
+    };
+}
+
+/**
+ * Checks and sorts catalog data before it is stored or returned.
+ *
+ * @param value - The catalog data to check.
+ * @returns Valid catalog data in a stable order.
+ */
+export function normalizeEditorCatalog(value: unknown): EditorCatalogFile {
+    const catalog = EditorCatalogFileSchema.parse(value);
+
+    return EditorCatalogFileSchema.parse({
+        ...catalog,
+        providers: Object.fromEntries(
+            EDITOR_CATALOG_PROVIDER_IDS.map((providerId) => [
+                providerId,
+                normalizeProviderState(
+                    providerId,
+                    catalog.providers[providerId],
+                ),
+            ]),
+        ),
+    });
+}
+
+/**
+ * Creates empty cached data for one provider.
+ *
+ * @returns Empty provider data.
+ */
+function createEmptyProviderState(): EditorCatalogProviderState {
+    return {
+        lastFetchedAt: null,
+        lastPublishedAt: null,
+        releases: [],
+    };
+}
+
+/**
+ * Removes invalid provider releases and sorts the remaining releases.
+ *
+ * @param providerId - The provider that owns the releases.
+ * @param state - The provider data to normalize.
+ * @returns Normalized provider data.
+ */
+function normalizeProviderState(
+    providerId: (typeof EDITOR_CATALOG_PROVIDER_IDS)[number],
+    state: EditorCatalogProviderState,
+): EditorCatalogProviderState {
+    const releasesById = new Map(
+        state.releases
+            .filter((release) => release.providerId === providerId)
+            .map((release) => [release.id, normalizeRelease(release)]),
+    );
+
+    return {
+        lastFetchedAt: state.lastFetchedAt,
+        lastPublishedAt: state.lastPublishedAt,
+        releases: [...releasesById.values()].sort(compareEditorReleases),
+    };
+}
+
+/**
+ * Sorts the variants and assets inside one release.
+ *
+ * @param release - The release to normalize.
+ * @returns A copy of the release in a stable order.
+ */
+function normalizeRelease(
+    release: EditorCatalogProviderState['releases'][number],
+): EditorCatalogProviderState['releases'][number] {
+    return {
+        ...release,
+        variants: [...release.variants]
+            .map((variant) => ({
+                ...variant,
+                assets: [...variant.assets].sort((a, b) =>
+                    a.id.localeCompare(b.id),
+                ),
+            }))
+            .sort((a, b) => a.flavor.localeCompare(b.flavor)),
+    };
+}
+
+/**
+ * Compares two releases so newer versions come first.
+ *
+ * @param a - The first release.
+ * @param b - The second release.
+ * @returns A sort value for the two releases.
+ */
+export function compareEditorReleases(
+    a: EditorCatalogProviderState['releases'][number],
+    b: EditorCatalogProviderState['releases'][number],
+): number {
+    const fields = ['major', 'minor', 'patch'] as const;
+    for (const field of fields) {
+        const difference = b.versionParts[field] - a.versionParts[field];
+        if (difference !== 0) {
+            return difference;
+        }
+    }
+
+    const channelDifference =
+        channelPriority(a.versionParts.channel) -
+        channelPriority(b.versionParts.channel);
+    if (channelDifference !== 0) {
+        return channelDifference;
+    }
+
+    return b.versionParts.iteration - a.versionParts.iteration;
+}
+
+/**
+ * Gets the sort priority for a release channel.
+ *
+ * @param channel - The release channel name.
+ * @returns The channel sort priority.
+ */
+function channelPriority(channel: string): number {
+    return ['stable', 'rc', 'beta', 'alpha', 'dev'].indexOf(channel) === -1
+        ? 99
+        : ['stable', 'rc', 'beta', 'alpha', 'dev'].indexOf(channel);
+}

--- a/main/src/editor-catalog/editor-catalog.service.test.ts
+++ b/main/src/editor-catalog/editor-catalog.service.test.ts
@@ -1,0 +1,199 @@
+import type {
+    EditorCatalogProviderId,
+    EditorCatalogRelease,
+} from '@shared/contracts';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createEmptyEditorCatalog } from './editor-catalog.schema.js';
+import { EditorCatalogService } from './editor-catalog.service.js';
+import type { EditorCatalogStore } from './editor-catalog.store.js';
+import type { EditorCatalogFile } from './editor-catalog.types.js';
+import type { GithubEditorCatalogAdapter } from './github-editor-catalog.adapter.js';
+
+vi.mock('electron-log', () => ({
+    default: {
+        error: vi.fn(),
+    },
+}));
+
+describe('EditorCatalogService', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-01-02T00:00:00.000Z'));
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('queries a fresh catalog without fetching', async () => {
+        const catalog = createCatalogWithRelease(
+            createRelease('official-stable', '4.5-stable'),
+        );
+        const { service, githubAdapter } = createService(catalog);
+
+        const result = await service.getCatalog({
+            query: { search: '4.5', platform: 'win32' },
+        });
+
+        expect(result.releases).toHaveLength(1);
+        expect(githubAdapter.fetchProvider).not.toHaveBeenCalled();
+        await expect(
+            service.getReleaseById('official-stable:4.5-stable'),
+        ).resolves.toMatchObject({ version: '4.5-stable' });
+    });
+
+    it('deduplicates concurrent stale refreshes', async () => {
+        const catalog = createEmptyEditorCatalog();
+        const { service, githubAdapter } = createService(catalog);
+
+        const [first, second] = await Promise.all([
+            service.getCatalog(),
+            service.getCatalog({ query: { prerelease: false } }),
+        ]);
+
+        expect(githubAdapter.fetchProvider).toHaveBeenCalledTimes(2);
+        expect(first.releases).toHaveLength(2);
+        expect(second.releases).toHaveLength(1);
+    });
+
+    it('keeps cached data and reports a provider refresh error', async () => {
+        const cached = createRelease('official-prerelease', '4.6-beta1');
+        const catalog = createCatalogWithRelease(cached);
+        catalog.providers['official-stable'].lastFetchedAt = null;
+        catalog.providers['official-prerelease'].lastFetchedAt = null;
+        const { service, githubAdapter } = createService(catalog);
+        githubAdapter.fetchProvider.mockImplementation(async (providerId) => {
+            if (providerId === 'official-prerelease') {
+                throw new Error('builds unavailable');
+            }
+            return {
+                providerId,
+                lastPublishedAt: '2026-01-02T00:00:00.000Z',
+                releases: [createRelease(providerId, '4.5-stable')],
+            };
+        });
+
+        const result = await service.refreshCatalog();
+
+        expect(result.releases).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ id: cached.id }),
+                expect.objectContaining({
+                    id: 'official-stable:4.5-stable',
+                }),
+            ]),
+        );
+        expect(
+            result.providers.find(({ id }) => id === 'official-prerelease')
+                ?.refreshError,
+        ).toBe('builds unavailable');
+    });
+
+    it('rebuilds a malformed catalog during explicit refresh', async () => {
+        const { service, store } = createService(createEmptyEditorCatalog());
+        store.read.mockRejectedValue(new Error('invalid catalog'));
+
+        const result = await service.refreshCatalog();
+
+        expect(store.replace).toHaveBeenCalledOnce();
+        expect(result.releases).toHaveLength(2);
+    });
+});
+
+function createService(initialCatalog: EditorCatalogFile) {
+    let catalog = structuredClone(initialCatalog);
+    const store = {
+        read: vi.fn(async () => structuredClone(catalog)),
+        update: vi.fn(
+            async (
+                mutator: (value: EditorCatalogFile) => EditorCatalogFile,
+            ) => {
+                catalog = mutator(structuredClone(catalog));
+                return structuredClone(catalog);
+            },
+        ),
+        replace: vi.fn(async (value: EditorCatalogFile) => {
+            catalog = structuredClone(value);
+            return structuredClone(catalog);
+        }),
+    };
+    const githubAdapter = {
+        fetchProvider: vi.fn(async (providerId: EditorCatalogProviderId) => ({
+            providerId,
+            lastPublishedAt: '2026-01-02T00:00:00.000Z',
+            releases: [
+                createRelease(
+                    providerId,
+                    providerId === 'official-stable'
+                        ? '4.5-stable'
+                        : '4.6-beta1',
+                ),
+            ],
+        })),
+    };
+
+    return {
+        service: new EditorCatalogService(
+            store as unknown as EditorCatalogStore,
+            githubAdapter as unknown as GithubEditorCatalogAdapter,
+        ),
+        store,
+        githubAdapter,
+    };
+}
+
+function createCatalogWithRelease(
+    release: EditorCatalogRelease,
+): EditorCatalogFile {
+    const catalog = createEmptyEditorCatalog();
+    catalog.providers[release.providerId] = {
+        lastFetchedAt: Date.now(),
+        lastPublishedAt: release.publishedAt,
+        releases: [release],
+    };
+    for (const provider of Object.values(catalog.providers)) {
+        provider.lastFetchedAt ??= Date.now();
+    }
+    return catalog;
+}
+
+function createRelease(
+    providerId: EditorCatalogProviderId,
+    version: string,
+): EditorCatalogRelease {
+    const prerelease = providerId === 'official-prerelease';
+    const flavor = prerelease ? 'dotnet' : 'gdscript';
+    return {
+        id: `${providerId}:${version}`,
+        sourceReleaseId: version,
+        providerId,
+        tag: version,
+        version,
+        baseVersion: version.slice(0, 3),
+        name: `Godot ${version}`,
+        publishedAt: '2026-01-01T00:00:00.000Z',
+        prerelease,
+        versionParts: {
+            major: 4,
+            minor: prerelease ? 6 : 5,
+            patch: 0,
+            channel: prerelease ? 'beta' : 'stable',
+            iteration: prerelease ? 1 : 0,
+        },
+        variants: [
+            {
+                id: `${providerId}:${version}:${flavor}`,
+                flavor,
+                assets: [
+                    {
+                        id: `${providerId}:${version}:${flavor}:win32:x64`,
+                        name: `${version}.zip`,
+                        downloadUrl: 'https://example.com/editor.zip',
+                        platform: 'win32',
+                        architecture: 'x64',
+                    },
+                ],
+            },
+        ],
+    };
+}

--- a/main/src/editor-catalog/editor-catalog.service.ts
+++ b/main/src/editor-catalog/editor-catalog.service.ts
@@ -1,0 +1,305 @@
+import { Injectable } from '@mariodebono/di';
+import type {
+    EditorCatalogProviderId,
+    EditorCatalogProviderStatus,
+    EditorCatalogQuery,
+    EditorCatalogRelease,
+    EditorCatalogResult,
+    GetEditorCatalogOptions,
+} from '@shared/contracts';
+import logger from 'electron-log';
+import {
+    EDITOR_CATALOG_CACHE_TTL_MS,
+    EDITOR_CATALOG_PROVIDER_IDS,
+} from './editor-catalog.constants.js';
+import {
+    compareEditorReleases,
+    createEmptyEditorCatalog,
+} from './editor-catalog.schema.js';
+// biome-ignore lint/style/useImportType: Required for DI constructor metadata
+import { EditorCatalogStore } from './editor-catalog.store.js';
+import type {
+    EditorCatalogFile,
+    FetchedEditorCatalogProvider,
+} from './editor-catalog.types.js';
+// biome-ignore lint/style/useImportType: Required for DI constructor metadata
+import { GithubEditorCatalogAdapter } from './github-editor-catalog.adapter.js';
+
+/** Reads, refreshes, and filters the editor catalog. */
+@Injectable()
+export class EditorCatalogService {
+    private refreshPromise: Promise<RefreshOutcome> | null = null;
+
+    /**
+     * Creates the catalog service.
+     *
+     * @param store - The store used for cached catalog data.
+     * @param githubAdapter - The adapter used to read GitHub releases.
+     */
+    constructor(
+        private readonly store: EditorCatalogStore,
+        private readonly githubAdapter: GithubEditorCatalogAdapter,
+    ) {}
+
+    /**
+     * Gets releases from the cache and refreshes stale data by default.
+     *
+     * @param options - Optional refresh and filter settings.
+     * @returns The matching releases and provider status.
+     */
+    async getCatalog(
+        options: GetEditorCatalogOptions = {},
+    ): Promise<EditorCatalogResult> {
+        const catalog = await this.store.read();
+        const staleProviders = EDITOR_CATALOG_PROVIDER_IDS.filter(
+            (providerId) => this.isStale(catalog, providerId),
+        );
+
+        if (options.refreshIfStale !== false && staleProviders.length > 0) {
+            return this.refresh(
+                [...EDITOR_CATALOG_PROVIDER_IDS],
+                options.query,
+            );
+        }
+
+        return this.createResult(catalog, options.query);
+    }
+
+    /**
+     * Finds one release by its exact catalog ID.
+     *
+     * @param id - The release ID to find.
+     * @returns The release, or null when it does not exist.
+     */
+    async getReleaseById(id: string): Promise<EditorCatalogRelease | null> {
+        const result = await this.getCatalog();
+        return result.releases.find((release) => release.id === id) ?? null;
+    }
+
+    /**
+     * Refreshes every provider and returns matching releases.
+     *
+     * @param query - Optional filters for the returned releases.
+     * @returns The refreshed releases and provider status.
+     */
+    refreshCatalog(query?: EditorCatalogQuery): Promise<EditorCatalogResult> {
+        return this.refresh([...EDITOR_CATALOG_PROVIDER_IDS], query);
+    }
+
+    /**
+     * Shares one active refresh between callers.
+     *
+     * @param providerIds - The providers to refresh.
+     * @param query - Optional filters for the returned releases.
+     * @returns The refreshed releases and provider status.
+     */
+    private async refresh(
+        providerIds: EditorCatalogProviderId[],
+        query?: EditorCatalogQuery,
+    ): Promise<EditorCatalogResult> {
+        if (!this.refreshPromise) {
+            this.refreshPromise = this.runRefresh(providerIds).finally(() => {
+                this.refreshPromise = null;
+            });
+        }
+
+        const outcome = await this.refreshPromise;
+        return this.createResult(outcome.catalog, query, outcome.errors);
+    }
+
+    /**
+     * Fetches provider updates and stores successful results.
+     *
+     * @param providerIds - The providers to fetch.
+     * @returns The updated catalog and any provider errors.
+     */
+    private async runRefresh(
+        providerIds: EditorCatalogProviderId[],
+    ): Promise<RefreshOutcome> {
+        let catalog: EditorCatalogFile;
+        let catalogReadable = true;
+        try {
+            catalog = await this.store.read();
+        } catch (error) {
+            catalogReadable = false;
+            catalog = createEmptyEditorCatalog();
+            logger.error('Failed to read editor catalog before refresh', error);
+        }
+
+        const refreshResults = await Promise.allSettled(
+            providerIds.map((providerId) =>
+                this.githubAdapter.fetchProvider(
+                    providerId,
+                    catalog.providers[providerId].lastPublishedAt,
+                ),
+            ),
+        );
+        const updates: FetchedEditorCatalogProvider[] = [];
+        const errors = new Map<EditorCatalogProviderId, string>();
+
+        refreshResults.forEach((result, index) => {
+            const providerId = providerIds[index];
+            if (result.status === 'fulfilled') {
+                updates.push(result.value);
+                return;
+            }
+
+            const message = getErrorMessage(result.reason);
+            errors.set(providerId, message);
+            logger.error(
+                `Failed to refresh editor catalog provider ${providerId}`,
+                result.reason,
+            );
+        });
+
+        if (updates.length > 0) {
+            const applyUpdates = (current: EditorCatalogFile) =>
+                mergeProviderUpdates(current, updates, Date.now());
+            catalog = catalogReadable
+                ? await this.store.update(applyUpdates)
+                : await this.store.replace(applyUpdates(catalog));
+        }
+
+        return { catalog, errors };
+    }
+
+    /**
+     * Builds the catalog result returned to callers.
+     *
+     * @param catalog - The stored catalog data.
+     * @param query - Optional release filters.
+     * @param refreshErrors - Errors from the latest provider refresh.
+     * @returns Matching releases and provider status.
+     */
+    private createResult(
+        catalog: EditorCatalogFile,
+        query?: EditorCatalogQuery,
+        refreshErrors: Map<EditorCatalogProviderId, string> = new Map(),
+    ): EditorCatalogResult {
+        const releases = EDITOR_CATALOG_PROVIDER_IDS.flatMap(
+            (providerId) => catalog.providers[providerId].releases,
+        )
+            .filter((release) => matchesQuery(release, query))
+            .sort(compareEditorReleases);
+        const providers: EditorCatalogProviderStatus[] =
+            EDITOR_CATALOG_PROVIDER_IDS.map((providerId) => ({
+                id: providerId,
+                lastFetchedAt: catalog.providers[providerId].lastFetchedAt,
+                isStale: this.isStale(catalog, providerId),
+                ...(refreshErrors.has(providerId)
+                    ? { refreshError: refreshErrors.get(providerId) }
+                    : {}),
+            }));
+
+        return { releases, providers };
+    }
+
+    /**
+     * Checks whether one provider should be refreshed.
+     *
+     * @param catalog - The stored catalog data.
+     * @param providerId - The provider to check.
+     * @returns True when the provider data is stale.
+     */
+    private isStale(
+        catalog: EditorCatalogFile,
+        providerId: EditorCatalogProviderId,
+    ): boolean {
+        const lastFetchedAt = catalog.providers[providerId].lastFetchedAt;
+        return (
+            lastFetchedAt === null ||
+            lastFetchedAt + EDITOR_CATALOG_CACHE_TTL_MS < Date.now()
+        );
+    }
+}
+
+/**
+ * Merges fetched provider data into the stored catalog.
+ *
+ * @param catalog - The current catalog.
+ * @param updates - The provider updates to merge.
+ * @param fetchedAt - The time when the updates were fetched.
+ * @returns A catalog containing the provider updates.
+ */
+function mergeProviderUpdates(
+    catalog: EditorCatalogFile,
+    updates: FetchedEditorCatalogProvider[],
+    fetchedAt: number,
+): EditorCatalogFile {
+    const providers = { ...catalog.providers };
+    for (const update of updates) {
+        const current = providers[update.providerId];
+        const releasesById = new Map(
+            [...current.releases, ...update.releases].map((release) => [
+                release.id,
+                release,
+            ]),
+        );
+        providers[update.providerId] = {
+            lastFetchedAt: fetchedAt,
+            lastPublishedAt: update.lastPublishedAt,
+            releases: [...releasesById.values()],
+        };
+    }
+
+    return { ...catalog, providers };
+}
+
+/** Result of refreshing one or more catalog providers. */
+type RefreshOutcome = {
+    catalog: EditorCatalogFile;
+    errors: Map<EditorCatalogProviderId, string>;
+};
+
+/**
+ * Checks whether a release matches all requested filters.
+ *
+ * @param release - The release to check.
+ * @param query - The filters to apply.
+ * @returns True when the release matches the query.
+ */
+function matchesQuery(
+    release: EditorCatalogRelease,
+    query?: EditorCatalogQuery,
+): boolean {
+    if (!query) {
+        return true;
+    }
+    if (
+        query.prerelease !== undefined &&
+        release.prerelease !== query.prerelease
+    ) {
+        return false;
+    }
+
+    const search = query.search?.trim().toLowerCase();
+    if (
+        search &&
+        ![release.version, release.tag, release.name].some((value) =>
+            value.toLowerCase().includes(search),
+        )
+    ) {
+        return false;
+    }
+
+    return release.variants.some(
+        (variant) =>
+            (!query.flavor || variant.flavor === query.flavor) &&
+            variant.assets.some(
+                (asset) =>
+                    (!query.platform || asset.platform === query.platform) &&
+                    (!query.architecture ||
+                        asset.architecture === query.architecture),
+            ),
+    );
+}
+
+/**
+ * Converts an unknown error value into a message.
+ *
+ * @param error - The error value to convert.
+ * @returns A readable error message.
+ */
+function getErrorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}

--- a/main/src/editor-catalog/editor-catalog.store.test.ts
+++ b/main/src/editor-catalog/editor-catalog.store.test.ts
@@ -1,0 +1,61 @@
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { AtomicJsonFileAdapter } from '../json-store/atomic-json-file.adapter.js';
+import { JsonStoreCoordinatorService } from '../json-store/json-store-coordinator.service.js';
+import { EditorCatalogStore } from './editor-catalog.store.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+    await Promise.all(
+        temporaryDirectories
+            .splice(0)
+            .map((directory) =>
+                fs.rm(directory, { recursive: true, force: true }),
+            ),
+    );
+});
+
+describe('EditorCatalogStore', () => {
+    it('persists an empty catalog when the file is missing', async () => {
+        const directory = await createTemporaryDirectory();
+        const catalogPath = path.join(directory, 'editor-catalog.json');
+        const store = createStore(catalogPath);
+
+        const catalog = await store.read();
+
+        expect(catalog.schemaVersion).toBe(1);
+        await expect(fs.readFile(catalogPath, 'utf-8')).resolves.toContain(
+            '"schemaVersion": 1',
+        );
+    });
+
+    it('rejects malformed new catalog data', async () => {
+        const directory = await createTemporaryDirectory();
+        const catalogPath = path.join(directory, 'editor-catalog.json');
+        await fs.writeFile(catalogPath, '{invalid', 'utf-8');
+        const store = createStore(catalogPath);
+
+        await expect(store.read()).rejects.toThrow();
+    });
+});
+
+function createStore(catalogPath: string): EditorCatalogStore {
+    const coordinator = new JsonStoreCoordinatorService(
+        new AtomicJsonFileAdapter(),
+    );
+    return new EditorCatalogStore(coordinator, {
+        directory: path.dirname(catalogPath),
+        fileName: path.basename(catalogPath),
+    });
+}
+
+async function createTemporaryDirectory(): Promise<string> {
+    const directory = await fs.mkdtemp(
+        path.join(os.tmpdir(), 'launcher-editor-catalog-'),
+    );
+    temporaryDirectories.push(directory);
+    return directory;
+}

--- a/main/src/editor-catalog/editor-catalog.store.ts
+++ b/main/src/editor-catalog/editor-catalog.store.ts
@@ -1,0 +1,69 @@
+import path from 'node:path';
+import { JsonFileStore } from '../json-store/json-file.store.js';
+import type { JsonStoreCoordinatorService } from '../json-store/json-store-coordinator.service.js';
+import {
+    createEmptyEditorCatalog,
+    normalizeEditorCatalog,
+} from './editor-catalog.schema.js';
+import type {
+    EditorCatalogFile,
+    EditorCatalogModuleOptions,
+} from './editor-catalog.types.js';
+
+/** Stores the editor catalog in one JSON file. */
+export class EditorCatalogStore extends JsonFileStore<EditorCatalogFile> {
+    /**
+     * Creates the catalog store.
+     *
+     * @param coordinator - The service that keeps JSON writes in order.
+     * @param options - The directory and file name used by the store.
+     */
+    constructor(
+        coordinator: JsonStoreCoordinatorService,
+        options: EditorCatalogModuleOptions,
+    ) {
+        super(coordinator, {
+            pathProvider: () =>
+                path.resolve(options.directory, options.fileName),
+            defaultValue: createEmptyEditorCatalog,
+            parse: (raw) => normalizeEditorCatalog(JSON.parse(raw)),
+            normalize: normalizeEditorCatalog,
+        });
+    }
+
+    /**
+     * Reads and normalizes the stored catalog.
+     *
+     * @returns The current normalized catalog.
+     */
+    async read(): Promise<EditorCatalogFile> {
+        const current = await this.readValue();
+        return (
+            await this.replaceValue(current.value, {
+                expectedVersion: current.version,
+            })
+        ).value;
+    }
+
+    /**
+     * Replaces all stored catalog data.
+     *
+     * @param value - The complete catalog to store.
+     * @returns The stored catalog.
+     */
+    async replace(value: EditorCatalogFile): Promise<EditorCatalogFile> {
+        return (await this.replaceValue(value)).value;
+    }
+
+    /**
+     * Updates the catalog while keeping writes in order.
+     *
+     * @param mutator - The function that creates the next catalog value.
+     * @returns The updated catalog.
+     */
+    async update(
+        mutator: (current: EditorCatalogFile) => EditorCatalogFile,
+    ): Promise<EditorCatalogFile> {
+        return (await this.updateValue(mutator)).value;
+    }
+}

--- a/main/src/editor-catalog/editor-catalog.types.ts
+++ b/main/src/editor-catalog/editor-catalog.types.ts
@@ -1,0 +1,48 @@
+import type {
+    EditorCatalogProviderId,
+    EditorCatalogRelease,
+} from '@shared/contracts';
+
+/** Storage settings supplied by the application. */
+export type EditorCatalogModuleOptions = {
+    directory: string;
+    fileName: string;
+};
+
+/** GitHub asset fields used by the catalog mapper. */
+export type GithubEditorAsset = {
+    id: number;
+    name: string;
+    browserDownloadUrl: string;
+};
+
+/** GitHub release fields used by the catalog mapper. */
+export type GithubEditorRelease = {
+    id: number;
+    name: string | null;
+    tagName: string;
+    publishedAt: string | null;
+    draft: boolean;
+    prerelease: boolean;
+    assets: GithubEditorAsset[];
+};
+
+/** Cached data for one catalog provider. */
+export type EditorCatalogProviderState = {
+    lastFetchedAt: number | null;
+    lastPublishedAt: string | null;
+    releases: EditorCatalogRelease[];
+};
+
+/** Complete catalog data stored in the JSON file. */
+export type EditorCatalogFile = {
+    schemaVersion: 1;
+    providers: Record<EditorCatalogProviderId, EditorCatalogProviderState>;
+};
+
+/** New provider data returned by a GitHub refresh. */
+export type FetchedEditorCatalogProvider = {
+    providerId: EditorCatalogProviderId;
+    lastPublishedAt: string | null;
+    releases: EditorCatalogRelease[];
+};

--- a/main/src/editor-catalog/github-editor-catalog.adapter.test.ts
+++ b/main/src/editor-catalog/github-editor-catalog.adapter.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { GithubEditorCatalogAdapter } from './github-editor-catalog.adapter.js';
+
+vi.mock('electron-log', () => ({
+    default: {
+        debug: vi.fn(),
+    },
+}));
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('GithubEditorCatalogAdapter', () => {
+    it('fetches and maps one provider page', async () => {
+        const fetchMock = vi.fn(async () =>
+            Response.json([
+                {
+                    id: 45,
+                    name: 'Godot 4.5',
+                    tag_name: '4.5-stable',
+                    published_at: '2026-01-01T00:00:00.000Z',
+                    draft: false,
+                    prerelease: false,
+                    assets: [
+                        {
+                            id: 1,
+                            name: 'Godot_v4.5-stable_win64.exe.zip',
+                            browser_download_url:
+                                'https://example.com/windows.zip',
+                        },
+                    ],
+                },
+            ]),
+        );
+        vi.stubGlobal('fetch', fetchMock);
+
+        const result = await new GithubEditorCatalogAdapter().fetchProvider(
+            'official-stable',
+            null,
+        );
+
+        expect(result.releases).toHaveLength(1);
+        expect(result.lastPublishedAt).toBe('2026-01-01T00:00:00.000Z');
+        expect(fetchMock).toHaveBeenCalledOnce();
+        expect(String(fetchMock.mock.calls[0][0])).toContain(
+            '/godotengine/godot/releases',
+        );
+    });
+
+    it('throws a useful response error', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(async () => new Response('rate limited', { status: 403 })),
+        );
+
+        await expect(
+            new GithubEditorCatalogAdapter().fetchProvider(
+                'official-stable',
+                null,
+            ),
+        ).rejects.toThrow('Failed to fetch editor catalog: 403; rate limited');
+    });
+});

--- a/main/src/editor-catalog/github-editor-catalog.adapter.ts
+++ b/main/src/editor-catalog/github-editor-catalog.adapter.ts
@@ -1,0 +1,152 @@
+import { Injectable } from '@mariodebono/di';
+import type { EditorCatalogProviderId } from '@shared/contracts';
+import logger from 'electron-log';
+import { z } from 'zod';
+import {
+    EDITOR_CATALOG_PAGE_LIMIT,
+    EDITOR_CATALOG_PAGE_SIZE,
+    EDITOR_CATALOG_PROVIDERS,
+} from './editor-catalog.constants.js';
+import type {
+    FetchedEditorCatalogProvider,
+    GithubEditorRelease,
+} from './editor-catalog.types.js';
+import { mapGithubEditorRelease } from './github-editor-release.mapper.js';
+
+const GithubReleaseSchema = z.object({
+    id: z.number().int(),
+    name: z.string().nullable(),
+    tag_name: z.string(),
+    published_at: z.string().nullable(),
+    draft: z.boolean(),
+    prerelease: z.boolean(),
+    assets: z.array(
+        z.object({
+            id: z.number().int(),
+            name: z.string(),
+            browser_download_url: z.url(),
+        }),
+    ),
+});
+
+/** Fetches editor releases from the configured GitHub providers. */
+@Injectable()
+export class GithubEditorCatalogAdapter {
+    /**
+     * Fetches releases published after the cached provider data.
+     *
+     * @param providerId - The provider to fetch.
+     * @param publishedAfter - The newest stored publication time.
+     * @returns New releases and the latest publication time.
+     */
+    async fetchProvider(
+        providerId: EditorCatalogProviderId,
+        publishedAfter: string | null,
+    ): Promise<FetchedEditorCatalogProvider> {
+        const provider = EDITOR_CATALOG_PROVIDERS[providerId];
+        const releases: GithubEditorRelease[] = [];
+
+        for (let page = 1; page <= EDITOR_CATALOG_PAGE_LIMIT; page += 1) {
+            const url = new URL(
+                `https://api.github.com/repos/${provider.owner}/${provider.repository}/releases`,
+            );
+            url.searchParams.set('page', String(page));
+            url.searchParams.set('per_page', String(EDITOR_CATALOG_PAGE_SIZE));
+            logger.debug(`Fetching editor catalog from ${url.toString()}`);
+
+            const response = await fetch(url);
+            if (!response.ok) {
+                const message = await response.text().catch(() => '');
+                throw new Error(
+                    `Failed to fetch editor catalog: ${response.status}${message ? `; ${message}` : ''}`,
+                );
+            }
+
+            const pageReleases = z
+                .array(GithubReleaseSchema)
+                .parse(await response.json())
+                .map(toGithubEditorRelease);
+            releases.push(...pageReleases);
+
+            if (pageReleases.length < EDITOR_CATALOG_PAGE_SIZE) {
+                break;
+            }
+        }
+
+        const afterTime = publishedAfter
+            ? new Date(publishedAfter).getTime()
+            : 0;
+        const mapped = releases
+            .filter((release) => {
+                const publishedTime = release.publishedAt
+                    ? new Date(release.publishedAt).getTime()
+                    : 0;
+                return publishedTime > afterTime;
+            })
+            .map((release) =>
+                mapGithubEditorRelease(
+                    providerId,
+                    provider.prerelease,
+                    release,
+                ),
+            )
+            .filter((release) => release !== null);
+        const latestPublishedAt = mapped.reduce<string | null>(
+            (latest, release) => laterDate(latest, release.publishedAt),
+            publishedAfter,
+        );
+
+        return {
+            providerId,
+            lastPublishedAt: latestPublishedAt,
+            releases: mapped,
+        };
+    }
+}
+
+/**
+ * Converts a checked GitHub API release into the internal input shape.
+ *
+ * @param value - The checked GitHub API release.
+ * @returns The release fields used by the catalog mapper.
+ */
+function toGithubEditorRelease(
+    value: z.infer<typeof GithubReleaseSchema>,
+): GithubEditorRelease {
+    return {
+        id: value.id,
+        name: value.name,
+        tagName: value.tag_name,
+        publishedAt: value.published_at,
+        draft: value.draft,
+        prerelease: value.prerelease,
+        assets: value.assets.map((asset) => ({
+            id: asset.id,
+            name: asset.name,
+            browserDownloadUrl: asset.browser_download_url,
+        })),
+    };
+}
+
+/**
+ * Chooses the later of two publication times.
+ *
+ * @param current - The current latest publication time.
+ * @param candidate - The publication time to compare.
+ * @returns The later time in ISO format.
+ */
+function laterDate(
+    current: string | null,
+    candidate: string | null,
+): string | null {
+    if (!candidate) {
+        return current;
+    }
+    if (
+        !current ||
+        new Date(candidate).getTime() > new Date(current).getTime()
+    ) {
+        return new Date(candidate).toISOString();
+    }
+    return current;
+}

--- a/main/src/editor-catalog/github-editor-release.mapper.test.ts
+++ b/main/src/editor-catalog/github-editor-release.mapper.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import type { GithubEditorRelease } from './editor-catalog.types.js';
+import {
+    mapGithubEditorRelease,
+    parseEditorVersion,
+} from './github-editor-release.mapper.js';
+
+describe('github editor release mapper', () => {
+    it('groups supported assets by flavor and target', () => {
+        const release = mapGithubEditorRelease(
+            'official-stable',
+            false,
+            createGithubRelease(),
+        );
+
+        expect(release).toMatchObject({
+            id: 'official-stable:4.5-stable',
+            baseVersion: '4.5',
+            prerelease: false,
+            versionParts: {
+                major: 4,
+                minor: 5,
+                patch: 0,
+                channel: 'stable',
+                iteration: 0,
+            },
+        });
+        expect(release?.variants).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    flavor: 'gdscript',
+                    assets: expect.arrayContaining([
+                        expect.objectContaining({
+                            platform: 'win32',
+                            architecture: 'x64',
+                        }),
+                        expect.objectContaining({
+                            platform: 'darwin',
+                            architecture: 'arm64',
+                        }),
+                    ]),
+                }),
+                expect.objectContaining({
+                    flavor: 'dotnet',
+                    assets: [
+                        expect.objectContaining({
+                            platform: 'linux',
+                            architecture: 'x64',
+                        }),
+                    ],
+                }),
+            ]),
+        );
+    });
+
+    it('rejects old, invalid, draft, and assetless releases', () => {
+        const base = createGithubRelease();
+
+        expect(
+            mapGithubEditorRelease('official-stable', false, {
+                ...base,
+                tagName: '3.6-stable',
+            }),
+        ).toBeNull();
+        expect(
+            mapGithubEditorRelease('official-stable', false, {
+                ...base,
+                draft: true,
+            }),
+        ).toBeNull();
+        expect(
+            mapGithubEditorRelease('official-stable', false, {
+                ...base,
+                assets: [],
+            }),
+        ).toBeNull();
+    });
+
+    it('parses supported release channels', () => {
+        expect(parseEditorVersion('v4.6-rc2')).toEqual({
+            major: 4,
+            minor: 6,
+            patch: 0,
+            channel: 'rc',
+            iteration: 2,
+        });
+        expect(parseEditorVersion('not-a-version')).toBeNull();
+    });
+});
+
+function createGithubRelease(): GithubEditorRelease {
+    return {
+        id: 45,
+        name: 'Godot 4.5',
+        tagName: '4.5-stable',
+        publishedAt: '2026-01-01T00:00:00.000Z',
+        draft: false,
+        prerelease: false,
+        assets: [
+            {
+                id: 1,
+                name: 'Godot_v4.5-stable_win64.exe.zip',
+                browserDownloadUrl: 'https://example.com/windows.zip',
+            },
+            {
+                id: 2,
+                name: 'Godot_v4.5-stable_macos.universal.zip',
+                browserDownloadUrl: 'https://example.com/macos.zip',
+            },
+            {
+                id: 3,
+                name: 'Godot_v4.5-stable_mono_linux.x86_64.zip',
+                browserDownloadUrl: 'https://example.com/linux-dotnet.zip',
+            },
+            {
+                id: 4,
+                name: 'Godot_v4.5-stable_web_editor.zip',
+                browserDownloadUrl: 'https://example.com/web.zip',
+            },
+        ],
+    };
+}

--- a/main/src/editor-catalog/github-editor-release.mapper.ts
+++ b/main/src/editor-catalog/github-editor-release.mapper.ts
@@ -1,0 +1,204 @@
+import type {
+    EditorCatalogArchitecture,
+    EditorCatalogAsset,
+    EditorCatalogFlavor,
+    EditorCatalogPlatform,
+    EditorCatalogProviderId,
+    EditorCatalogRelease,
+} from '@shared/contracts';
+import { EDITOR_CATALOG_MIN_VERSION } from './editor-catalog.constants.js';
+import type {
+    GithubEditorAsset,
+    GithubEditorRelease,
+} from './editor-catalog.types.js';
+
+/** Platform and architectures found in an asset name. */
+type AssetTarget = {
+    platform: EditorCatalogPlatform;
+    architectures: EditorCatalogArchitecture[];
+};
+
+/**
+ * Converts one GitHub release into a catalog release.
+ *
+ * @param providerId - The provider that supplied the release.
+ * @param providerPrerelease - Whether the provider contains prereleases.
+ * @param release - The GitHub release to convert.
+ * @returns A catalog release, or null when the release is unsupported.
+ */
+export function mapGithubEditorRelease(
+    providerId: EditorCatalogProviderId,
+    providerPrerelease: boolean,
+    release: GithubEditorRelease,
+): EditorCatalogRelease | null {
+    if (release.draft || !release.tagName.trim()) {
+        return null;
+    }
+
+    const versionParts = parseEditorVersion(release.tagName);
+    if (!versionParts || versionParts.major < EDITOR_CATALOG_MIN_VERSION) {
+        return null;
+    }
+
+    const releaseId = `${providerId}:${release.tagName}`;
+    const assetsByFlavor = Map.groupBy(
+        release.assets.flatMap((asset) => mapGithubAsset(releaseId, asset)),
+        ({ flavor }) => flavor,
+    );
+    const variants = (
+        [...assetsByFlavor.entries()] as Array<
+            [
+                EditorCatalogFlavor,
+                Array<{
+                    flavor: EditorCatalogFlavor;
+                    asset: EditorCatalogAsset;
+                }>,
+            ]
+        >
+    ).map(([flavor, entries]) => ({
+        id: `${releaseId}:${flavor}`,
+        flavor,
+        assets: entries.map(({ asset }) => asset),
+    }));
+
+    if (variants.length === 0) {
+        return null;
+    }
+
+    return {
+        id: releaseId,
+        sourceReleaseId: String(release.id),
+        providerId,
+        tag: release.tagName,
+        version: release.tagName,
+        baseVersion: `${versionParts.major}.${versionParts.minor}`,
+        name: release.name?.trim() || release.tagName,
+        publishedAt: normalizePublishedAt(release.publishedAt),
+        prerelease: providerPrerelease || release.prerelease,
+        versionParts,
+        variants,
+    };
+}
+
+/**
+ * Reads version parts from a Godot editor tag.
+ *
+ * @param version - The editor version or tag to read.
+ * @returns Parsed version parts, or null when the value is invalid.
+ */
+export function parseEditorVersion(
+    version: string,
+): EditorCatalogRelease['versionParts'] | null {
+    const match = version
+        .trim()
+        .replace(/^v/i, '')
+        .match(
+            /^(\d+)\.(\d+)(?:\.(\d+))?(?:-(stable|rc|beta|alpha|dev)(\d+)?)?$/i,
+        );
+    if (!match) {
+        return null;
+    }
+
+    return {
+        major: Number.parseInt(match[1], 10),
+        minor: Number.parseInt(match[2], 10),
+        patch: match[3] ? Number.parseInt(match[3], 10) : 0,
+        channel: match[4]?.toLowerCase() ?? 'stable',
+        iteration: match[5] ? Number.parseInt(match[5], 10) : 0,
+    };
+}
+
+/**
+ * Converts one GitHub asset into catalog assets.
+ *
+ * @param releaseId - The catalog ID of the parent release.
+ * @param source - The GitHub asset to convert.
+ * @returns Catalog assets for each supported architecture.
+ */
+function mapGithubAsset(
+    releaseId: string,
+    source: GithubEditorAsset,
+): Array<{ flavor: EditorCatalogFlavor; asset: EditorCatalogAsset }> {
+    const target = getAssetTarget(source.name);
+    if (!target) {
+        return [];
+    }
+
+    const flavor: EditorCatalogFlavor = source.name
+        .toLowerCase()
+        .includes('mono')
+        ? 'dotnet'
+        : 'gdscript';
+
+    return target.architectures.map((architecture) => ({
+        flavor,
+        asset: {
+            id: `${releaseId}:${flavor}:${source.id}:${target.platform}:${architecture}`,
+            name: source.name,
+            downloadUrl: source.browserDownloadUrl,
+            platform: target.platform,
+            architecture,
+        },
+    }));
+}
+
+/**
+ * Finds the platform and architectures in an asset name.
+ *
+ * @param name - The GitHub asset file name.
+ * @returns The supported target, or null when none is found.
+ */
+function getAssetTarget(name: string): AssetTarget | null {
+    const normalized = name.toLowerCase();
+    if (normalized.includes('windows_arm64')) {
+        return { platform: 'win32', architectures: ['arm64'] };
+    }
+    if (normalized.includes('win64')) {
+        return { platform: 'win32', architectures: ['x64'] };
+    }
+    if (normalized.includes('win32')) {
+        return { platform: 'win32', architectures: ['ia32'] };
+    }
+    if (
+        normalized.includes('osx') ||
+        normalized.includes('macos') ||
+        normalized.includes('universal')
+    ) {
+        return { platform: 'darwin', architectures: ['x64', 'arm64'] };
+    }
+    if (normalized.includes('linux') || normalized.includes('x11')) {
+        if (normalized.includes('arm32')) {
+            return { platform: 'linux', architectures: ['arm'] };
+        }
+        if (normalized.includes('arm64')) {
+            return { platform: 'linux', architectures: ['arm64'] };
+        }
+        if (normalized.includes('x86_32') || normalized.includes('32')) {
+            return { platform: 'linux', architectures: ['ia32'] };
+        }
+        if (
+            normalized.includes('x86_64') ||
+            normalized.includes('x86-64') ||
+            normalized.includes('64')
+        ) {
+            return { platform: 'linux', architectures: ['x64'] };
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Converts a publication time into a valid ISO value.
+ *
+ * @param value - The publication time to normalize.
+ * @returns The ISO time, or null when the value is missing or invalid.
+ */
+function normalizePublishedAt(value: string | null): string | null {
+    if (!value) {
+        return null;
+    }
+
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}

--- a/renderer/src/bridge.test.ts
+++ b/renderer/src/bridge.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
     appBridge,
     codeEditorIntegrationBridge,
+    editorCatalogBridge,
     getPathForFile,
     subscribeAppEvent,
 } from './bridge.js';
@@ -30,6 +31,9 @@ type TestElectronApi = {
         integrationId: string,
         pathToValidate: string,
     ) => Promise<unknown>;
+    'editorCatalog.getCatalog': () => Promise<unknown>;
+    'editorCatalog.getReleaseById': (id: string) => Promise<unknown>;
+    'editorCatalog.refreshCatalog': () => Promise<unknown>;
 };
 
 describe('renderer bridge', () => {
@@ -49,6 +53,9 @@ describe('renderer bridge', () => {
     }));
     const setDefaultIntegration = vi.fn(async () => []);
     const validateIntegrationPath = vi.fn(async () => ({ valid: true }));
+    const getCatalog = vi.fn(async () => ({ releases: [], providers: [] }));
+    const getReleaseById = vi.fn(async () => null);
+    const refreshCatalog = vi.fn(async () => ({ releases: [], providers: [] }));
     const unsubscribe = vi.fn();
     let projectsListener: ((projects: unknown[]) => void) | undefined;
 
@@ -70,6 +77,9 @@ describe('renderer bridge', () => {
                 setDefaultIntegration,
             'codeEditorIntegration.validateIntegrationPath':
                 validateIntegrationPath,
+            'editorCatalog.getCatalog': getCatalog,
+            'editorCatalog.getReleaseById': getReleaseById,
+            'editorCatalog.refreshCatalog': refreshCatalog,
             subscribeProjects: (listener) => {
                 projectsListener = listener;
                 return unsubscribe;
@@ -127,6 +137,18 @@ describe('renderer bridge', () => {
             execFlagsOverride: '',
         });
         expect(setDefaultIntegration).toHaveBeenCalledWith('vscode');
+    });
+
+    it('delegates through the editor catalog namespace', async () => {
+        await editorCatalogBridge.getCatalog();
+        await editorCatalogBridge.getReleaseById('official-stable:4.5-stable');
+        await editorCatalogBridge.refreshCatalog();
+
+        expect(getCatalog).toHaveBeenCalledOnce();
+        expect(getReleaseById).toHaveBeenCalledWith(
+            'official-stable:4.5-stable',
+        );
+        expect(refreshCatalog).toHaveBeenCalledOnce();
     });
 
     it('subscribes and unsubscribes from application events', () => {

--- a/renderer/src/bridge.ts
+++ b/renderer/src/bridge.ts
@@ -4,12 +4,13 @@ import {
     getPathForFile,
     type RendererIpcListener,
 } from '@mariodebono/di-electron/renderer';
-import type { AppBridgeNamespaces, AppEventMap } from '@shared/contracts';
+import type { AppEventMap, BridgeNamespaces } from '@shared/contracts';
 
-const rendererBridge = createRendererBridge<AppBridgeNamespaces>();
+const rendererBridge = createRendererBridge<BridgeNamespaces>();
 
 export const appBridge = rendererBridge.app;
 export const codeEditorIntegrationBridge = rendererBridge.codeEditorIntegration;
+export const editorCatalogBridge = rendererBridge.editorCatalog;
 
 const appEvents = createRendererEvents();
 

--- a/shared/src/contracts/app/app.bridge.d.ts
+++ b/shared/src/contracts/app/app.bridge.d.ts
@@ -1,7 +1,4 @@
-import type {
-    CodeEditorId,
-    CodeEditorIntegrationBridge,
-} from '../codeEditorIntegration/index.js';
+import type { CodeEditorId } from '../codeEditorIntegration/index.js';
 import type { UserPreferences } from '../preferences/index.js';
 import type {
     AddProjectOptions,
@@ -175,9 +172,4 @@ export type AppBridge = {
     ): Promise<AppUpdateMessage>;
     changeLanguage(lang: string): Promise<string>;
     rendererReady(): Promise<void>;
-};
-
-export type AppBridgeNamespaces = {
-    app: AppBridge;
-    codeEditorIntegration: CodeEditorIntegrationBridge;
 };

--- a/shared/src/contracts/bridge.types.d.ts
+++ b/shared/src/contracts/bridge.types.d.ts
@@ -1,0 +1,12 @@
+import type { AppBridge } from './app/index.js';
+import type { CodeEditorIntegrationBridge } from './codeEditorIntegration/index.js';
+import type { EditorCatalogBridge } from './editor-catalog/index.js';
+
+/**
+ * Lists the independent bridges exposed to the renderer.
+ */
+export type BridgeNamespaces = {
+    app: AppBridge;
+    codeEditorIntegration: CodeEditorIntegrationBridge;
+    editorCatalog: EditorCatalogBridge;
+};

--- a/shared/src/contracts/editor-catalog/editor-catalog.bridge.d.ts
+++ b/shared/src/contracts/editor-catalog/editor-catalog.bridge.d.ts
@@ -1,0 +1,105 @@
+/** Identifies a source of editor releases. */
+export type EditorCatalogProviderId = 'official-stable' | 'official-prerelease';
+
+/** Identifies the scripting support included in an editor build. */
+export type EditorCatalogFlavor = 'gdscript' | 'dotnet';
+/** Identifies an operating system supported by an editor asset. */
+export type EditorCatalogPlatform = 'win32' | 'darwin' | 'linux';
+/** Identifies a processor architecture supported by an editor asset. */
+export type EditorCatalogArchitecture = 'x64' | 'arm64' | 'ia32' | 'arm';
+
+/** Describes one downloadable editor file. */
+export type EditorCatalogAsset = {
+    id: string;
+    name: string;
+    downloadUrl: string;
+    platform: EditorCatalogPlatform;
+    architecture: EditorCatalogArchitecture;
+};
+
+/** Groups release assets by editor flavor. */
+export type EditorCatalogVariant = {
+    id: string;
+    flavor: EditorCatalogFlavor;
+    assets: EditorCatalogAsset[];
+};
+
+/** Contains version values used for sorting releases. */
+export type EditorCatalogVersionParts = {
+    major: number;
+    minor: number;
+    patch: number;
+    channel: string;
+    iteration: number;
+};
+
+/** Describes one editor release in the catalog. */
+export type EditorCatalogRelease = {
+    id: string;
+    sourceReleaseId: string;
+    providerId: EditorCatalogProviderId;
+    tag: string;
+    version: string;
+    baseVersion: string;
+    name: string;
+    publishedAt: string | null;
+    prerelease: boolean;
+    versionParts: EditorCatalogVersionParts;
+    variants: EditorCatalogVariant[];
+};
+
+/** Reports the cache state of one catalog provider. */
+export type EditorCatalogProviderStatus = {
+    id: EditorCatalogProviderId;
+    lastFetchedAt: number | null;
+    isStale: boolean;
+    refreshError?: string;
+};
+
+/** Filters editor releases returned by the catalog. */
+export type EditorCatalogQuery = {
+    search?: string;
+    prerelease?: boolean;
+    flavor?: EditorCatalogFlavor;
+    platform?: EditorCatalogPlatform;
+    architecture?: EditorCatalogArchitecture;
+};
+
+/** Contains matching releases and provider cache state. */
+export type EditorCatalogResult = {
+    releases: EditorCatalogRelease[];
+    providers: EditorCatalogProviderStatus[];
+};
+
+/** Controls catalog refresh and filtering behavior. */
+export type GetEditorCatalogOptions = {
+    refreshIfStale?: boolean;
+    query?: EditorCatalogQuery;
+};
+
+/** Defines the catalog requests available to the renderer. */
+export type EditorCatalogBridge = {
+    /**
+     * Gets releases from the editor catalog.
+     *
+     * @param options - Optional refresh and filter settings.
+     * @returns The matching releases and provider status.
+     */
+    getCatalog(options?: GetEditorCatalogOptions): Promise<EditorCatalogResult>;
+
+    /**
+     * Finds one release by its exact catalog ID.
+     *
+     * @param id - The release ID to find.
+     * @returns The release, or null when it does not exist.
+     */
+    getReleaseById(id: string): Promise<EditorCatalogRelease | null>;
+
+    /**
+     * Refreshes the catalog and returns matching releases.
+     *
+     * @param query - Optional filters for the returned releases.
+     * @returns The refreshed releases and provider status.
+     */
+    refreshCatalog(query?: EditorCatalogQuery): Promise<EditorCatalogResult>;
+};

--- a/shared/src/contracts/editor-catalog/index.d.ts
+++ b/shared/src/contracts/editor-catalog/index.d.ts
@@ -1,0 +1,1 @@
+export type * from './editor-catalog.bridge.js';

--- a/shared/src/contracts/index.d.ts
+++ b/shared/src/contracts/index.d.ts
@@ -1,5 +1,7 @@
 export type * from './app/index.js';
+export type * from './bridge.types.js';
 export type * from './codeEditorIntegration/index.js';
+export type * from './editor-catalog/index.js';
 export type * from './ipc/index.js';
 export type * from './preferences/index.js';
 export type * from './projects/index.js';

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -74,6 +74,7 @@ vi.mock('@mariodebono/di-electron/renderer', () => {
             codeEditorIntegration: createBridgeNamespace(
                 'codeEditorIntegration',
             ),
+            editorCatalog: createBridgeNamespace('editorCatalog'),
         }),
         createRendererEvents: () => ({
             on: (


### PR DESCRIPTION

- add an editor catalog module with its own service, controller, store, and GitHub adapter
- store normalised catalog data in a separate JSON file
- support catalog refresh, stale cache handling, filtering, and release lookup by ID
- expose the catalog through its own shared bridge namespace
- keep the existing release system unchanged for backward compatibility

This adds the catalog backend and renderer bridge only. Release installation and UI migration will follow separately.