### PR TITLE
fix(ui): use native modal dialogs

### DIFF
--- a/e2e/codeEditorIntegration.spec.ts
+++ b/e2e/codeEditorIntegration.spec.ts
@@ -106,6 +106,166 @@ test('SelectField supports keyboard navigation and announces its selected code e
     await expect(trigger).not.toBeFocused();
 });
 
+test('Confirmation dialogs contain focus and restore it after Escape', async () => {
+    const integrationRow = await openCodeEditorSettings();
+    const enabledSwitch = integrationRow.getByRole('checkbox', {
+        name: 'Enabled: Visual Studio Code',
+    });
+    await enabledSwitch.click();
+
+    const dialog = mainPage.getByRole('dialog', {
+        name: 'Disable Visual Studio Code?',
+    });
+    const cancelButton = dialog.getByRole('button', {
+        name: 'Cancel',
+        exact: true,
+    });
+    await expect(dialog).toBeVisible();
+    await expect(cancelButton).toBeFocused();
+    expect(await dialog.evaluate((element) => element.matches(':modal'))).toBe(
+        true,
+    );
+
+    const projectsNavigation = mainPage.getByTestId('btnProjects');
+    await projectsNavigation.evaluate((element) => element.focus());
+    await expect(cancelButton).toBeFocused();
+
+    await mainPage.keyboard.press('Escape');
+    await expect(dialog).toHaveCount(0);
+    await expect(enabledSwitch).toBeFocused();
+    await expect(enabledSwitch).toBeChecked();
+});
+
+test('Alerts focus their safe action and remain modal', async () => {
+    await stubRecordedIpcHandler(electronApp, {
+        key: 'clearReleaseCache',
+        channel: 'app.clearReleaseCache',
+        data: undefined,
+        error: 'Simulated cache refresh failure.',
+    });
+    await mainPage.getByTestId('btnSettings').click();
+    await mainPage.getByTestId('tabInstalls').click();
+
+    const refreshButton = mainPage.getByRole('button', {
+        name: 'Refresh cache',
+        exact: true,
+    });
+    await refreshButton.click();
+
+    const dialog = mainPage.getByRole('dialog', {
+        name: 'Unable to Refresh Cache',
+    });
+    const okButton = dialog.getByRole('button', { name: 'Ok', exact: true });
+    await expect(dialog).toBeVisible();
+    await expect(okButton).toBeFocused();
+    expect(await dialog.evaluate((element) => element.matches(':modal'))).toBe(
+        true,
+    );
+
+    await mainPage.getByTestId('btnProjects').evaluate((element) =>
+        element.focus(),
+    );
+    await expect(okButton).toBeFocused();
+
+    await mainPage.keyboard.press('Escape');
+    await expect(dialog).toHaveCount(0);
+});
+
+test('Git identity dialog returns to Create Project and blocks Escape while saving', async () => {
+    const projectName = 'Modal Focus E2E Project';
+    await stubGlobalGitIdentity(electronApp, { name: '', email: '' });
+    await openCreateProject();
+
+    await mainPage.getByTestId('inputProjectName').fill(projectName);
+    const createButton = mainPage.getByTestId('btnCreateProject');
+    await createButton.click();
+
+    const warningDialog = mainPage.getByRole('dialog', {
+        name: 'Git identity required',
+    });
+    const warningTitle = warningDialog.getByRole('heading', {
+        name: 'Git identity required',
+    });
+    await expect(warningDialog).toBeVisible();
+    await expect(warningTitle).toBeFocused();
+    expect(
+        await warningDialog.evaluate((element) => element.matches(':modal')),
+    ).toBe(true);
+
+    const projectNameInput = mainPage.getByTestId('inputProjectName');
+    await projectNameInput.evaluate((element) => element.focus());
+    await expect(warningTitle).toBeFocused();
+
+    await mainPage.keyboard.press('Escape');
+    await expect(warningDialog).toHaveCount(0);
+    const createDrawer = mainPage.getByRole('dialog', {
+        name: 'New Project',
+    });
+    await expect(createDrawer).toBeVisible();
+    expect(
+        await createDrawer.evaluate((element) =>
+            element.contains(document.activeElement),
+        ),
+    ).toBe(true);
+
+    await stubRecordedIpcHandler(electronApp, {
+        key: 'saveIdentityPreset',
+        channel: 'git.saveProjectIdentityPreset',
+        data: {
+            success: true,
+            preset: {
+                name: 'Modal User',
+                email: 'modal@example.com',
+                useForNewRepositories: true,
+            },
+        },
+        pending: true,
+    });
+    await stubRecordedIpcHandler(electronApp, {
+        key: 'createProjectAfterIdentity',
+        channel: 'projects.createProject',
+        data: {
+            success: false,
+            error: 'Captured Create Project request.',
+        },
+    });
+
+    await createButton.click();
+    await warningDialog
+        .getByRole('button', { name: 'Add Git identity', exact: true })
+        .click();
+    const identityDialog = mainPage.getByRole('dialog', {
+        name: 'Add Git identity',
+    });
+    await identityDialog.getByLabel('Name', { exact: true }).fill('Modal User');
+    await identityDialog
+        .getByLabel('Email', { exact: true })
+        .fill('modal@example.com');
+    await identityDialog
+        .getByLabel('Save as default local identity', { exact: true })
+        .check();
+    const saveButton = identityDialog.getByRole('button', {
+        name: 'Save and create project',
+        exact: true,
+    });
+    await saveButton.click();
+    await expect
+        .poll(() => readRecordedIpcCalls(electronApp, 'saveIdentityPreset'))
+        .toHaveLength(1);
+    await expect(saveButton).toBeDisabled();
+
+    await mainPage.keyboard.press('Escape');
+    await expect(identityDialog).toBeVisible();
+
+    await releaseRecordedIpcHandler(electronApp, 'saveIdentityPreset');
+    await expect(identityDialog).toHaveCount(0);
+    await expect
+        .poll(() =>
+            readRecordedIpcCalls(electronApp, 'createProjectAfterIdentity'),
+        )
+        .toHaveLength(1);
+});
+
 test('Create Project submits both an integration and explicit None', async () => {
     const projectName = 'Code Editor E2E Project';
 

--- a/renderer/src/components/alert.component.tsx
+++ b/renderer/src/components/alert.component.tsx
@@ -1,5 +1,5 @@
 import { ExternalLink } from 'lucide-react';
-import type { ReactNode } from 'react';
+import { type ReactNode, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { GITHUB_STATUS_URL } from '../constants';
 import { useAppNavigation } from '../hooks/useAppNavigation';
@@ -40,16 +40,26 @@ function renderAlertLine(
     );
 }
 
+/**
+ * Renders a dismissible application alert.
+ *
+ * @param props - Alert message, presentation, and dismissal callback.
+ * @returns The alert dialog.
+ */
 export const Alert: React.FC<AlertProps> = ({ message, onOk, title, icon }) => {
     const { t } = useTranslation('common');
     const { openExternalLink } = useAppNavigation();
+    const okButtonRef = useRef<HTMLButtonElement>(null);
 
     return (
         <Dialog
             icon={icon}
             title={title}
+            initialFocusRef={okButtonRef}
+            onRequestClose={onOk}
             footer={
                 <button
+                    ref={okButtonRef}
                     type="button"
                     data-testid="btnAlertOk"
                     onClick={onOk}

--- a/renderer/src/components/confirm.component.tsx
+++ b/renderer/src/components/confirm.component.tsx
@@ -1,4 +1,4 @@
-import { Fragment, type ReactNode } from 'react';
+import { Fragment, type ReactNode, useRef } from 'react';
 import { Dialog } from './dialog.component';
 
 interface AlertProps {
@@ -23,10 +23,16 @@ export type ConfirmButton =
           onClick?: ConfirmButtonClick;
       };
 
+/**
+ * Runs a confirmation action and closes when it reports success.
+ *
+ * @param callback - Optional confirmation action.
+ * @param shouldClose - Callback that removes the confirmation.
+ */
 const onClickShouldClose = (
     callback?: ConfirmButtonClick,
     shouldClose?: () => void,
-) => {
+): void => {
     const result = callback?.();
 
     if (result instanceof Promise) {
@@ -43,6 +49,26 @@ const onClickShouldClose = (
     }
 };
 
+/**
+ * Closes a confirmation through its declared Cancel action.
+ *
+ * @param button - Cancel button whose callback should run.
+ * @param shouldClose - Callback that removes the confirmation.
+ */
+function requestCancel(
+    button: Exclude<ConfirmButton, { key: string }>,
+    shouldClose: () => void,
+): void {
+    shouldClose();
+    void button.onClick?.();
+}
+
+/**
+ * Renders a controlled confirmation dialog.
+ *
+ * @param props - Confirmation content, actions, and close callback.
+ * @returns The confirmation dialog.
+ */
 export const Confirm: React.FC<AlertProps> = ({
     content,
     buttons,
@@ -50,10 +76,21 @@ export const Confirm: React.FC<AlertProps> = ({
     icon,
     shouldClose,
 }) => {
+    const cancelButtonRef = useRef<HTMLButtonElement>(null);
+    const cancelButton = buttons?.find(
+        (button) => !('render' in button) && button.isCancel,
+    );
+
     return (
         <Dialog
             icon={icon}
             title={title}
+            initialFocusRef={cancelButton ? cancelButtonRef : undefined}
+            onRequestClose={
+                cancelButton && !('render' in cancelButton)
+                    ? () => requestCancel(cancelButton, shouldClose)
+                    : undefined
+            }
             footer={buttons?.map((button, index) => (
                 <Fragment
                     key={
@@ -66,12 +103,12 @@ export const Confirm: React.FC<AlertProps> = ({
                         button.render(shouldClose)
                     ) : (
                         <button
+                            ref={button.isCancel ? cancelButtonRef : undefined}
                             type="button"
                             data-testid={`btnAlert${index}`}
                             onClick={() => {
                                 if (button.isCancel) {
-                                    shouldClose();
-                                    void button.onClick?.();
+                                    requestCancel(button, shouldClose);
                                 } else {
                                     onClickShouldClose(button.onClick, () =>
                                         shouldClose(),

--- a/renderer/src/components/dialog.component.test.tsx
+++ b/renderer/src/components/dialog.component.test.tsx
@@ -3,12 +3,18 @@ import { describe, expect, it } from 'vitest';
 import { Dialog } from './dialog.component';
 
 describe('Dialog', () => {
-    it('renders in a fixed modal layer above drawers', () => {
+    it('renders a labelled native dialog without opening it declaratively', () => {
         const html = renderToStaticMarkup(
             <Dialog title="Example dialog">Dialog content</Dialog>,
         );
 
-        expect(html).toContain('class="fixed z-60 inset-0');
+        expect(html).toContain('<dialog');
+        expect(html).toContain('aria-labelledby=');
+        expect(html).toContain('tabindex="-1"');
+        expect(html).toContain('max-w-lg');
+        expect(html).not.toContain(' open=""');
+        expect(html).not.toContain('role="dialog"');
+        expect(html).not.toContain('aria-modal="true"');
     });
 
     it('wraps footer actions when they exceed the dialog width', () => {
@@ -27,5 +33,17 @@ describe('Dialog', () => {
         );
 
         expect(html).toContain('flex flex-wrap justify-end gap-2');
+    });
+
+    it('uses a custom panel width without retaining the default width', () => {
+        const html = renderToStaticMarkup(
+            <Dialog title="Wide dialog" panelClassName="max-w-4xl">
+                Dialog content
+            </Dialog>,
+        );
+
+        expect(html).toContain('max-w-4xl');
+        expect(html).not.toContain('max-w-lg');
+        expect(html).toContain('min-h-0 flex-1');
     });
 });

--- a/renderer/src/components/dialog.component.tsx
+++ b/renderer/src/components/dialog.component.tsx
@@ -1,45 +1,126 @@
-import type { ReactNode } from 'react';
+import {
+    type ReactNode,
+    type RefObject,
+    useId,
+    useLayoutEffect,
+    useRef,
+} from 'react';
 
 type DialogProps = {
     icon?: ReactNode;
     title: string;
     children: ReactNode;
     footer?: ReactNode;
+    panelClassName?: string;
+    initialFocusRef?: RefObject<HTMLElement | null>;
+    returnFocusRef?: RefObject<HTMLElement | null>;
+    onRequestClose?: () => void;
 };
 
+/**
+ * Renders application content in the browser's modal top layer.
+ *
+ * @param props - Dialog content, focus target, and controlled close callback.
+ * @returns The native modal dialog.
+ */
 export const Dialog: React.FC<DialogProps> = ({
     icon,
     title,
     children,
     footer,
+    panelClassName = '',
+    initialFocusRef,
+    returnFocusRef,
+    onRequestClose,
 }) => {
+    const dialogRef = useRef<HTMLDialogElement>(null);
+    const titleRef = useRef<HTMLHeadingElement>(null);
+    const onRequestCloseRef = useRef(onRequestClose);
+    onRequestCloseRef.current = onRequestClose;
+    const titleId = useId();
+    const widthClassName = panelClassName ? '' : 'max-w-lg';
+
+    useLayoutEffect(() => {
+        const dialog = dialogRef.current;
+        if (!dialog) {
+            return;
+        }
+
+        if (!dialog.open) {
+            dialog.showModal();
+        }
+
+        /**
+         * Routes native Escape requests through controlled React state.
+         *
+         * @param event - Native dialog cancellation event.
+         */
+        const handleCancel = (event: Event): void => {
+            event.preventDefault();
+            onRequestCloseRef.current?.();
+        };
+        dialog.addEventListener('cancel', handleCancel);
+
+        const initialFocusTarget = initialFocusRef?.current;
+        if (
+            initialFocusTarget?.isConnected &&
+            dialog.contains(initialFocusTarget) &&
+            !initialFocusTarget.matches(':disabled')
+        ) {
+            initialFocusTarget.focus({ preventScroll: true });
+        } else {
+            titleRef.current?.focus({ preventScroll: true });
+        }
+
+        return () => {
+            dialog.removeEventListener('cancel', handleCancel);
+            if (dialog.open) {
+                dialog.close();
+            }
+            const returnFocusTarget = returnFocusRef?.current;
+            if (returnFocusTarget?.isConnected) {
+                window.requestAnimationFrame(() => {
+                    returnFocusTarget.focus({ preventScroll: true });
+                });
+            }
+        };
+    }, [initialFocusRef, returnFocusRef]);
+
     return (
-        <div className="fixed z-60 inset-0 bg-black/80 flex items-center justify-center p-4">
-            <section
-                className="bg-base-100 border border-base-300 rounded-lg shadow-2xl w-full max-w-lg max-h-[85vh] flex flex-col overflow-hidden"
-                role="dialog"
-                aria-modal="true"
-                aria-label={title}
-            >
-                <header className="flex items-center gap-3 px-5 py-4 border-b border-base-300 bg-base-200/60">
-                    {icon && (
-                        <div className="w-6 h-6 flex items-center justify-center">
-                            {icon}
-                        </div>
+        <dialog
+            ref={dialogRef}
+            aria-labelledby={titleId}
+            className="fixed z-60 inset-0 m-0 h-full w-full max-h-none max-w-none overflow-hidden border-0 bg-transparent p-0 text-inherit backdrop:bg-transparent"
+        >
+            <div className="h-full w-full bg-black/80 flex items-center justify-center p-4">
+                <section
+                    className={`bg-base-100 border border-base-300 rounded-lg shadow-2xl w-full max-h-[85vh] flex flex-col overflow-hidden ${widthClassName} ${panelClassName}`}
+                >
+                    <header className="flex items-center gap-3 px-5 py-4 border-b border-base-300 bg-base-200/60">
+                        {icon && (
+                            <div className="w-6 h-6 flex items-center justify-center">
+                                {icon}
+                            </div>
+                        )}
+                        <h1
+                            ref={titleRef}
+                            id={titleId}
+                            tabIndex={-1}
+                            className="text-base-content font-bold text-lg leading-tight pt-1 outline-none"
+                        >
+                            {title}
+                        </h1>
+                    </header>
+                    <div className="min-h-0 flex-1 px-5 py-4 overflow-auto leading-6 text-base-content/80">
+                        {children}
+                    </div>
+                    {footer && (
+                        <footer className="px-5 py-4 border-t border-base-300 bg-base-200/40 flex flex-wrap justify-end gap-2">
+                            {footer}
+                        </footer>
                     )}
-                    <h1 className="text-base-content font-bold text-lg leading-tight pt-1">
-                        {title}
-                    </h1>
-                </header>
-                <div className="px-5 py-4 overflow-auto leading-6 text-base-content/80">
-                    {children}
-                </div>
-                {footer && (
-                    <footer className="px-5 py-4 border-t border-base-300 bg-base-200/40 flex flex-wrap justify-end gap-2">
-                        {footer}
-                    </footer>
-                )}
-            </section>
-        </div>
+                </section>
+            </div>
+        </dialog>
     );
 };

--- a/renderer/src/views/subViews/createProject/components/create-project-git-identity-dialog.component.test.tsx
+++ b/renderer/src/views/subViews/createProject/components/create-project-git-identity-dialog.component.test.tsx
@@ -36,6 +36,8 @@ describe('CreateProjectGitIdentityDialog', () => {
                 onUseDifferentIdentity={noop}
                 onBack={noop}
                 onSave={noop}
+                onRequestClose={noop}
+                returnFocusRef={{ current: null }}
             />,
         );
 
@@ -69,6 +71,8 @@ describe('CreateProjectGitIdentityDialog', () => {
                 onUseDifferentIdentity={noop}
                 onBack={noop}
                 onSave={noop}
+                onRequestClose={noop}
+                returnFocusRef={{ current: null }}
             />,
         );
 
@@ -103,6 +107,8 @@ describe('CreateProjectGitIdentityDialog', () => {
                 onUseDifferentIdentity={noop}
                 onBack={noop}
                 onSave={noop}
+                onRequestClose={noop}
+                returnFocusRef={{ current: null }}
             />,
         );
 
@@ -135,6 +141,8 @@ describe('CreateProjectGitIdentityDialog', () => {
                 onUseDifferentIdentity={noop}
                 onBack={noop}
                 onSave={noop}
+                onRequestClose={noop}
+                returnFocusRef={{ current: null }}
             />,
         );
         expect(completeGlobalHtml).toContain('gitIdentity.presetTitle');
@@ -165,6 +173,8 @@ describe('CreateProjectGitIdentityDialog', () => {
                 onUseDifferentIdentity={noop}
                 onBack={noop}
                 onSave={noop}
+                onRequestClose={noop}
+                returnFocusRef={{ current: null }}
             />,
         );
         expect(missingGlobalHtml).toContain('gitIdentity.useDifferent');
@@ -195,6 +205,8 @@ describe('CreateProjectGitIdentityDialog', () => {
                 onUseDifferentIdentity={noop}
                 onBack={noop}
                 onSave={noop}
+                onRequestClose={noop}
+                returnFocusRef={{ current: null }}
             />,
         );
 

--- a/renderer/src/views/subViews/createProject/components/create-project-git-identity-dialog.component.tsx
+++ b/renderer/src/views/subViews/createProject/components/create-project-git-identity-dialog.component.tsx
@@ -1,6 +1,7 @@
 import type { GitIdentityScope } from '@shared/contracts';
 import { TriangleAlert } from 'lucide-react';
 import type React from 'react';
+import type { RefObject } from 'react';
 import { Dialog } from '../../../../components/dialog.component';
 import { TextField } from '../../../../components/ui/textField.component';
 import type { CreateProjectGitIdentitySaveChoice } from '../createProject.model';
@@ -31,6 +32,8 @@ type CreateProjectGitIdentityDialogProps = {
     onUseDifferentIdentity: () => void;
     onBack: () => void;
     onSave: () => void;
+    onRequestClose: () => void;
+    returnFocusRef: RefObject<HTMLElement | null>;
 };
 
 /**
@@ -63,12 +66,16 @@ export const CreateProjectGitIdentityDialog: React.FC<
     onUseDifferentIdentity,
     onBack,
     onSave,
+    onRequestClose,
+    returnFocusRef,
 }) => {
     if (page === 'warning') {
         return (
             <Dialog
                 icon={<TriangleAlert className="text-warning" />}
                 title={t('gitIdentity.warningTitle')}
+                onRequestClose={onRequestClose}
+                returnFocusRef={returnFocusRef}
                 footer={
                     <>
                         <button
@@ -104,6 +111,8 @@ export const CreateProjectGitIdentityDialog: React.FC<
                     ? 'gitIdentity.presetTitle'
                     : 'gitIdentity.formTitle',
             )}
+            onRequestClose={saving ? undefined : onRequestClose}
+            returnFocusRef={returnFocusRef}
             footer={
                 presetPage ? (
                     <>

--- a/renderer/src/views/subViews/createProject/components/createProjectActions.component.tsx
+++ b/renderer/src/views/subViews/createProject/components/createProjectActions.component.tsx
@@ -1,4 +1,5 @@
 import type React from 'react';
+import type { Ref } from 'react';
 
 type CreateProjectActionsProps = {
     editNow: boolean;
@@ -10,8 +11,15 @@ type CreateProjectActionsProps = {
     onEditNowChange: (enabled: boolean) => void;
     onCancel: () => void;
     onCreateProject: () => void;
+    createButtonRef: Ref<HTMLButtonElement>;
 };
 
+/**
+ * Renders the Create Project drawer actions.
+ *
+ * @param props - Action state, callbacks, labels, and Create button ref.
+ * @returns The Create Project actions.
+ */
 export const CreateProjectActions: React.FC<CreateProjectActionsProps> = ({
     editNow,
     creating,
@@ -22,6 +30,7 @@ export const CreateProjectActions: React.FC<CreateProjectActionsProps> = ({
     onEditNowChange,
     onCancel,
     onCreateProject,
+    createButtonRef,
 }) => (
     <div className="flex w-full flex-wrap items-center justify-between gap-4">
         <label className="flex items-center">
@@ -38,6 +47,7 @@ export const CreateProjectActions: React.FC<CreateProjectActionsProps> = ({
         </label>
         <div className="flex gap-4 items-center">
             <button
+                ref={createButtonRef}
                 type="button"
                 disabled={creating}
                 onClick={onCancel}

--- a/renderer/src/views/subViews/createProjectDrawer.subview.tsx
+++ b/renderer/src/views/subViews/createProjectDrawer.subview.tsx
@@ -75,6 +75,7 @@ export const CreateProjectDrawer: React.FC<SubViewProps> = ({
         'common',
         'installEditor',
     ]);
+    const createButtonRef = useRef<HTMLButtonElement>(null);
     const [renderer, setRenderer] = useState<RendererType[5]>('FORWARD_PLUS');
     const [releaseKey, setReleaseKey] = useState<string | null>(null);
     const [projectName, setProjectName] = useState<string>('');
@@ -872,6 +873,7 @@ export const CreateProjectDrawer: React.FC<SubViewProps> = ({
                             onEditNowChange={setEditNow}
                             onCancel={() => onOpenChange(false)}
                             onCreateProject={() => void onCreateProject()}
+                            createButtonRef={createButtonRef}
                         />
                     </Drawer.Footer>
                 </form>
@@ -913,6 +915,8 @@ export const CreateProjectDrawer: React.FC<SubViewProps> = ({
                     onUseDifferentIdentity={handleUseDifferentGitIdentity}
                     onBack={handleGitIdentityBack}
                     onSave={() => void handleSaveGitIdentity()}
+                    onRequestClose={() => setGitIdentityDialogPage(null)}
+                    returnFocusRef={createButtonRef}
                 />
             )}
         </>


### PR DESCRIPTION
- Replace visual-only dialogs with native modal dialogs.
- Keep keyboard focus inside the active dialog.
- Give alerts and confirmations safe initial focus.
- Route Escape through controlled close behaviour and block it during busy operations.
- Restore focus when returning to the underlying workflow.