### PR TITLE
chore(media): stabilize documentation screenshot capture

### DIFF
--- a/e2e/documentationScreenshots/screenshots.installs.ts
+++ b/e2e/documentationScreenshots/screenshots.installs.ts
@@ -49,6 +49,13 @@ const DOWNLOAD_ERROR_SCREENSHOTS: ScreenshotConfig[] = [
         visibleError: "GitHub's download service is temporarily unavailable.",
         externalLinkLabel: 'githubstatus.com',
     }),
+    createDownloadErrorScreenshot({
+        fileBase: 'screen_installs_archive_integrity_mismatch',
+        description: 'Install New Version view with archive integrity mismatch',
+        error: 'The downloaded editor archive failed its integrity check and was not installed.',
+        visibleError:
+            'The downloaded editor archive failed its integrity check and was not installed.',
+    }),
 ];
 
 export const INSTALLS_SCREENSHOTS: ScreenshotConfig[] = [

--- a/main/src/app-lifecycle.service.test.ts
+++ b/main/src/app-lifecycle.service.test.ts
@@ -130,7 +130,11 @@ describe('AppLifecycleService', () => {
     const onActivate = vi.fn();
     const offActivate = vi.fn();
     const configService = {
-        getAll: vi.fn(() => ({ isDev: false, startHidden: false })),
+        getAll: vi.fn(() => ({
+            isDev: false,
+            startHidden: false,
+            docsScreenshots: false,
+        })),
     };
     const electronAppService = {
         clearApplicationMenu: vi.fn(),
@@ -203,6 +207,7 @@ describe('AppLifecycleService', () => {
         configService.getAll.mockReturnValue({
             isDev: false,
             startHidden: false,
+            docsScreenshots: false,
         });
         mocks.getUserPreferences.mockResolvedValue({ ...defaultPreferences });
         mocks.launchProject.mockResolvedValue({ launched: true });
@@ -270,6 +275,10 @@ describe('AppLifecycleService', () => {
 
         await initializeLifecycle(service);
 
+        expect(mocks.setupFocusRevalidation).toHaveBeenCalledWith(
+            mainWindow,
+            expect.any(Function),
+        );
         expect(windowManager.revealMainWindow).not.toHaveBeenCalled();
 
         service.revealInitialWindow();
@@ -278,10 +287,24 @@ describe('AppLifecycleService', () => {
         expect(windowManager.revealMainWindow).toHaveBeenCalledOnce();
     });
 
+    it('does not install focus revalidation for documentation screenshots', async () => {
+        configService.getAll.mockReturnValue({
+            isDev: false,
+            startHidden: false,
+            docsScreenshots: true,
+        });
+        const service = createService();
+
+        await initializeLifecycle(service);
+
+        expect(mocks.setupFocusRevalidation).not.toHaveBeenCalled();
+    });
+
     it('keeps a hidden launch hidden after the renderer is ready', async () => {
         configService.getAll.mockReturnValue({
             isDev: false,
             startHidden: true,
+            docsScreenshots: false,
         });
         const service = createService();
 
@@ -296,6 +319,7 @@ describe('AppLifecycleService', () => {
         configService.getAll.mockReturnValue({
             isDev: false,
             startHidden: true,
+            docsScreenshots: false,
         });
         trayAvailabilityService.isAvailable.mockResolvedValue(false);
         const service = createService();

--- a/main/src/app-lifecycle.service.ts
+++ b/main/src/app-lifecycle.service.ts
@@ -158,9 +158,13 @@ export class AppLifecycleService implements OnModuleInit, OnModuleDestroy {
             },
         );
 
-        this.disposeFocusRevalidation = setupFocusRevalidation(mainWindow, () =>
-            this.codeEditorIntegrationService.revalidateIntegrationSettings(),
-        );
+        if (!this.config.docsScreenshots) {
+            this.disposeFocusRevalidation = setupFocusRevalidation(
+                mainWindow,
+                () =>
+                    this.codeEditorIntegrationService.revalidateIntegrationSettings(),
+            );
+        }
         electronAutoUpdater.on(
             'before-quit-for-update',
             this.handleBeforeQuitForUpdate,


### PR DESCRIPTION
- prevent focus revalidation from interrupting documentation screenshot capture
- add coverage for screenshot-mode lifecycle behaviour
- add the archive integrity mismatch screenshot scenario
