### PR TITLE
perf(editor-catalog): stop refresh at cached releases

### DIFF
--- a/main/src/editor-catalog/editor-catalog.service.test.ts
+++ b/main/src/editor-catalog/editor-catalog.service.test.ts
@@ -6,7 +6,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createEmptyEditorCatalog } from './editor-catalog.schema.js';
 import { EditorCatalogService } from './editor-catalog.service.js';
 import type { EditorCatalogStore } from './editor-catalog.store.js';
-import type { EditorCatalogFile } from './editor-catalog.types.js';
+import type {
+    EditorCatalogFile,
+    FetchedEditorCatalogProvider,
+} from './editor-catalog.types.js';
 import type { GithubEditorCatalogAdapter } from './github-editor-catalog.adapter.js';
 
 vi.mock('electron-log', () => ({
@@ -40,6 +43,89 @@ describe('EditorCatalogService', () => {
         await expect(
             service.getReleaseById('official-stable:4.5-stable'),
         ).resolves.toMatchObject({ version: '4.5-stable' });
+    });
+
+    it('automatically refreshes only stale providers', async () => {
+        const cached = createRelease('official-stable', '4.5-stable');
+        const catalog = createCatalogWithRelease(cached);
+        catalog.providers['official-stable'].lastFetchedAt = null;
+        const { service, githubAdapter } = createService(catalog);
+
+        await service.getCatalog();
+
+        expect(githubAdapter.fetchProvider).toHaveBeenCalledOnce();
+        expect(githubAdapter.fetchProvider).toHaveBeenCalledWith(
+            'official-stable',
+            cached.publishedAt,
+        );
+    });
+
+    it('explicitly refreshes every provider', async () => {
+        const catalog = createCatalogWithRelease(
+            createRelease('official-stable', '4.5-stable'),
+        );
+        const { service, githubAdapter } = createService(catalog);
+
+        await service.refreshCatalog();
+
+        expect(githubAdapter.fetchProvider).toHaveBeenCalledTimes(2);
+        expect(githubAdapter.fetchProvider).toHaveBeenCalledWith(
+            'official-stable',
+            catalog.providers['official-stable'].lastPublishedAt,
+        );
+        expect(githubAdapter.fetchProvider).toHaveBeenCalledWith(
+            'official-prerelease',
+            catalog.providers['official-prerelease'].lastPublishedAt,
+        );
+    });
+
+    it('fetches providers missing from an active automatic refresh', async () => {
+        const cached = createRelease('official-stable', '4.5-stable');
+        const catalog = createCatalogWithRelease(cached);
+        catalog.providers['official-stable'].lastFetchedAt = null;
+        const { service, githubAdapter } = createService(catalog);
+        let resolveStableRefresh: (
+            value: FetchedEditorCatalogProvider,
+        ) => void = () => undefined;
+        const stableRefresh = new Promise<FetchedEditorCatalogProvider>(
+            (resolve) => {
+                resolveStableRefresh = resolve;
+            },
+        );
+        githubAdapter.fetchProvider.mockImplementation(async (providerId) => {
+            if (providerId === 'official-stable') {
+                return stableRefresh;
+            }
+            return {
+                providerId,
+                lastPublishedAt: '2026-01-02T00:00:00.000Z',
+                releases: [createRelease(providerId, '4.6-beta1')],
+            };
+        });
+
+        const automaticRefresh = service.getCatalog();
+        await vi.waitFor(() =>
+            expect(githubAdapter.fetchProvider).toHaveBeenCalledOnce(),
+        );
+        const explicitRefresh = service.refreshCatalog();
+        resolveStableRefresh({
+            providerId: 'official-stable',
+            lastPublishedAt: '2026-01-02T00:00:00.000Z',
+            releases: [createRelease('official-stable', '4.5-stable')],
+        });
+
+        const [, explicitResult] = await Promise.all([
+            automaticRefresh,
+            explicitRefresh,
+        ]);
+
+        expect(githubAdapter.fetchProvider).toHaveBeenCalledTimes(2);
+        expect(githubAdapter.fetchProvider).toHaveBeenNthCalledWith(
+            2,
+            'official-prerelease',
+            null,
+        );
+        expect(explicitResult.releases).toHaveLength(2);
     });
 
     it('deduplicates concurrent stale refreshes', async () => {
@@ -87,6 +173,26 @@ describe('EditorCatalogService', () => {
             result.providers.find(({ id }) => id === 'official-prerelease')
                 ?.refreshError,
         ).toBe('builds unavailable');
+    });
+
+    it('updates the fetch time when no new releases are found', async () => {
+        const cached = createRelease('official-stable', '4.5-stable');
+        const catalog = createCatalogWithRelease(cached);
+        catalog.providers['official-stable'].lastFetchedAt = 0;
+        const { service, githubAdapter } = createService(catalog);
+        githubAdapter.fetchProvider.mockResolvedValue({
+            providerId: 'official-stable',
+            lastPublishedAt: cached.publishedAt,
+            releases: [],
+        });
+
+        const result = await service.getCatalog();
+
+        expect(result.releases).toContainEqual(cached);
+        expect(
+            result.providers.find(({ id }) => id === 'official-stable')
+                ?.lastFetchedAt,
+        ).toBe(Date.now());
     });
 
     it('rebuilds a malformed catalog during explicit refresh', async () => {

--- a/main/src/editor-catalog/editor-catalog.service.ts
+++ b/main/src/editor-catalog/editor-catalog.service.ts
@@ -28,7 +28,7 @@ import { GithubEditorCatalogAdapter } from './github-editor-catalog.adapter.js';
 /** Reads, refreshes, and filters the editor catalog. */
 @Injectable()
 export class EditorCatalogService {
-    private refreshPromise: Promise<RefreshOutcome> | null = null;
+    private activeRefresh: ActiveRefresh | null = null;
 
     /**
      * Creates the catalog service.
@@ -56,10 +56,7 @@ export class EditorCatalogService {
         );
 
         if (options.refreshIfStale !== false && staleProviders.length > 0) {
-            return this.refresh(
-                [...EDITOR_CATALOG_PROVIDER_IDS],
-                options.query,
-            );
+            return this.refresh(staleProviders, options.query);
         }
 
         return this.createResult(catalog, options.query);
@@ -97,14 +94,58 @@ export class EditorCatalogService {
         providerIds: EditorCatalogProviderId[],
         query?: EditorCatalogQuery,
     ): Promise<EditorCatalogResult> {
-        if (!this.refreshPromise) {
-            this.refreshPromise = this.runRefresh(providerIds).finally(() => {
-                this.refreshPromise = null;
+        const outcome = await this.refreshProviders(providerIds);
+        return this.createResult(outcome.catalog, query, outcome.errors);
+    }
+
+    /**
+     * Shares the active refresh and queues provider IDs it does not cover.
+     *
+     * @param providerIds - The providers the caller needs refreshed.
+     * @returns The updated catalog and relevant provider errors.
+     */
+    private async refreshProviders(
+        providerIds: EditorCatalogProviderId[],
+    ): Promise<RefreshOutcome> {
+        if (!this.activeRefresh) {
+            const activeRefresh: ActiveRefresh = {
+                providerIds: new Set(providerIds),
+                promise: this.runRefresh(providerIds),
+            };
+            activeRefresh.promise = activeRefresh.promise.finally(() => {
+                if (this.activeRefresh === activeRefresh) {
+                    this.activeRefresh = null;
+                }
             });
+            this.activeRefresh = activeRefresh;
         }
 
-        const outcome = await this.refreshPromise;
-        return this.createResult(outcome.catalog, query, outcome.errors);
+        const activeRefresh = this.activeRefresh;
+        const missingProviderIds = providerIds.filter(
+            (providerId) => !activeRefresh.providerIds.has(providerId),
+        );
+        const outcome = await activeRefresh.promise;
+        const errors = new Map<EditorCatalogProviderId, string>();
+        for (const providerId of providerIds) {
+            const message = outcome.errors.get(providerId);
+            if (message !== undefined) {
+                errors.set(providerId, message);
+            }
+        }
+
+        if (missingProviderIds.length > 0) {
+            const missingOutcome =
+                await this.refreshProviders(missingProviderIds);
+            for (const [providerId, message] of missingOutcome.errors) {
+                errors.set(providerId, message);
+            }
+            return {
+                catalog: missingOutcome.catalog,
+                errors,
+            };
+        }
+
+        return { catalog: outcome.catalog, errors };
     }
 
     /**
@@ -249,6 +290,12 @@ function mergeProviderUpdates(
 type RefreshOutcome = {
     catalog: EditorCatalogFile;
     errors: Map<EditorCatalogProviderId, string>;
+};
+
+/** One active provider refresh shared by concurrent callers. */
+type ActiveRefresh = {
+    providerIds: Set<EditorCatalogProviderId>;
+    promise: Promise<RefreshOutcome>;
 };
 
 /**

--- a/main/src/editor-catalog/github-editor-catalog.adapter.test.ts
+++ b/main/src/editor-catalog/github-editor-catalog.adapter.test.ts
@@ -12,27 +12,11 @@ afterEach(() => {
 });
 
 describe('GithubEditorCatalogAdapter', () => {
-    it('fetches and maps one provider page', async () => {
-        const fetchMock = vi.fn(async () =>
-            Response.json([
-                {
-                    id: 45,
-                    name: 'Godot 4.5',
-                    tag_name: '4.5-stable',
-                    published_at: '2026-01-01T00:00:00.000Z',
-                    draft: false,
-                    prerelease: false,
-                    assets: [
-                        {
-                            id: 1,
-                            name: 'Godot_v4.5-stable_win64.exe.zip',
-                            browser_download_url:
-                                'https://example.com/windows.zip',
-                        },
-                    ],
-                },
-            ]),
-        );
+    it('fetches every page during an empty-cache bootstrap', async () => {
+        const fetchMock = createPagedFetchMock([
+            createGithubReleasePage(1, 100),
+            createGithubReleasePage(101, 1),
+        ]);
         vi.stubGlobal('fetch', fetchMock);
 
         const result = await new GithubEditorCatalogAdapter().fetchProvider(
@@ -40,12 +24,110 @@ describe('GithubEditorCatalogAdapter', () => {
             null,
         );
 
-        expect(result.releases).toHaveLength(1);
-        expect(result.lastPublishedAt).toBe('2026-01-01T00:00:00.000Z');
-        expect(fetchMock).toHaveBeenCalledOnce();
+        expect(result.releases).toHaveLength(101);
+        expect(result.lastPublishedAt).toBe(createPublishedAt(101));
+        expect(fetchMock).toHaveBeenCalledTimes(2);
         expect(String(fetchMock.mock.calls[0][0])).toContain(
             '/godotengine/godot/releases',
         );
+        expect(String(fetchMock.mock.calls[1][0])).toContain('page=2');
+    });
+
+    it('stops on the first page when it reaches the cached boundary', async () => {
+        const publishedAfter = createPublishedAt(101);
+        const fetchMock = createPagedFetchMock([
+            createGithubReleasePage(1, 100),
+            [],
+        ]);
+        vi.stubGlobal('fetch', fetchMock);
+
+        const result = await new GithubEditorCatalogAdapter().fetchProvider(
+            'official-stable',
+            publishedAfter,
+        );
+
+        expect(result.releases).toEqual([]);
+        expect(result.lastPublishedAt).toBe(publishedAfter);
+        expect(fetchMock).toHaveBeenCalledOnce();
+    });
+
+    it('keeps newer releases from the complete boundary page', async () => {
+        const publishedAfter = createPublishedAt(100);
+        const page = [
+            createGithubRelease(102),
+            createGithubRelease(101),
+            createGithubRelease(100),
+            ...createGithubReleasePage(1, 97, null),
+        ];
+        const fetchMock = createPagedFetchMock([page, []]);
+        vi.stubGlobal('fetch', fetchMock);
+
+        const result = await new GithubEditorCatalogAdapter().fetchProvider(
+            'official-stable',
+            publishedAfter,
+        );
+
+        expect(result.releases.map(({ tag }) => tag)).toEqual([
+            '4.102-stable',
+            '4.101-stable',
+        ]);
+        expect(result.lastPublishedAt).toBe(createPublishedAt(102));
+        expect(fetchMock).toHaveBeenCalledOnce();
+    });
+
+    it('continues until a later page reaches the cached boundary', async () => {
+        const publishedAfter = createPublishedAt(100);
+        const firstPage = createGithubReleasePage(103, 100);
+        const secondPage = [
+            createGithubRelease(102),
+            createGithubRelease(101),
+            createGithubRelease(100),
+            ...createGithubReleasePage(1, 97, null),
+        ];
+        const fetchMock = createPagedFetchMock([firstPage, secondPage, []]);
+        vi.stubGlobal('fetch', fetchMock);
+
+        const result = await new GithubEditorCatalogAdapter().fetchProvider(
+            'official-stable',
+            publishedAfter,
+        );
+
+        expect(result.releases).toHaveLength(102);
+        expect(result.lastPublishedAt).toBe(createPublishedAt(202));
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not use null publication dates as a boundary', async () => {
+        const publishedAfter = createPublishedAt(100);
+        const fetchMock = createPagedFetchMock([
+            createGithubReleasePage(1, 100, null),
+            [],
+        ]);
+        vi.stubGlobal('fetch', fetchMock);
+
+        const result = await new GithubEditorCatalogAdapter().fetchProvider(
+            'official-stable',
+            publishedAfter,
+        );
+
+        expect(result.releases).toEqual([]);
+        expect(result.lastPublishedAt).toBe(publishedAfter);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('keeps the page limit as the final pagination guard', async () => {
+        const fullPage = createGithubReleasePage(1, 100, null);
+        const fetchMock = vi.fn(async () => Response.json(fullPage));
+        vi.stubGlobal('fetch', fetchMock);
+
+        const result = await new GithubEditorCatalogAdapter().fetchProvider(
+            'official-stable',
+            null,
+        );
+
+        expect(result.releases).toEqual([]);
+        expect(result.lastPublishedAt).toBeNull();
+        expect(fetchMock).toHaveBeenCalledTimes(100);
     });
 
     it('throws a useful response error', async () => {
@@ -62,3 +144,79 @@ describe('GithubEditorCatalogAdapter', () => {
         ).rejects.toThrow('Failed to fetch editor catalog: 403; rate limited');
     });
 });
+
+/** Raw GitHub release response used by adapter tests. */
+type GithubReleaseResponse = ReturnType<typeof createGithubRelease>;
+
+/**
+ * Creates a fetch mock that returns one GitHub response page per call.
+ *
+ * @param pages - The response pages to return in order.
+ * @returns A fetch mock for the configured pages.
+ */
+function createPagedFetchMock(pages: GithubReleaseResponse[][]) {
+    let pageIndex = 0;
+    return vi.fn(async () => Response.json(pages[pageIndex++] ?? []));
+}
+
+/**
+ * Creates a page of GitHub release responses.
+ *
+ * @param startId - The first release ID and version component.
+ * @param length - The number of releases to create.
+ * @param publishedAt - Fixed publication time, or undefined to derive it from each ID.
+ * @returns A page of GitHub release responses.
+ */
+function createGithubReleasePage(
+    startId: number,
+    length: number,
+    publishedAt?: string | null,
+): GithubReleaseResponse[] {
+    return Array.from({ length }, (_, index) =>
+        createGithubRelease(
+            startId + index,
+            publishedAt === undefined
+                ? createPublishedAt(startId + index)
+                : publishedAt,
+        ),
+    );
+}
+
+/**
+ * Creates one valid GitHub release response.
+ *
+ * @param id - The release ID and version component.
+ * @param publishedAt - The release publication time.
+ * @returns A valid GitHub release response.
+ */
+function createGithubRelease(
+    id: number,
+    publishedAt: string | null = createPublishedAt(id),
+) {
+    const tag = `4.${id}-stable`;
+    return {
+        id,
+        name: `Godot ${tag}`,
+        tag_name: tag,
+        published_at: publishedAt,
+        draft: false,
+        prerelease: false,
+        assets: [
+            {
+                id,
+                name: `Godot_v${tag}_win64.exe.zip`,
+                browser_download_url: `https://example.com/${tag}.zip`,
+            },
+        ],
+    };
+}
+
+/**
+ * Creates a stable ISO publication time from a numeric offset.
+ *
+ * @param offset - The number of days after the test epoch.
+ * @returns The derived ISO publication time.
+ */
+function createPublishedAt(offset: number): string {
+    return new Date(Date.UTC(2020, 0, 1 + offset)).toISOString();
+}

--- a/main/src/editor-catalog/github-editor-catalog.adapter.ts
+++ b/main/src/editor-catalog/github-editor-catalog.adapter.ts
@@ -44,7 +44,11 @@ export class GithubEditorCatalogAdapter {
         publishedAfter: string | null,
     ): Promise<FetchedEditorCatalogProvider> {
         const provider = EDITOR_CATALOG_PROVIDERS[providerId];
-        const releases: GithubEditorRelease[] = [];
+        const releases: FetchedEditorCatalogProvider['releases'] = [];
+        const afterTime = publishedAfter
+            ? new Date(publishedAfter).getTime()
+            : 0;
+        let latestPublishedAt = publishedAfter;
 
         for (let page = 1; page <= EDITOR_CATALOG_PAGE_LIMIT; page += 1) {
             const url = new URL(
@@ -66,40 +70,47 @@ export class GithubEditorCatalogAdapter {
                 .array(GithubReleaseSchema)
                 .parse(await response.json())
                 .map(toGithubEditorRelease);
-            releases.push(...pageReleases);
+            const reachedBoundary =
+                publishedAfter !== null &&
+                pageReleases.some((release) => {
+                    if (!release.publishedAt) {
+                        return false;
+                    }
+                    return new Date(release.publishedAt).getTime() <= afterTime;
+                });
+            const mappedPage = pageReleases
+                .filter((release) => {
+                    if (!release.publishedAt) {
+                        return false;
+                    }
+                    return new Date(release.publishedAt).getTime() > afterTime;
+                })
+                .map((release) =>
+                    mapGithubEditorRelease(
+                        providerId,
+                        provider.prerelease,
+                        release,
+                    ),
+                )
+                .filter((release) => release !== null);
+            releases.push(...mappedPage);
+            latestPublishedAt = mappedPage.reduce<string | null>(
+                (latest, release) => laterDate(latest, release.publishedAt),
+                latestPublishedAt,
+            );
 
-            if (pageReleases.length < EDITOR_CATALOG_PAGE_SIZE) {
+            if (
+                pageReleases.length < EDITOR_CATALOG_PAGE_SIZE ||
+                reachedBoundary
+            ) {
                 break;
             }
         }
 
-        const afterTime = publishedAfter
-            ? new Date(publishedAfter).getTime()
-            : 0;
-        const mapped = releases
-            .filter((release) => {
-                const publishedTime = release.publishedAt
-                    ? new Date(release.publishedAt).getTime()
-                    : 0;
-                return publishedTime > afterTime;
-            })
-            .map((release) =>
-                mapGithubEditorRelease(
-                    providerId,
-                    provider.prerelease,
-                    release,
-                ),
-            )
-            .filter((release) => release !== null);
-        const latestPublishedAt = mapped.reduce<string | null>(
-            (latest, release) => laterDate(latest, release.publishedAt),
-            publishedAfter,
-        );
-
         return {
             providerId,
             lastPublishedAt: latestPublishedAt,
-            releases: mapped,
+            releases,
         };
     }
 }


### PR DESCRIPTION
- Stop GitHub release pagination after processing the page that reaches the cached releases.
- Preserve full pagination when building the catalog for the first time.
- Refresh only stale providers during automatic catalog refreshes.
- Preserve explicit all provider reloads, including when another refresh is already active.
