### PR TITLE
Fix: prevent nested git repositories

### DIFF
--- a/e2e/documentationScreenshots/runtime.ts
+++ b/e2e/documentationScreenshots/runtime.ts
@@ -13,6 +13,7 @@ import type {
     AppUpdateMessage,
     CodeEditorIntegrationSettings,
     GitIdentity,
+    InitializeProjectGitResult,
     EditorCatalogArchitecture,
     EditorCatalogPlatform,
     EditorCatalogRelease,
@@ -671,6 +672,30 @@ export async function stubProjectGitInitializationFailure(
             },
         }));
     }, error);
+}
+
+/**
+ * Stubs a successful project Git initialization result.
+ *
+ * @param electronApp - The Electron app whose handler should be replaced.
+ * @param result - Structured Git initialization result returned to the renderer.
+ * @returns A promise that ends when the handler is ready.
+ */
+export async function stubProjectGitInitializationResult(
+    electronApp: ElectronApplication,
+    result: InitializeProjectGitResult,
+) {
+    await electronApp.evaluate(
+        ({ ipcMain }, injectedResult: InitializeProjectGitResult) => {
+            const channel = 'app.initializeProjectGit';
+            ipcMain.removeHandler(channel);
+            ipcMain.handle(channel, async () => ({
+                success: true,
+                data: injectedResult,
+            }));
+        },
+        result,
+    );
 }
 
 export async function stubCodeEditorIntegrationRescan(

--- a/e2e/documentationScreenshots/screenshots.projects.ts
+++ b/e2e/documentationScreenshots/screenshots.projects.ts
@@ -13,6 +13,7 @@ import {
     stubCodeEditorIntegrationSettings,
     stubGlobalGitIdentity,
     stubProjectGitInitializationFailure,
+    stubProjectGitInitializationResult,
     stubToolIntegrations,
 } from './runtime';
 import {
@@ -542,6 +543,72 @@ export const PROJECT_SCREENSHOTS: ScreenshotConfig[] = [
             electronApp: ElectronApplication,
             theme: ThemeConfig,
         ) => {
+            await page.keyboard.press('Escape');
+            await page.waitForTimeout(200);
+            await prepareAppWithStubbedData(page, electronApp);
+            await applyTheme(page, theme);
+        },
+    },
+    {
+        fileBase:
+            'screen_projects_settings_source_control_existing_repository',
+        description: 'Project settings existing Git repository notice',
+        navigate: async (
+            page: ElectronPage,
+            electronApp: ElectronApplication,
+            theme: ThemeConfig,
+        ) => {
+            await prepareAppWithStubbedData(page, electronApp);
+            await stubProjectGitInitializationResult(electronApp, {
+                project: {
+                    ...SAMPLE_PROJECT_PROTOTYPE,
+                    withGit: true,
+                },
+                gitSetup: {
+                    status: 'existing-repository',
+                    root: '/Users/docs/Godot/Projects',
+                    isProjectRoot: false,
+                    kind: 'standard',
+                },
+            });
+            await applyTheme(page, theme);
+            await page.getByTestId('btnProjects').click();
+            const projectCard = page
+                .locator('[data-project-path]')
+                .filter({
+                    has: page.getByText(SAMPLE_PROJECT_PROTOTYPE.name, {
+                        exact: true,
+                    }),
+                })
+                .first();
+            await projectCard.getByTestId('btnProjectSettings').click();
+            await page
+                .getByTestId('tabProjectSettings_sourceControl')
+                .click();
+            await page
+                .getByRole('button', {
+                    name: 'Initialize Git',
+                    exact: true,
+                })
+                .click();
+            const notice = page.getByRole('dialog', {
+                name: 'Existing Git repository detected',
+            });
+            await expect(notice).toBeVisible({ timeout: 10000 });
+            await expect(notice).toContainText(
+                'This project is already covered by the Git repository at /Users/docs/Godot/Projects. No Git setup changes were made.',
+            );
+            await page.waitForTimeout(400);
+        },
+        cleanup: async (
+            page: ElectronPage,
+            electronApp: ElectronApplication,
+            theme: ThemeConfig,
+        ) => {
+            const okButton = page.getByTestId('btnAlertOk');
+            if (await okButton.isVisible().catch(() => false)) {
+                await okButton.click();
+            }
             await page.keyboard.press('Escape');
             await page.waitForTimeout(200);
             await prepareAppWithStubbedData(page, electronApp);

--- a/e2e/documentationScreenshots/screenshots.projects.ts
+++ b/e2e/documentationScreenshots/screenshots.projects.ts
@@ -598,6 +598,10 @@ export const PROJECT_SCREENSHOTS: ScreenshotConfig[] = [
             await expect(notice).toContainText(
                 'This project is already covered by the Git repository at /Users/docs/Godot/Projects. No Git setup changes were made.',
             );
+            await expect(
+                page.getByTestId('tabProjectSettings_sourceControl'),
+            ).toHaveAttribute('aria-selected', 'true');
+            await expect(page.getByTestId('projectGitActive')).toBeVisible();
             await page.waitForTimeout(400);
         },
         cleanup: async (

--- a/locales/de/projects.json
+++ b/locales/de/projects.json
@@ -161,7 +161,10 @@
             "active": "Aktiv",
             "initialize": "Git initialisieren",
             "initializing": "Wird initialisiert...",
-            "initFailed": "Git konnte nicht initialisiert werden."
+            "initFailed": "Git konnte nicht initialisiert werden.",
+            "existingRepositoryTitle": "Vorhandenes Git-Repository erkannt",
+            "existingRepositoryRoot": "Dieses Projekt ist bereits ein Git-Repository. Es wurden keine Änderungen an der Git-Einrichtung vorgenommen.",
+            "existingRepositoryParent": "Dieses Projekt wird bereits durch das Git-Repository unter {{root}} verwaltet. Es wurden keine Änderungen an der Git-Einrichtung vorgenommen."
         },
         "launch": {
             "title": "Starten",

--- a/locales/en/projects.json
+++ b/locales/en/projects.json
@@ -161,7 +161,10 @@
             "active": "Active",
             "initialize": "Initialize Git",
             "initializing": "Initializing...",
-            "initFailed": "Could not initialize Git."
+            "initFailed": "Could not initialize Git.",
+            "existingRepositoryTitle": "Existing Git repository detected",
+            "existingRepositoryRoot": "This project is already a Git repository. No Git setup changes were made.",
+            "existingRepositoryParent": "This project is already covered by the Git repository at {{root}}. No Git setup changes were made."
         },
         "launch": {
             "title": "Launch",

--- a/locales/es/projects.json
+++ b/locales/es/projects.json
@@ -161,7 +161,10 @@
             "active": "Activo",
             "initialize": "Inicializar Git",
             "initializing": "Inicializando...",
-            "initFailed": "No se pudo inicializar Git."
+            "initFailed": "No se pudo inicializar Git.",
+            "existingRepositoryTitle": "Se detectó un repositorio de Git existente",
+            "existingRepositoryRoot": "Este proyecto ya es un repositorio de Git. No se realizaron cambios en la configuración de Git.",
+            "existingRepositoryParent": "Este proyecto ya está incluido en el repositorio de Git de {{root}}. No se realizaron cambios en la configuración de Git."
         },
         "launch": {
             "title": "Inicio",

--- a/locales/fr/projects.json
+++ b/locales/fr/projects.json
@@ -161,7 +161,10 @@
             "active": "Actif",
             "initialize": "Initialiser Git",
             "initializing": "Initialisation...",
-            "initFailed": "Impossible d'initialiser Git."
+            "initFailed": "Impossible d'initialiser Git.",
+            "existingRepositoryTitle": "Dépôt Git existant détecté",
+            "existingRepositoryRoot": "Ce projet est déjà un dépôt Git. Aucune modification de la configuration Git n'a été effectuée.",
+            "existingRepositoryParent": "Ce projet est déjà couvert par le dépôt Git situé dans {{root}}. Aucune modification de la configuration Git n'a été effectuée."
         },
         "launch": {
             "title": "Lancement",

--- a/locales/it/projects.json
+++ b/locales/it/projects.json
@@ -161,7 +161,10 @@
             "active": "Attivo",
             "initialize": "Inizializza Git",
             "initializing": "Inizializzazione...",
-            "initFailed": "Impossibile inizializzare Git."
+            "initFailed": "Impossibile inizializzare Git.",
+            "existingRepositoryTitle": "Rilevato un repository Git esistente",
+            "existingRepositoryRoot": "Questo progetto è già un repository Git. Non sono state apportate modifiche alla configurazione di Git.",
+            "existingRepositoryParent": "Questo progetto è già incluso nel repository Git in {{root}}. Non sono state apportate modifiche alla configurazione di Git."
         },
         "launch": {
             "title": "Avvio",

--- a/locales/ja/projects.json
+++ b/locales/ja/projects.json
@@ -161,7 +161,10 @@
             "active": "有効",
             "initialize": "Git を初期化",
             "initializing": "初期化中...",
-            "initFailed": "Git を初期化できませんでした。"
+            "initFailed": "Git を初期化できませんでした。",
+            "existingRepositoryTitle": "既存の Git リポジトリを検出しました",
+            "existingRepositoryRoot": "このプロジェクトはすでに Git リポジトリです。Git の設定は変更されませんでした。",
+            "existingRepositoryParent": "このプロジェクトはすでに {{root}} の Git リポジトリに含まれています。Git の設定は変更されませんでした。"
         },
         "launch": {
             "title": "起動",

--- a/locales/mt/projects.json
+++ b/locales/mt/projects.json
@@ -161,7 +161,10 @@
             "active": "Attiv",
             "initialize": "Inizjalizza Git",
             "initializing": "Qed jiġi inizjalizzat...",
-            "initFailed": "Ma setax jiġi inizjalizzat Git."
+            "initFailed": "Ma setax jiġi inizjalizzat Git.",
+            "existingRepositoryTitle": "Instab repożitorju Git eżistenti",
+            "existingRepositoryRoot": "Dan il-proġett diġà huwa repożitorju Git. Ma sar l-ebda tibdil fis-setup ta' Git.",
+            "existingRepositoryParent": "Dan il-proġett diġà jinsab fir-repożitorju Git f'{{root}}. Ma sar l-ebda tibdil fis-setup ta' Git."
         },
         "launch": {
             "title": "Tnedija",

--- a/locales/pl/projects.json
+++ b/locales/pl/projects.json
@@ -161,7 +161,10 @@
             "active": "Aktywne",
             "initialize": "Zainicjalizuj Git",
             "initializing": "Inicjalizowanie...",
-            "initFailed": "Nie można zainicjalizować Git."
+            "initFailed": "Nie można zainicjalizować Git.",
+            "existingRepositoryTitle": "Wykryto istniejące repozytorium Git",
+            "existingRepositoryRoot": "Ten projekt jest już repozytorium Git. Nie wprowadzono żadnych zmian w konfiguracji Git.",
+            "existingRepositoryParent": "Ten projekt znajduje się już w repozytorium Git w {{root}}. Nie wprowadzono żadnych zmian w konfiguracji Git."
         },
         "launch": {
             "title": "Uruchamianie",

--- a/locales/pt-BR/projects.json
+++ b/locales/pt-BR/projects.json
@@ -161,7 +161,10 @@
             "active": "Ativo",
             "initialize": "Inicializar Git",
             "initializing": "Inicializando...",
-            "initFailed": "Não foi possível inicializar o Git."
+            "initFailed": "Não foi possível inicializar o Git.",
+            "existingRepositoryTitle": "Repositório Git existente detectado",
+            "existingRepositoryRoot": "Este projeto já é um repositório Git. Nenhuma alteração foi feita na configuração do Git.",
+            "existingRepositoryParent": "Este projeto já está incluído no repositório Git em {{root}}. Nenhuma alteração foi feita na configuração do Git."
         },
         "launch": {
             "title": "Inicialização",

--- a/locales/pt/projects.json
+++ b/locales/pt/projects.json
@@ -161,7 +161,10 @@
             "active": "Ativo",
             "initialize": "Inicializar Git",
             "initializing": "A inicializar...",
-            "initFailed": "Não foi possível inicializar o Git."
+            "initFailed": "Não foi possível inicializar o Git.",
+            "existingRepositoryTitle": "Repositório Git existente detetado",
+            "existingRepositoryRoot": "Este projeto já é um repositório Git. Não foram efetuadas alterações à configuração do Git.",
+            "existingRepositoryParent": "Este projeto já está incluído no repositório Git em {{root}}. Não foram efetuadas alterações à configuração do Git."
         },
         "launch": {
             "title": "Arranque",

--- a/locales/ru/projects.json
+++ b/locales/ru/projects.json
@@ -161,7 +161,10 @@
             "active": "Активен",
             "initialize": "Инициализировать Git",
             "initializing": "Инициализация...",
-            "initFailed": "Не удалось инициализировать Git."
+            "initFailed": "Не удалось инициализировать Git.",
+            "existingRepositoryTitle": "Обнаружен существующий репозиторий Git",
+            "existingRepositoryRoot": "Этот проект уже является репозиторием Git. Настройки Git не были изменены.",
+            "existingRepositoryParent": "Этот проект уже находится в репозитории Git по адресу {{root}}. Настройки Git не были изменены."
         },
         "launch": {
             "title": "Запуск",

--- a/locales/tr/projects.json
+++ b/locales/tr/projects.json
@@ -161,7 +161,10 @@
             "active": "Etkin",
             "initialize": "Git'i başlat",
             "initializing": "Başlatılıyor...",
-            "initFailed": "Git başlatılamadı."
+            "initFailed": "Git başlatılamadı.",
+            "existingRepositoryTitle": "Mevcut bir Git deposu algılandı",
+            "existingRepositoryRoot": "Bu proje zaten bir Git deposudur. Git kurulumunda değişiklik yapılmadı.",
+            "existingRepositoryParent": "Bu proje zaten {{root}} konumundaki Git deposunun kapsamındadır. Git kurulumunda değişiklik yapılmadı."
         },
         "launch": {
             "title": "Başlatma",

--- a/locales/zh-CN/projects.json
+++ b/locales/zh-CN/projects.json
@@ -161,7 +161,10 @@
             "active": "已启用",
             "initialize": "初始化 Git",
             "initializing": "正在初始化...",
-            "initFailed": "无法初始化 Git。"
+            "initFailed": "无法初始化 Git。",
+            "existingRepositoryTitle": "检测到现有 Git 仓库",
+            "existingRepositoryRoot": "此项目已经是 Git 仓库。未对 Git 设置进行任何更改。",
+            "existingRepositoryParent": "此项目已包含在 {{root}} 的 Git 仓库中。未对 Git 设置进行任何更改。"
         },
         "launch": {
             "title": "启动",

--- a/locales/zh-TW/projects.json
+++ b/locales/zh-TW/projects.json
@@ -161,7 +161,10 @@
             "active": "已啟用",
             "initialize": "初始化 Git",
             "initializing": "正在初始化...",
-            "initFailed": "無法初始化 Git。"
+            "initFailed": "無法初始化 Git。",
+            "existingRepositoryTitle": "偵測到現有 Git 儲存庫",
+            "existingRepositoryRoot": "此專案已經是 Git 儲存庫。未對 Git 設定進行任何變更。",
+            "existingRepositoryParent": "此專案已包含在 {{root}} 的 Git 儲存庫中。未對 Git 設定進行任何變更。"
         },
         "launch": {
             "title": "啟動",

--- a/main/src/app-lifecycle.service.test.ts
+++ b/main/src/app-lifecycle.service.test.ts
@@ -161,6 +161,9 @@ describe('AppLifecycleService', () => {
     const toolIntegrationService = {
         refreshAll: vi.fn(),
     };
+    const gitService = {
+        inspectRepository: vi.fn(),
+    };
 
     const trayAvailabilityService = {
         isAvailable: vi.fn(async () => true),
@@ -174,6 +177,7 @@ describe('AppLifecycleService', () => {
             i18nService as never,
             codeEditorIntegrationService as never,
             toolIntegrationService as never,
+            gitService as never,
             trayAvailabilityService as never,
         );
     }
@@ -278,6 +282,7 @@ describe('AppLifecycleService', () => {
         expect(mocks.setupFocusRevalidation).toHaveBeenCalledWith(
             mainWindow,
             expect.any(Function),
+            gitService,
         );
         expect(windowManager.revealMainWindow).not.toHaveBeenCalled();
 

--- a/main/src/app-lifecycle.service.ts
+++ b/main/src/app-lifecycle.service.ts
@@ -35,6 +35,8 @@ import { getAppIconPath } from './pathResolver.js';
 // biome-ignore lint/style/useImportType: Required for DI constructor metadata
 import { TrayAvailabilityService } from './services/tray-availability.service.js';
 // biome-ignore lint/style/useImportType: Required for DI constructor metadata
+import { GitService } from './tool-integration/integrations/git/git.service.js';
+// biome-ignore lint/style/useImportType: Required for DI constructor metadata
 import { ToolIntegrationService } from './tool-integration/tool-integration.service.js';
 import { setAutoStart } from './utils/platform.utils.js';
 import { ensurePreferencesStorage } from './utils/prefs.utils.js';
@@ -55,6 +57,7 @@ export class AppLifecycleService implements OnModuleInit, OnModuleDestroy {
      * @param i18nService - Main-process localization service.
      * @param codeEditorIntegrationService - Code editor lifecycle facade.
      * @param toolIntegrationService - Command-line tool lifecycle facade.
+     * @param gitService - Git repository inspection service.
      * @param trayAvailabilityService - System tray availability service.
      */
     constructor(
@@ -64,6 +67,7 @@ export class AppLifecycleService implements OnModuleInit, OnModuleDestroy {
         private readonly i18nService: I18nService,
         private readonly codeEditorIntegrationService: CodeEditorIntegrationService,
         private readonly toolIntegrationService: ToolIntegrationService,
+        private readonly gitService: GitService,
         private readonly trayAvailabilityService: TrayAvailabilityService,
     ) {}
 
@@ -100,7 +104,7 @@ export class AppLifecycleService implements OnModuleInit, OnModuleDestroy {
         );
 
         logger.debug('App ready, checking projects and releases');
-        await checkAndUpdateProjects();
+        await checkAndUpdateProjects({}, this.gitService);
         await checkAndUpdateReleases();
     }
 
@@ -163,6 +167,7 @@ export class AppLifecycleService implements OnModuleInit, OnModuleDestroy {
                 mainWindow,
                 () =>
                     this.codeEditorIntegrationService.revalidateIntegrationSettings(),
+                this.gitService,
             );
         }
         electronAutoUpdater.on(

--- a/main/src/app.controller.ts
+++ b/main/src/app.controller.ts
@@ -323,6 +323,7 @@ export class AppController implements AppBridge {
             projectPath,
             this.codeEditorIntegrationService,
             options,
+            this.gitService,
         );
     }
 
@@ -397,12 +398,12 @@ export class AppController implements AppBridge {
 
     @AppHandler('checkProjectValid')
     checkProjectValid(project: ProjectDetails) {
-        return checkProjectIsValid(project);
+        return checkProjectIsValid(project, this.gitService);
     }
 
     @AppHandler('checkAllProjectsValid')
     checkAllProjectsValid() {
-        return checkAndUpdateProjects();
+        return checkAndUpdateProjects({}, this.gitService);
     }
 
     @AppHandler('getPlatform')

--- a/main/src/checks.test.ts
+++ b/main/src/checks.test.ts
@@ -418,7 +418,7 @@ config/icon="res://assets/icon.svg"
         fs.rmSync(releaseDir, { recursive: true, force: true });
     });
 
-    it('updates withGit flag based on .git directory presence', async () => {
+    it('updates withGit from repository inspection', async () => {
         const projectDir = fs.mkdtempSync(
             path.join(os.tmpdir(), 'launcher-project-git-'),
         );
@@ -461,9 +461,22 @@ config/icon="res://assets/icon.svg"
         fs.writeFileSync(project.launch_path, '');
         fs.writeFileSync(project.release.editor_path, '');
 
-        const validatedProject = await checkProjectValid(project);
+        const gitService = {
+            inspectRepository: vi.fn().mockResolvedValue({
+                status: 'inside-work-tree',
+                root: projectDir,
+                isProjectRoot: true,
+                kind: 'standard',
+            }),
+        };
+        const validatedProject = await checkProjectValid(
+            project,
+            {},
+            gitService as never,
+        );
 
         expect(validatedProject.withGit).toBe(true);
+        expect(gitService.inspectRepository).toHaveBeenCalledWith(projectDir);
 
         fs.rmSync(projectDir, { recursive: true, force: true });
         fs.rmSync(releaseDir, { recursive: true, force: true });

--- a/main/src/checks.ts
+++ b/main/src/checks.ts
@@ -5,6 +5,7 @@ import logger from 'electron-log';
 
 import { getCurrentAppConfig } from './config/index.js';
 import { PROJECTS_FILENAME } from './constants.js';
+import type { GitService } from './tool-integration/integrations/git/git.service.js';
 import { SetProjectEditorRelease } from './utils/godot.utils.js';
 import {
     getProjectIconUrlFromParsed,
@@ -88,8 +89,16 @@ export async function checkAndUpdateReleases(): Promise<InstalledRelease[]> {
     return await saveStoredInstalledReleases(dedupeInstalledReleases(releases));
 }
 
+/**
+ * Revalidates stored projects and persists their current state.
+ *
+ * @param options - Project validation behavior.
+ * @param gitService - Optional Git service for repository inspection.
+ * @returns The validated project list.
+ */
 export async function checkAndUpdateProjects(
     options: ProjectValidationOptions = {},
+    gitService?: GitService,
 ): Promise<ProjectDetails[]> {
     logger.info('Checking and updating projects');
 
@@ -105,7 +114,9 @@ export async function checkAndUpdateProjects(
         const validated: ProjectDetails[] = [];
 
         for (const project of projects) {
-            validated.push(await checkProjectValid(project, options));
+            validated.push(
+                await checkProjectValid(project, options, gitService),
+            );
         }
 
         try {
@@ -129,9 +140,18 @@ export async function checkAndUpdateProjects(
     );
 }
 
+/**
+ * Revalidates one project and refreshes its derived metadata.
+ *
+ * @param project - Project details to validate.
+ * @param options - Project validation behavior.
+ * @param gitService - Optional Git service for repository inspection.
+ * @returns The updated project details.
+ */
 export async function checkProjectValid(
     project: ProjectDetails,
     options: ProjectValidationOptions = {},
+    gitService?: GitService,
 ): Promise<ProjectDetails> {
     if (getCurrentAppConfig().docsScreenshots) {
         return project;
@@ -193,8 +213,15 @@ export async function checkProjectValid(
         project.release.valid = true;
     }
 
-    const gitDirPath = path.resolve(project.path, '.git');
-    project.withGit = await pathExistsForValidation(gitDirPath);
+    if (gitService) {
+        const gitInspection = await gitService.inspectRepository(project.path);
+        if (
+            gitInspection.status === 'inside-work-tree' ||
+            gitInspection.status === 'not-a-repository'
+        ) {
+            project.withGit = gitInspection.status === 'inside-work-tree';
+        }
+    }
 
     return project;
 }

--- a/main/src/commands/addProject.test.ts
+++ b/main/src/commands/addProject.test.ts
@@ -278,6 +278,30 @@ describe('addProject', () => {
         );
     });
 
+    it('marks an imported project as covered by an enclosing repository', async () => {
+        const gitService = {
+            inspectRepository: vi.fn().mockResolvedValue({
+                status: 'inside-work-tree',
+                root: '/fake',
+                isProjectRoot: false,
+                kind: 'standard',
+            }),
+        };
+
+        const result = await addProject(
+            '/fake/project/project.godot',
+            codeEditorIntegrationService,
+            {},
+            gitService as never,
+        );
+
+        expect(result.success).toBe(true);
+        expect(result.newProject?.withGit).toBe(true);
+        expect(gitService.inspectRepository).toHaveBeenCalledWith(
+            '/fake/project',
+        );
+    });
+
     it('sanitises only the imported editor directory name', async () => {
         getProjectNameFromParsed.mockResolvedValue('Example: Project');
 

--- a/main/src/commands/addProject.ts
+++ b/main/src/commands/addProject.ts
@@ -17,6 +17,7 @@ import {
     PROJECTS_FILENAME,
 } from '../constants.js';
 import { t } from '../i18n/index.js';
+import type { GitService } from '../tool-integration/integrations/git/git.service.js';
 import {
     DEFAULT_PROJECT_DEFINITION,
     getProjectDefinition,
@@ -184,10 +185,20 @@ function buildMissingRelease(
     };
 }
 
+/**
+ * Imports an existing Godot project into the Launcher project list.
+ *
+ * @param projectPath - Path to the project's project.godot file.
+ * @param codeEditorIntegrationService - Code editor integration service.
+ * @param options - Optional missing-editor resolution.
+ * @param gitService - Git service used to inspect repository coverage.
+ * @returns The project import result.
+ */
 export async function addProject(
     projectPath: string,
     codeEditorIntegrationService: CodeEditorIntegrationService,
     options: AddProjectOptions = {},
+    gitService?: GitService,
 ): Promise<AddProjectToListResult> {
     const { configDir } = getDefaultDirs();
     const projectListPath = path.resolve(configDir, PROJECTS_FILENAME);
@@ -439,7 +450,8 @@ export async function addProject(
         );
     }
 
-    const withGit = fs.existsSync(path.resolve(dirname, '.git'));
+    const gitInspection = await gitService?.inspectRepository(dirname);
+    const withGit = gitInspection?.status === 'inside-work-tree';
     const configuredIntegrationIds =
         await codeEditorIntegrationService.findConfiguredIntegrations(dirname);
     const codeEditorId =

--- a/main/src/commands/createProject.test.ts
+++ b/main/src/commands/createProject.test.ts
@@ -104,6 +104,7 @@ const gitServiceMocks = {
     addAndCommit: vi.fn(),
     exists: vi.fn(),
     init: vi.fn(),
+    inspectRepository: vi.fn(),
     renameBranch: vi.fn(),
     setIdentity: vi.fn(),
 };
@@ -172,6 +173,17 @@ describe('createProject', () => {
         gitServiceMocks.renameBranch.mockResolvedValue(true);
         gitServiceMocks.setIdentity.mockResolvedValue(true);
         gitServiceMocks.addAndCommit.mockResolvedValue(true);
+        gitServiceMocks.inspectRepository.mockImplementation(
+            async (projectPath: string) =>
+                gitServiceMocks.init.mock.calls.length === 0
+                    ? { status: 'not-a-repository' as const }
+                    : {
+                          status: 'inside-work-tree' as const,
+                          root: projectPath,
+                          isProjectRoot: true,
+                          kind: 'standard' as const,
+                      },
+        );
         userPreferencesMocks.getUserPreferences.mockResolvedValue({
             projects_location: '/projects',
             install_location: '/install',
@@ -317,7 +329,7 @@ describe('createProject', () => {
         );
     });
 
-    it('adds Git metadata before initializing and committing', async () => {
+    it('initializes Git before adding metadata and committing', async () => {
         const result = await createProject(
             'Git Project',
             release,
@@ -359,8 +371,8 @@ describe('createProject', () => {
             gitServiceMocks.renameBranch.mock.invocationCallOrder[0];
         const commitCallOrder =
             gitServiceMocks.addAndCommit.mock.invocationCallOrder[0];
-        expect(copyCallOrders[0]).toBeLessThan(initCallOrder);
-        expect(copyCallOrders[1]).toBeLessThan(initCallOrder);
+        expect(initCallOrder).toBeLessThan(copyCallOrders[0]);
+        expect(initCallOrder).toBeLessThan(copyCallOrders[1]);
         expect(launcherConfigCallOrder).toBeLessThan(initCallOrder);
         expect(initCallOrder).toBeLessThan(renameCallOrder);
         expect(renameCallOrder).toBeLessThan(commitCallOrder);
@@ -480,6 +492,11 @@ describe('createProject', () => {
         'cleans up when Git $stage fails',
         async ({ mock, expectedRename, expectedCommit }) => {
             mock.mockResolvedValueOnce(false);
+            if (mock === gitServiceMocks.init) {
+                gitServiceMocks.inspectRepository
+                    .mockResolvedValueOnce({ status: 'not-a-repository' })
+                    .mockResolvedValueOnce({ status: 'not-a-repository' });
+            }
 
             const result = await createProject(
                 'Failed Git',
@@ -567,6 +584,40 @@ describe('createProject', () => {
         expect(fsMocks.promises.copyFile).not.toHaveBeenCalled();
         expect(gitServiceMocks.exists).toHaveBeenCalledOnce();
         expect(gitServiceMocks.init).not.toHaveBeenCalled();
+        expect(gitServiceMocks.addAndCommit).not.toHaveBeenCalled();
+    });
+
+    it('uses an enclosing repository without performing Git mutations', async () => {
+        const projectPath = path.resolve('/projects/Parent/Git-Project');
+        gitServiceMocks.inspectRepository.mockResolvedValue({
+            status: 'inside-work-tree',
+            root: path.resolve('/projects/Parent'),
+            isProjectRoot: false,
+            kind: 'standard',
+        });
+
+        const result = await createProject(
+            'Git Project',
+            release,
+            'FORWARD_PLUS',
+            null,
+            true,
+            codeEditorIntegrationService,
+            projectPath,
+        );
+
+        expect(result.success).toBe(true);
+        expect(result.projectDetails?.withGit).toBe(true);
+        expect(result.gitSetup).toEqual({
+            status: 'existing-repository',
+            root: path.resolve('/projects/Parent'),
+            isProjectRoot: false,
+            kind: 'standard',
+        });
+        expect(fsMocks.promises.copyFile).not.toHaveBeenCalled();
+        expect(gitServiceMocks.init).not.toHaveBeenCalled();
+        expect(gitServiceMocks.renameBranch).not.toHaveBeenCalled();
+        expect(gitServiceMocks.setIdentity).not.toHaveBeenCalled();
         expect(gitServiceMocks.addAndCommit).not.toHaveBeenCalled();
     });
 

--- a/main/src/commands/createProject.ts
+++ b/main/src/commands/createProject.ts
@@ -4,7 +4,9 @@ import type {
     CodeEditorId,
     CreateProjectGitOptions,
     CreateProjectResult,
+    GitRepositoryInfo,
     InstalledRelease,
+    ProjectGitSetupOutcome,
     RendererType,
 } from '@shared/contracts';
 import { app } from 'electron';
@@ -37,6 +39,28 @@ import { addProjectToList } from '../utils/projects.utils.js';
 import { getUserPreferences } from './userPreferences.js';
 
 /**
+ * Verifies that a project directory is exactly its current repository root.
+ *
+ * @param gitService - Typed Git command service.
+ * @param projectPath - Project directory to inspect.
+ * @returns Information about the verified project repository.
+ */
+async function requireProjectRepositoryRoot(
+    gitService: GitService,
+    projectPath: string,
+): Promise<GitRepositoryInfo> {
+    const inspection = await gitService.inspectRepository(projectPath);
+    if (inspection.status !== 'inside-work-tree' || !inspection.isProjectRoot) {
+        throw new Error(t('createProject:errors.failedGitInit'));
+    }
+    return {
+        root: inspection.root,
+        isProjectRoot: inspection.isProjectRoot,
+        kind: inspection.kind,
+    };
+}
+
+/**
  * Creates a project and configures its selected editor integrations.
  *
  * @param projectName - Display name for the new project.
@@ -61,6 +85,7 @@ export async function createProject(
     overwriteProjectPath?: string,
     gitOptions?: CreateProjectGitOptions,
 ): Promise<CreateProjectResult> {
+    let gitSetup: ProjectGitSetupOutcome = { status: 'not-requested' };
     if (codeEditorId) {
         try {
             await codeEditorIntegrationService.assertIntegrationSelectable(
@@ -79,6 +104,7 @@ export async function createProject(
             'Create Project with Git, but Git is not installed. Setting withGit to false',
         );
         withGit = false;
+        gitSetup = { status: 'git-unavailable' };
     }
 
     projectName = projectName.trim();
@@ -207,56 +233,105 @@ export async function createProject(
             launcherVersion: app.getVersion(),
         });
 
-        // Add the recommended Git metadata and initialize the repository.
+        // Initialize only when the project is not already covered by a work tree.
         if (withGit) {
-            await fs.promises.copyFile(
-                path.resolve(projectResDir, 'default_gitignore'),
-                path.resolve(projectPath, '.gitignore'),
-            );
-            await fs.promises.copyFile(
-                path.resolve(projectResDir, 'default-gitattributes'),
-                path.resolve(projectPath, '.gitattributes'),
-            );
-            if (!(await gitService.init(projectPath))) {
+            let inspection = await gitService.inspectRepository(projectPath);
+            if (inspection.status === 'inspection-failed') {
                 throw new Error(t('createProject:errors.failedGitInit'));
             }
-            if (!(await gitService.renameBranch(projectPath))) {
-                throw new Error(t('createProject:errors.failedGitBranch'));
+            if (inspection.status === 'git-unavailable') {
+                withGit = false;
+                gitSetup = { status: 'git-unavailable' };
+            } else if (inspection.status === 'inside-work-tree') {
+                gitSetup = {
+                    status: 'existing-repository',
+                    root: inspection.root,
+                    isProjectRoot: inspection.isProjectRoot,
+                    kind: inspection.kind,
+                };
+            } else {
+                if (!(await gitService.init(projectPath))) {
+                    inspection =
+                        await gitService.inspectRepository(projectPath);
+                    if (inspection.status === 'inside-work-tree') {
+                        gitSetup = {
+                            status: 'existing-repository',
+                            root: inspection.root,
+                            isProjectRoot: inspection.isProjectRoot,
+                            kind: inspection.kind,
+                        };
+                    } else {
+                        throw new Error(
+                            t('createProject:errors.failedGitInit'),
+                        );
+                    }
+                } else {
+                    const repository = await requireProjectRepositoryRoot(
+                        gitService,
+                        projectPath,
+                    );
+                    gitSetup = {
+                        status: 'initialized',
+                        ...repository,
+                    };
+                }
             }
 
-            const resolvedGitOptions = gitOptions ?? {
-                initialCommit: 'create',
-            };
-            if (resolvedGitOptions.initialCommit === 'create') {
-                if (resolvedGitOptions.identity) {
-                    const name = resolvedGitOptions.identity.name.trim();
-                    const email = resolvedGitOptions.identity.email.trim();
-                    const { scope } = resolvedGitOptions.identity;
-                    if (
-                        !name ||
-                        !email ||
-                        (scope !== 'repository' && scope !== 'global')
-                    ) {
-                        throw new Error(
-                            t('createProject:errors.invalidGitIdentity'),
-                        );
-                    }
-                    if (
-                        !(await gitService.setIdentity(
-                            name,
-                            email,
-                            scope,
-                            projectPath,
-                        ))
-                    ) {
-                        throw new Error(
-                            t('createProject:errors.failedGitIdentity'),
-                        );
-                    }
+            if (gitSetup.status === 'initialized') {
+                await requireProjectRepositoryRoot(gitService, projectPath);
+                await fs.promises.copyFile(
+                    path.resolve(projectResDir, 'default_gitignore'),
+                    path.resolve(projectPath, '.gitignore'),
+                );
+                await requireProjectRepositoryRoot(gitService, projectPath);
+                await fs.promises.copyFile(
+                    path.resolve(projectResDir, 'default-gitattributes'),
+                    path.resolve(projectPath, '.gitattributes'),
+                );
+                if (!(await gitService.renameBranch(projectPath))) {
+                    throw new Error(t('createProject:errors.failedGitBranch'));
                 }
 
-                if (!(await gitService.addAndCommit(projectPath))) {
-                    throw new Error(t('createProject:errors.failedGitCommit'));
+                const resolvedGitOptions = gitOptions ?? {
+                    initialCommit: 'create',
+                };
+                if (resolvedGitOptions.initialCommit === 'create') {
+                    if (resolvedGitOptions.identity) {
+                        const name = resolvedGitOptions.identity.name.trim();
+                        const email = resolvedGitOptions.identity.email.trim();
+                        const { scope } = resolvedGitOptions.identity;
+                        if (
+                            !name ||
+                            !email ||
+                            (scope !== 'repository' && scope !== 'global')
+                        ) {
+                            throw new Error(
+                                t('createProject:errors.invalidGitIdentity'),
+                            );
+                        }
+                        await requireProjectRepositoryRoot(
+                            gitService,
+                            projectPath,
+                        );
+                        if (
+                            !(await gitService.setIdentity(
+                                name,
+                                email,
+                                scope,
+                                projectPath,
+                            ))
+                        ) {
+                            throw new Error(
+                                t('createProject:errors.failedGitIdentity'),
+                            );
+                        }
+                    }
+
+                    if (!(await gitService.addAndCommit(projectPath))) {
+                        throw new Error(
+                            t('createProject:errors.failedGitCommit'),
+                        );
+                    }
                 }
             }
         }
@@ -289,6 +364,7 @@ export async function createProject(
         const result: CreateProjectResult = {
             success: true,
             projectPath,
+            gitSetup,
             projectDetails: {
                 name: projectName,
                 version: release.version,

--- a/main/src/commands/projects.test.ts
+++ b/main/src/commands/projects.test.ts
@@ -198,10 +198,12 @@ const integrationMocks = codeEditorIntegrationService as unknown as {
 
 const gitService = {
     init: vi.fn(),
+    inspectRepository: vi.fn(),
 } as unknown as GitService;
 
 const gitServiceMocks = gitService as unknown as {
     init: ReturnType<typeof vi.fn>;
+    inspectRepository: ReturnType<typeof vi.fn>;
 };
 
 const trayAvailabilityService = {
@@ -1733,11 +1735,14 @@ describe('initializeProjectGit', () => {
         );
 
         gitServiceMocks.init.mockResolvedValue(true);
-        existsSync.mockImplementation(
-            (target: unknown) =>
-                typeof target === 'string' &&
-                target.endsWith(`${path.sep}.git`),
-        );
+        gitServiceMocks.inspectRepository
+            .mockResolvedValueOnce({ status: 'not-a-repository' })
+            .mockResolvedValueOnce({
+                status: 'inside-work-tree',
+                root: storedProject.path,
+                isProjectRoot: true,
+                kind: 'standard',
+            });
 
         const result = await initializeProjectGit(
             { ...storedProject },
@@ -1763,7 +1768,8 @@ describe('initializeProjectGit', () => {
                 }),
             ]),
         );
-        expect(result.withGit).toBe(true);
+        expect(result.project.withGit).toBe(true);
+        expect(result.gitSetup.status).toBe('initialized');
     });
 
     it('throws when git initialization fails', async () => {
@@ -1802,7 +1808,9 @@ describe('initializeProjectGit', () => {
             version: 'v1',
         });
         gitServiceMocks.init.mockResolvedValue(false);
-        existsSync.mockReturnValue(false);
+        gitServiceMocks.inspectRepository.mockResolvedValue({
+            status: 'not-a-repository',
+        });
 
         await expect(
             initializeProjectGit({ ...storedProject }, gitService),
@@ -1810,5 +1818,36 @@ describe('initializeProjectGit', () => {
 
         expect(storeProjectsList).not.toHaveBeenCalled();
         expect(ipcWebContentsSend).not.toHaveBeenCalled();
+    });
+
+    it('accepts an enclosing repository without initializing Git', async () => {
+        const storedProject = createProjectDetails({
+            path: '/projects/parent/demo',
+            withGit: false,
+        });
+        getProjectsSnapshot.mockResolvedValue({
+            projects: [storedProject],
+            version: 'v1',
+        });
+        storeProjectsList.mockImplementation(
+            async (_path, projects, _options) => projects,
+        );
+        gitServiceMocks.inspectRepository.mockResolvedValue({
+            status: 'inside-work-tree',
+            root: '/projects/parent',
+            isProjectRoot: false,
+            kind: 'standard',
+        });
+
+        const result = await initializeProjectGit(storedProject, gitService);
+
+        expect(result.project.withGit).toBe(true);
+        expect(result.gitSetup).toEqual({
+            status: 'existing-repository',
+            root: '/projects/parent',
+            isProjectRoot: false,
+            kind: 'standard',
+        });
+        expect(gitServiceMocks.init).not.toHaveBeenCalled();
     });
 });

--- a/main/src/commands/projects.ts
+++ b/main/src/commands/projects.ts
@@ -3,9 +3,9 @@ import {
     type ChildProcessByStdio,
     spawn,
 } from 'node:child_process';
-import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type {
+    InitializeProjectGitResult,
     LaunchProjectOptions,
     LaunchProjectResult,
     ProjectDetails,
@@ -298,10 +298,18 @@ export async function launchProject(
     return { launched: true };
 }
 
+/**
+ * Revalidates one project for an application bridge request.
+ *
+ * @param project - Project details to validate.
+ * @param gitService - Optional Git repository inspection service.
+ * @returns The updated project details.
+ */
 export async function checkProjectIsValid(
     project: ProjectDetails,
+    gitService?: GitService,
 ): Promise<ProjectDetails> {
-    return await checkProjectValid(project);
+    return await checkProjectValid(project, {}, gitService);
 }
 
 export async function setProjectWindowed(
@@ -613,7 +621,7 @@ export {
 export async function initializeProjectGit(
     project: ProjectDetails,
     gitService: GitService,
-): Promise<ProjectDetails> {
+): Promise<InitializeProjectGitResult> {
     const projectListPath = resolveProjectListPath();
 
     for (let attempt = 0; attempt < PROJECT_WRITE_MAX_ATTEMPTS; attempt++) {
@@ -631,16 +639,47 @@ export async function initializeProjectGit(
             release: { ...updatedProjects[projectIndex].release },
         };
 
-        if (targetProject.withGit) {
-            return targetProject;
-        }
-
-        const gitInitialized = await gitService.init(targetProject.path);
-        const gitFolderExists = fs.existsSync(
-            path.resolve(targetProject.path, '.git'),
-        );
-
-        if (!gitInitialized || !gitFolderExists) {
+        let inspection = await gitService.inspectRepository(targetProject.path);
+        let gitSetup: InitializeProjectGitResult['gitSetup'];
+        if (inspection.status === 'inside-work-tree') {
+            gitSetup = {
+                status: 'existing-repository',
+                root: inspection.root,
+                isProjectRoot: inspection.isProjectRoot,
+                kind: inspection.kind,
+            };
+        } else if (inspection.status === 'not-a-repository') {
+            if (!(await gitService.init(targetProject.path))) {
+                inspection = await gitService.inspectRepository(
+                    targetProject.path,
+                );
+                if (inspection.status !== 'inside-work-tree') {
+                    throw new Error(t('projects:initGit.errors.initFailed'));
+                }
+                gitSetup = {
+                    status: 'existing-repository',
+                    root: inspection.root,
+                    isProjectRoot: inspection.isProjectRoot,
+                    kind: inspection.kind,
+                };
+            } else {
+                inspection = await gitService.inspectRepository(
+                    targetProject.path,
+                );
+                if (
+                    inspection.status !== 'inside-work-tree' ||
+                    !inspection.isProjectRoot
+                ) {
+                    throw new Error(t('projects:initGit.errors.initFailed'));
+                }
+                gitSetup = {
+                    status: 'initialized',
+                    root: inspection.root,
+                    isProjectRoot: inspection.isProjectRoot,
+                    kind: inspection.kind,
+                };
+            }
+        } else {
             throw new Error(t('projects:initGit.errors.initFailed'));
         }
 
@@ -665,7 +704,7 @@ export async function initializeProjectGit(
 
             project.withGit = latestProject.withGit;
 
-            return latestProject;
+            return { project: latestProject, gitSetup };
         } catch (error) {
             if (
                 error instanceof JsonStoreConflictError &&

--- a/main/src/helpers/revalidate.helper.test.ts
+++ b/main/src/helpers/revalidate.helper.test.ts
@@ -61,6 +61,7 @@ const createMockBrowserWindow = () => {
 let mockWindow: ReturnType<typeof createMockBrowserWindow>;
 
 let refreshCodeEditorIntegrations: ReturnType<typeof vi.fn>;
+const gitService = { inspectRepository: vi.fn() };
 describe('setupFocusRevalidation', () => {
     beforeEach(() => {
         vi.useFakeTimers();
@@ -79,6 +80,7 @@ describe('setupFocusRevalidation', () => {
         const dispose = setupFocusRevalidation(
             mockWindow as unknown as BrowserWindow,
             refreshCodeEditorIntegrations,
+            gitService as never,
         );
 
         mockWindow.emit('focus');
@@ -89,9 +91,10 @@ describe('setupFocusRevalidation', () => {
         expect(moduleMocks.checkAndUpdateReleases).toHaveBeenCalledTimes(1);
         expect(moduleMocks.checkAndUpdateProjects).toHaveBeenCalledTimes(1);
         expect(refreshCodeEditorIntegrations).toHaveBeenCalledTimes(1);
-        expect(moduleMocks.checkAndUpdateProjects).toHaveBeenCalledWith({
-            repairMissingLaunchPath: false,
-        });
+        expect(moduleMocks.checkAndUpdateProjects).toHaveBeenCalledWith(
+            { repairMissingLaunchPath: false },
+            gitService,
+        );
 
         expect(moduleMocks.ipcWebContentsSend).toHaveBeenCalledWith(
             'releases-updated',
@@ -119,6 +122,7 @@ describe('setupFocusRevalidation', () => {
         const dispose = setupFocusRevalidation(
             mockWindow as unknown as BrowserWindow,
             refreshCodeEditorIntegrations,
+            gitService as never,
         );
 
         mockWindow.emit('focus');
@@ -142,6 +146,7 @@ describe('setupFocusRevalidation', () => {
         const dispose = setupFocusRevalidation(
             mockWindow as unknown as BrowserWindow,
             refreshCodeEditorIntegrations,
+            gitService as never,
         );
 
         mockWindow.emit('focus');

--- a/main/src/helpers/revalidate.helper.ts
+++ b/main/src/helpers/revalidate.helper.ts
@@ -3,6 +3,7 @@ import type { BrowserWindow } from 'electron';
 import logger from 'electron-log';
 
 import { checkAndUpdateProjects, checkAndUpdateReleases } from '../checks.js';
+import type { GitService } from '../tool-integration/integrations/git/git.service.js';
 import { ipcWebContentsSend } from '../utils.js';
 
 const FOCUS_DEBOUNCE_MS = 2000;
@@ -12,9 +13,18 @@ type RefreshCodeEditorIntegrations = () => Promise<
     CodeEditorIntegrationSettings[]
 >;
 
+/**
+ * Refreshes project, release, and code editor state for a visible window.
+ *
+ * @param targetWindow - Window that receives refreshed state.
+ * @param refreshCodeEditorIntegrations - Code editor refresh callback.
+ * @param gitService - Git repository inspection service.
+ * @returns A promise that resolves after revalidation.
+ */
 async function performRevalidation(
     targetWindow: BrowserWindow,
     refreshCodeEditorIntegrations: RefreshCodeEditorIntegrations,
+    gitService: GitService,
 ): Promise<void> {
     if (targetWindow.isDestroyed()) {
         logger.warn('Skipping revalidation: main window destroyed');
@@ -26,7 +36,10 @@ async function performRevalidation(
     try {
         const [releases, projects, codeEditorSettings] = await Promise.all([
             checkAndUpdateReleases(),
-            checkAndUpdateProjects({ repairMissingLaunchPath: false }),
+            checkAndUpdateProjects(
+                { repairMissingLaunchPath: false },
+                gitService,
+            ),
             refreshCodeEditorIntegrations().catch((error) => {
                 logger.error(
                     'Failed to refresh code editor integrations',
@@ -58,9 +71,18 @@ async function performRevalidation(
     }
 }
 
+/**
+ * Schedules revalidation when the main window regains focus.
+ *
+ * @param mainWindow - Main application window.
+ * @param refreshCodeEditorIntegrations - Code editor refresh callback.
+ * @param gitService - Git repository inspection service.
+ * @returns A callback that removes listeners and timers.
+ */
 export function setupFocusRevalidation(
     mainWindow: BrowserWindow,
     refreshCodeEditorIntegrations: RefreshCodeEditorIntegrations,
+    gitService: GitService,
 ): () => void {
     let debounceTimer: NodeJS.Timeout | undefined;
     let backgroundTimer: NodeJS.Timeout | undefined;
@@ -87,6 +109,7 @@ export function setupFocusRevalidation(
                 await performRevalidation(
                     mainWindow,
                     refreshCodeEditorIntegrations,
+                    gitService,
                 );
                 lastRun = Date.now();
             } finally {

--- a/main/src/tool-integration/integrations/git/git.service.test.ts
+++ b/main/src/tool-integration/integrations/git/git.service.test.ts
@@ -30,6 +30,14 @@ const failure = (): ToolExecutionResult => ({
     exitCode: 1,
 });
 
+const notRepositoryFailure = (): ToolExecutionResult => ({
+    success: false,
+    reason: 'command-failed',
+    stdout: '',
+    stderr: 'fatal: not a git repository',
+    exitCode: 128,
+});
+
 describe('GitService', () => {
     let service: GitService;
 
@@ -40,6 +48,15 @@ describe('GitService', () => {
     });
 
     it('executes Git through the stable tool ID and explicit working directory', async () => {
+        vi.spyOn(service, 'inspectRepository')
+            .mockResolvedValueOnce({ status: 'not-a-repository' })
+            .mockResolvedValueOnce({
+                status: 'inside-work-tree',
+                root: '/projects/demo',
+                isProjectRoot: true,
+                kind: 'standard',
+            });
+
         await expect(service.init('/projects/demo')).resolves.toBe(true);
 
         expect(execute).toHaveBeenCalledWith('git', {
@@ -114,6 +131,14 @@ describe('GitService', () => {
     ])(
         'sets $scope identity with separate arguments',
         async ({ scope, expectedArgs, expectedCwd }) => {
+            if (scope === 'repository') {
+                vi.spyOn(service, 'inspectRepository').mockResolvedValue({
+                    status: 'inside-work-tree',
+                    root: '/projects/demo',
+                    isProjectRoot: true,
+                    kind: 'standard',
+                });
+            }
             await expect(
                 service.setIdentity(
                     'Mario',
@@ -195,6 +220,12 @@ describe('GitService', () => {
     });
 
     it('renames the initial branch in the repository working directory', async () => {
+        vi.spyOn(service, 'inspectRepository').mockResolvedValue({
+            status: 'inside-work-tree',
+            root: '/projects/demo',
+            isProjectRoot: true,
+            kind: 'standard',
+        });
         await expect(service.renameBranch('/projects/demo')).resolves.toBe(
             true,
         );
@@ -206,6 +237,12 @@ describe('GitService', () => {
     });
 
     it('stages and commits sequentially', async () => {
+        vi.spyOn(service, 'inspectRepository').mockResolvedValue({
+            status: 'inside-work-tree',
+            root: '/projects/demo',
+            isProjectRoot: true,
+            kind: 'standard',
+        });
         await expect(service.addAndCommit('/projects/demo')).resolves.toBe(
             true,
         );
@@ -221,6 +258,12 @@ describe('GitService', () => {
     });
 
     it('does not commit when staging fails', async () => {
+        vi.spyOn(service, 'inspectRepository').mockResolvedValue({
+            status: 'inside-work-tree',
+            root: '/projects/demo',
+            isProjectRoot: true,
+            kind: 'standard',
+        });
         execute.mockResolvedValueOnce(failure());
 
         await expect(service.addAndCommit('/projects/demo')).resolves.toBe(
@@ -230,11 +273,138 @@ describe('GitService', () => {
     });
 
     it('converts unexpected tool service failures into command failure', async () => {
+        vi.spyOn(service, 'inspectRepository').mockResolvedValueOnce({
+            status: 'not-a-repository',
+        });
         execute.mockRejectedValueOnce(new Error('unexpected'));
 
         await expect(service.init('/projects/demo')).resolves.toBe(false);
         expect(logger.error).toHaveBeenCalledWith(
             'Git command failed unexpectedly',
         );
+    });
+
+    it('reports a project nested in a standard repository', async () => {
+        execute
+            .mockResolvedValueOnce(success('true\n'))
+            .mockResolvedValueOnce(success('/projects/parent\n'))
+            .mockResolvedValueOnce(success('\n'));
+
+        await expect(
+            service.inspectRepository('/projects/parent/demo'),
+        ).resolves.toEqual({
+            status: 'inside-work-tree',
+            root: '/projects/parent',
+            isProjectRoot: false,
+            kind: 'standard',
+        });
+
+        expect(execute).toHaveBeenNthCalledWith(1, 'git', {
+            args: ['rev-parse', '--is-inside-work-tree'],
+            cwd: '/',
+            env: { LC_ALL: 'C', LANG: 'C' },
+            timeoutMs: 5000,
+        });
+    });
+
+    it('classifies a submodule before considering its .git file marker', async () => {
+        execute
+            .mockResolvedValueOnce(success('true\n'))
+            .mockResolvedValueOnce(success('/projects/parent/submodule\n'))
+            .mockResolvedValueOnce(success('/projects/parent\n'));
+
+        await expect(
+            service.inspectRepository('/projects/parent/submodule'),
+        ).resolves.toMatchObject({
+            status: 'inside-work-tree',
+            kind: 'submodule',
+        });
+    });
+
+    it('classifies a repository root with a .git file as a linked worktree', async () => {
+        vi.spyOn(
+            service as unknown as {
+                isGitFile: (gitPath: string) => Promise<boolean>;
+            },
+            'isGitFile',
+        ).mockResolvedValue(true);
+        execute
+            .mockResolvedValueOnce(success('true\n'))
+            .mockResolvedValueOnce(success('/projects/worktree\n'))
+            .mockResolvedValueOnce(success('\n'));
+
+        await expect(
+            service.inspectRepository('/projects/worktree'),
+        ).resolves.toEqual({
+            status: 'inside-work-tree',
+            root: '/projects/worktree',
+            isProjectRoot: true,
+            kind: 'linked-worktree',
+        });
+    });
+
+    it('distinguishes no repository from unavailable Git', async () => {
+        execute.mockResolvedValueOnce(notRepositoryFailure());
+        await expect(
+            service.inspectRepository('/projects/demo'),
+        ).resolves.toEqual({ status: 'not-a-repository' });
+
+        execute.mockResolvedValueOnce({
+            ...failure(),
+            reason: 'unavailable',
+        });
+        await expect(
+            service.inspectRepository('/projects/demo'),
+        ).resolves.toEqual({ status: 'git-unavailable' });
+    });
+
+    it('refuses repository mutations when the project is nested', async () => {
+        vi.spyOn(service, 'inspectRepository').mockResolvedValue({
+            status: 'inside-work-tree',
+            root: '/projects/parent',
+            isProjectRoot: false,
+            kind: 'standard',
+        });
+
+        await expect(
+            service.renameBranch('/projects/parent/demo'),
+        ).resolves.toBe(false);
+        await expect(
+            service.addAndCommit('/projects/parent/demo'),
+        ).resolves.toBe(false);
+        await expect(
+            service.setIdentity(
+                'Mario',
+                'mario@example.com',
+                'repository',
+                '/projects/parent/demo',
+            ),
+        ).resolves.toBe(false);
+        expect(execute).not.toHaveBeenCalled();
+    });
+
+    it('rechecks repository scope between staging and committing', async () => {
+        vi.spyOn(service, 'inspectRepository')
+            .mockResolvedValueOnce({
+                status: 'inside-work-tree',
+                root: '/projects/demo',
+                isProjectRoot: true,
+                kind: 'standard',
+            })
+            .mockResolvedValueOnce({
+                status: 'inside-work-tree',
+                root: '/projects',
+                isProjectRoot: false,
+                kind: 'standard',
+            });
+
+        await expect(service.addAndCommit('/projects/demo')).resolves.toBe(
+            false,
+        );
+        expect(execute).toHaveBeenCalledTimes(1);
+        expect(execute).toHaveBeenCalledWith('git', {
+            args: ['add', '.'],
+            cwd: '/projects/demo',
+        });
     });
 });

--- a/main/src/tool-integration/integrations/git/git.service.ts
+++ b/main/src/tool-integration/integrations/git/git.service.ts
@@ -1,9 +1,22 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { Injectable } from '@mariodebono/di';
-import type { GitIdentity, GitIdentityScope } from '@shared/contracts';
+import type {
+    GitIdentity,
+    GitIdentityScope,
+    GitRepositoryInspection,
+    GitRepositoryKind,
+} from '@shared/contracts';
 import logger from 'electron-log';
 // biome-ignore lint/style/useImportType: Required for DI constructor metadata
 import { ToolIntegrationService } from '../../tool-integration.service.js';
-import type { ToolExecutionResult } from '../../tool-integration.types.js';
+import type {
+    ToolExecutionRequest,
+    ToolExecutionResult,
+} from '../../tool-integration.types.js';
+
+const GIT_INSPECTION_TIMEOUT_MS = 5000;
+const GIT_INSPECTION_ENV = { LC_ALL: 'C', LANG: 'C' } as const;
 
 @Injectable()
 export class GitService {
@@ -23,6 +36,93 @@ export class GitService {
      */
     async exists(): Promise<boolean> {
         return (await this.run(['--version'])).success;
+    }
+
+    /**
+     * Inspects the Git work tree that contains a project path.
+     *
+     * For a path that does not exist yet, Git runs from its nearest existing
+     * parent so project creation can detect an enclosing repository.
+     *
+     * @param projectPath - Existing or planned project directory to inspect.
+     * @returns A typed repository inspection result.
+     */
+    async inspectRepository(
+        projectPath: string,
+    ): Promise<GitRepositoryInspection> {
+        const inspectionDirectory =
+            await this.findInspectionDirectory(projectPath);
+        if (!inspectionDirectory) {
+            return { status: 'inspection-failed' };
+        }
+
+        const requestOptions = {
+            env: GIT_INSPECTION_ENV,
+            timeoutMs: GIT_INSPECTION_TIMEOUT_MS,
+        };
+        const insideResult = await this.run(
+            ['rev-parse', '--is-inside-work-tree'],
+            inspectionDirectory,
+            false,
+            requestOptions,
+        );
+        if (!insideResult.success) {
+            if (
+                insideResult.reason === 'disabled' ||
+                insideResult.reason === 'invalid' ||
+                insideResult.reason === 'unavailable'
+            ) {
+                return { status: 'git-unavailable' };
+            }
+            if (
+                insideResult.reason === 'command-failed' &&
+                insideResult.stderr
+                    .toLowerCase()
+                    .includes('not a git repository')
+            ) {
+                return { status: 'not-a-repository' };
+            }
+            return { status: 'inspection-failed' };
+        }
+        if (insideResult.stdout.trim() !== 'true') {
+            return { status: 'not-a-repository' };
+        }
+
+        const rootResult = await this.run(
+            ['rev-parse', '--show-toplevel'],
+            inspectionDirectory,
+            false,
+            requestOptions,
+        );
+        if (!rootResult.success || !rootResult.stdout.trim()) {
+            return { status: 'inspection-failed' };
+        }
+
+        const root = await this.normalizePath(rootResult.stdout.trim());
+        const normalizedProjectPath = await this.normalizePath(projectPath);
+        const superprojectResult = await this.run(
+            ['rev-parse', '--show-superproject-working-tree'],
+            inspectionDirectory,
+            false,
+            requestOptions,
+        );
+        if (!superprojectResult.success) {
+            return { status: 'inspection-failed' };
+        }
+
+        let kind: GitRepositoryKind = 'standard';
+        if (superprojectResult.stdout.trim()) {
+            kind = 'submodule';
+        } else if (await this.isGitFile(path.resolve(root, '.git'))) {
+            kind = 'linked-worktree';
+        }
+
+        return {
+            status: 'inside-work-tree',
+            root,
+            isProjectRoot: this.pathsEqual(root, normalizedProjectPath),
+            kind,
+        };
     }
 
     /**
@@ -127,6 +227,15 @@ export class GitService {
         scope: GitIdentityScope,
         dir: string,
     ): Promise<boolean> {
+        if (
+            scope === 'repository' &&
+            !(await this.isProjectRepositoryRoot(dir))
+        ) {
+            logger.error(
+                'Refusing to set repository identity outside the project repository root',
+            );
+            return false;
+        }
         const scopeArgs = scope === 'global' ? ['--global'] : [];
         const cwd = scope === 'repository' ? dir : undefined;
         const nameResult = await this.run(
@@ -185,7 +294,17 @@ export class GitService {
      * @returns Whether repository initialization succeeded.
      */
     async init(dir: string): Promise<boolean> {
-        return (await this.run(['init'], dir)).success;
+        const inspection = await this.inspectRepository(dir);
+        if (inspection.status !== 'not-a-repository') {
+            logger.error(
+                'Refusing to initialize Git inside an existing work tree',
+            );
+            return false;
+        }
+        if (!(await this.run(['init'], dir)).success) {
+            return false;
+        }
+        return await this.isProjectRepositoryRoot(dir);
     }
 
     /**
@@ -195,6 +314,12 @@ export class GitService {
      * @returns Whether the branch rename succeeded.
      */
     async renameBranch(dir: string): Promise<boolean> {
+        if (!(await this.isProjectRepositoryRoot(dir))) {
+            logger.error(
+                'Refusing to rename a branch outside the project repository root',
+            );
+            return false;
+        }
         return (await this.run(['branch', '-m', 'main'], dir)).success;
     }
 
@@ -205,8 +330,21 @@ export class GitService {
      * @returns Whether every initial commit command succeeded.
      */
     async addAndCommit(dir: string): Promise<boolean> {
+        if (!(await this.isProjectRepositoryRoot(dir))) {
+            logger.error(
+                'Refusing to stage files outside the project repository root',
+            );
+            return false;
+        }
         const addResult = await this.run(['add', '.'], dir);
         if (!addResult.success) {
+            return false;
+        }
+
+        if (!(await this.isProjectRepositoryRoot(dir))) {
+            logger.error(
+                'Refusing to commit outside the project repository root',
+            );
             return false;
         }
 
@@ -215,22 +353,131 @@ export class GitService {
     }
 
     /**
+     * Checks whether a directory is the root of its current Git work tree.
+     *
+     * @param dir - Project directory to inspect.
+     * @returns Whether the project is exactly the repository root.
+     */
+    private async isProjectRepositoryRoot(dir: string): Promise<boolean> {
+        const inspection = await this.inspectRepository(dir);
+        return (
+            inspection.status === 'inside-work-tree' && inspection.isProjectRoot
+        );
+    }
+
+    /**
+     * Finds the nearest existing directory that Git can inspect.
+     *
+     * @param targetPath - Existing or planned project path.
+     * @returns The nearest existing directory, or null when none can be read.
+     */
+    private async findInspectionDirectory(
+        targetPath: string,
+    ): Promise<string | null> {
+        let candidate = path.resolve(targetPath);
+        while (true) {
+            try {
+                const stat = await fs.promises.stat(candidate);
+                if (stat.isDirectory()) {
+                    return candidate;
+                }
+                candidate = path.dirname(candidate);
+            } catch (error) {
+                if (
+                    !(error instanceof Error) ||
+                    !('code' in error) ||
+                    (error.code !== 'ENOENT' && error.code !== 'ENOTDIR')
+                ) {
+                    return null;
+                }
+                candidate = path.dirname(candidate);
+            }
+
+            const parent = path.dirname(candidate);
+            if (parent === candidate) {
+                try {
+                    return (await fs.promises.stat(candidate)).isDirectory()
+                        ? candidate
+                        : null;
+                } catch {
+                    return null;
+                }
+            }
+        }
+    }
+
+    /**
+     * Normalizes an existing path or resolves a planned path through its
+     * nearest real parent directory.
+     *
+     * @param targetPath - Path to normalize.
+     * @returns An absolute path with resolved parent symlinks.
+     */
+    private async normalizePath(targetPath: string): Promise<string> {
+        const resolvedPath = path.resolve(targetPath);
+        try {
+            return path.normalize(await fs.promises.realpath(resolvedPath));
+        } catch {
+            const parent = await this.findInspectionDirectory(resolvedPath);
+            if (!parent) {
+                return path.normalize(resolvedPath);
+            }
+            const realParent = await fs.promises.realpath(parent);
+            return path.normalize(
+                path.resolve(realParent, path.relative(parent, resolvedPath)),
+            );
+        }
+    }
+
+    /**
+     * Checks whether a repository marker is a file.
+     *
+     * @param gitPath - Repository marker path.
+     * @returns Whether the marker exists as a file.
+     */
+    private async isGitFile(gitPath: string): Promise<boolean> {
+        try {
+            return (await fs.promises.stat(gitPath)).isFile();
+        } catch {
+            return false;
+        }
+    }
+
+    /**
+     * Compares normalized paths using platform case rules.
+     *
+     * @param left - First path.
+     * @param right - Second path.
+     * @returns Whether both paths identify the same location.
+     */
+    private pathsEqual(left: string, right: string): boolean {
+        const normalizedLeft = path.normalize(left);
+        const normalizedRight = path.normalize(right);
+        return process.platform === 'win32'
+            ? normalizedLeft.toLowerCase() === normalizedRight.toLowerCase()
+            : normalizedLeft === normalizedRight;
+    }
+
+    /**
      * Executes Git through its revalidated tool installation.
      *
      * @param args - Arguments passed to Git as separate process arguments.
      * @param cwd - Optional working directory for the Git process.
      * @param logError - Whether command failures should be logged.
+     * @param requestOptions - Optional environment and timeout overrides.
      * @returns Structured tool execution output.
      */
     private async run(
         args: readonly string[],
         cwd?: string,
         logError = true,
+        requestOptions: Omit<ToolExecutionRequest, 'args' | 'cwd'> = {},
     ): Promise<ToolExecutionResult> {
         try {
             const result = await this.toolIntegrationService.execute('git', {
                 args,
                 cwd,
+                ...requestOptions,
             });
             if (!result.success && logError) {
                 logger.error(`Git command failed: ${result.reason}`);

--- a/renderer/src/hooks/useProjects.tsx
+++ b/renderer/src/hooks/useProjects.tsx
@@ -6,6 +6,7 @@ import type {
     CodeEditorIntegrationSettings,
     CreateProjectGitOptions,
     CreateProjectResult,
+    InitializeProjectGitResult,
     InstalledRelease,
     LaunchProjectResult,
     ProjectDetails,
@@ -66,7 +67,9 @@ interface ProjectsContext {
     resetProjectCodeEditorConfig: (
         project: ProjectDetails,
     ) => Promise<SetProjectCodeEditorResult>;
-    initializeProjectGit: (project: ProjectDetails) => Promise<ProjectDetails>;
+    initializeProjectGit: (
+        project: ProjectDetails,
+    ) => Promise<InitializeProjectGitResult>;
     exportProjectEditorSettings: (project: ProjectDetails) => Promise<void>;
     importProjectEditorSettings: (project: ProjectDetails) => Promise<void>;
     openProjectFolder: (project: ProjectDetails) => Promise<void>;
@@ -267,9 +270,9 @@ export const ProjectsProvider: FC<ProjectsProviderProps> = ({ children }) => {
     };
 
     const initializeProjectGit = async (project: ProjectDetails) => {
-        const updatedProject = await appBridge.initializeProjectGit(project);
-        updateProjectState(updatedProject);
-        return updatedProject;
+        const result = await appBridge.initializeProjectGit(project);
+        updateProjectState(result.project);
+        return result;
     };
 
     const exportProjectEditorSettings = async (project: ProjectDetails) => {

--- a/renderer/src/views/subViews/createProjectDrawer.subview.tsx
+++ b/renderer/src/views/subViews/createProjectDrawer.subview.tsx
@@ -12,6 +12,7 @@ import { appBridge } from '../../bridge.ts';
 import { Drawer } from '../../components/ui/drawer/drawer.component';
 import { WaitingForDialogOverlay } from '../../components/waitingForDialogOverlay.component';
 import { useGit } from '../../hooks/git.hook';
+import { useAlerts } from '../../hooks/useAlerts';
 import { useCodeEditorIntegrations } from '../../hooks/useCodeEditorIntegrations';
 import { useFileSystem } from '../../hooks/useFileSystem';
 import { usePreferences } from '../../hooks/usePreferences';
@@ -94,6 +95,7 @@ export const CreateProjectDrawer: React.FC<SubViewProps> = ({
     const defaultOverwriteBasePathRef = useRef('');
 
     const { installedReleases, downloadingReleases } = useRelease();
+    const { addAlert } = useAlerts();
     const { createProject, launchProject } = useProjects();
     const { pathExists } = useFileSystem();
     const { getGlobalIdentity } = useGit();
@@ -270,6 +272,21 @@ export const CreateProjectDrawer: React.FC<SubViewProps> = ({
         setCreating(false);
 
         if (result.success && result.projectDetails) {
+            if (result.gitSetup?.status === 'existing-repository') {
+                addAlert(
+                    t(
+                        'projects:editProject.sourceControl.existingRepositoryTitle',
+                    ),
+                    result.gitSetup.isProjectRoot
+                        ? t(
+                              'projects:editProject.sourceControl.existingRepositoryRoot',
+                          )
+                        : t(
+                              'projects:editProject.sourceControl.existingRepositoryParent',
+                              { root: result.gitSetup.root },
+                          ),
+                );
+            }
             onOpenChange(false);
             if (editNow) {
                 launchProject(result.projectDetails);

--- a/renderer/src/views/subViews/projectSettingsDrawer.subview.tsx
+++ b/renderer/src/views/subViews/projectSettingsDrawer.subview.tsx
@@ -8,9 +8,9 @@ import type {
     RenameProjectResult,
 } from '@shared/contracts';
 import clsx from 'clsx';
-import { GitBranch, PanelTop, Pin } from 'lucide-react';
+import { CircleCheck, GitBranch, PanelTop, Pin } from 'lucide-react';
 import type React from 'react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getSelectableReleaseKey } from '../../components/selectInstalledRelease/selectInstalledRelease.model';
 import { CopyBadge } from '../../components/ui/copyBadge.component';
@@ -134,9 +134,17 @@ export const ProjectSettingsDrawer: React.FC<ProjectSettingsDrawerProps> = ({
     >([]);
     const [loadingCodeEditors, setLoadingCodeEditors] = useState(false);
     const [codeEditorLoadFailed, setCodeEditorLoadFailed] = useState(false);
+    const activeProjectPathRef = useRef<string | null>(null);
 
     useEffect(() => {
         if (!open || !project) {
+            activeProjectPathRef.current = null;
+            return;
+        }
+
+        const projectChanged = activeProjectPathRef.current !== project.path;
+        activeProjectPathRef.current = project.path;
+        if (!projectChanged) {
             return;
         }
 
@@ -734,7 +742,14 @@ export const ProjectSettingsDrawer: React.FC<ProjectSettingsDrawerProps> = ({
                                     </div>
                                 </div>
                                 {withGit ? (
-                                    <span className="badge badge-success badge-outline">
+                                    <span
+                                        className="badge badge-success gap-1.5"
+                                        data-testid="projectGitActive"
+                                    >
+                                        <CircleCheck
+                                            className="h-4 w-4"
+                                            aria-hidden="true"
+                                        />
                                         {t('editProject.sourceControl.active')}
                                     </span>
                                 ) : loadingGitAvailability ? (

--- a/renderer/src/views/subViews/projectSettingsDrawer.subview.tsx
+++ b/renderer/src/views/subViews/projectSettingsDrawer.subview.tsx
@@ -1,6 +1,7 @@
 import type {
     CodeEditorId,
     CodeEditorIntegrationSettings,
+    InitializeProjectGitResult,
     InstalledRelease,
     ProjectDetails,
     RenameProjectOptions,
@@ -62,7 +63,7 @@ type ProjectSettingsDrawerProps = {
     ) => Promise<ProjectDetails>;
     onInitializeProjectGit: (
         project: ProjectDetails,
-    ) => Promise<ProjectDetails>;
+    ) => Promise<InitializeProjectGitResult>;
     onResetProjectCodeEditorConfig: (
         project: ProjectDetails,
     ) => Promise<ProjectDetails>;
@@ -101,7 +102,7 @@ export const ProjectSettingsDrawer: React.FC<ProjectSettingsDrawerProps> = ({
         'installs',
         'createProject',
     ]);
-    const { addCustomConfirm } = useAlerts();
+    const { addAlert, addCustomConfirm } = useAlerts();
     const { listIntegrationSettings } = useCodeEditorIntegrations();
     const { listIntegrations } = useToolIntegrations();
     const [activeTab, setActiveTab] = useState<ProjectSettingsTab>('project');
@@ -337,8 +338,19 @@ export const ProjectSettingsDrawer: React.FC<ProjectSettingsDrawerProps> = ({
         setIsInitializingGit(true);
         setFormError(undefined);
         try {
-            const updatedProject = await onInitializeProjectGit(project);
-            setWithGit(updatedProject.withGit);
+            const result = await onInitializeProjectGit(project);
+            setWithGit(result.project.withGit);
+            if (result.gitSetup.status === 'existing-repository') {
+                addAlert(
+                    t('editProject.sourceControl.existingRepositoryTitle'),
+                    result.gitSetup.isProjectRoot
+                        ? t('editProject.sourceControl.existingRepositoryRoot')
+                        : t(
+                              'editProject.sourceControl.existingRepositoryParent',
+                              { root: result.gitSetup.root },
+                          ),
+                );
+            }
         } catch (error) {
             setFormError(
                 error instanceof Error

--- a/shared/src/contracts/app/app.bridge.d.ts
+++ b/shared/src/contracts/app/app.bridge.d.ts
@@ -6,6 +6,7 @@ import type {
     ChangeProjectEditorResult,
     CreateProjectGitOptions,
     CreateProjectResult,
+    InitializeProjectGitResult,
     LaunchProjectOptions,
     LaunchProjectResult,
     ProjectDetails,
@@ -146,7 +147,9 @@ export type AppBridge = {
     resetProjectCodeEditorConfig(
         project: ProjectDetails,
     ): Promise<SetProjectCodeEditorResult>;
-    initializeProjectGit(project: ProjectDetails): Promise<ProjectDetails>;
+    initializeProjectGit(
+        project: ProjectDetails,
+    ): Promise<InitializeProjectGitResult>;
     exportProjectEditorSettings(project: ProjectDetails): Promise<void>;
     importProjectEditorSettings(project: ProjectDetails): Promise<void>;
     launchProject(

--- a/shared/src/contracts/projects/index.d.ts
+++ b/shared/src/contracts/projects/index.d.ts
@@ -20,6 +20,26 @@ export type GitIdentity = {
 
 export type GitIdentityScope = 'repository' | 'global';
 
+export type GitRepositoryKind = 'standard' | 'linked-worktree' | 'submodule';
+
+export type GitRepositoryInfo = {
+    root: string;
+    isProjectRoot: boolean;
+    kind: GitRepositoryKind;
+};
+
+export type GitRepositoryInspection =
+    | ({ status: 'inside-work-tree' } & GitRepositoryInfo)
+    | { status: 'not-a-repository' }
+    | { status: 'git-unavailable' }
+    | { status: 'inspection-failed' };
+
+export type ProjectGitSetupOutcome =
+    | { status: 'not-requested' }
+    | { status: 'git-unavailable' }
+    | ({ status: 'initialized' } & GitRepositoryInfo)
+    | ({ status: 'existing-repository' } & GitRepositoryInfo);
+
 export type CreateProjectGitOptions =
     | { initialCommit: 'skip' }
     | {
@@ -65,6 +85,14 @@ export type ProjectDetails = {
 export type CreateProjectResult = BackendResult & {
     projectPath?: string;
     projectDetails?: ProjectDetails;
+    gitSetup?: ProjectGitSetupOutcome;
+};
+
+export type InitializeProjectGitResult = {
+    project: ProjectDetails;
+    gitSetup:
+        | ({ status: 'initialized' } & GitRepositoryInfo)
+        | ({ status: 'existing-repository' } & GitRepositoryInfo);
 };
 
 export type ProjectLauncherEditorRequest = {


### PR DESCRIPTION
- Prevents automatic Git setup from creating nested repositories.
- Detects parent repositories, linked worktrees, and submodules before Git mutations.
- Skips metadata, branch, identity, staging, and commit changes when an existing repository owns the project.
- Keeps the Source Control tab selected after initialisation and shows a clear active checkmark.
- Adds localised notices and updated screenshots for the safe existing-repository outcome.