### PR TITLE
refactor(projects): retire legacy VS Code persistence flag

### DIFF
--- a/e2e/legacy-code-editor-migration.spec.ts
+++ b/e2e/legacy-code-editor-migration.spec.ts
@@ -1,0 +1,62 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { _electron, expect, test } from '@playwright/test';
+import { createFixtureHome } from './support/e2e-fixture-runtime';
+import { getMainWindow } from './splashscreen/getMainWindow';
+
+test('upgrades a legacy VS Code selection without retaining its flag', async () => {
+    const fixtureHome = await createFixtureHome();
+    const projectsPath = path.join(
+        fixtureHome,
+        '.gd-launcher',
+        'projects.json',
+    );
+    const [sample] = JSON.parse(await fs.readFile(projectsPath, 'utf-8'));
+    const { codeEditorId: _codeEditorId, ...legacyProject } = sample;
+    await fs.writeFile(
+        projectsPath,
+        JSON.stringify([{ ...legacyProject, withVSCode: true }]),
+    );
+    const bootstrapPath = path.join(fixtureHome, 'bootstrap.cjs');
+    await fs.writeFile(
+        bootstrapPath,
+        `
+        require(${JSON.stringify(path.resolve('e2e/support/overrideHome.cjs'))});
+        const os = require('node:os');
+        if (os.homedir() !== ${JSON.stringify(fixtureHome)}) {
+            throw new Error('Fixture home isolation failed');
+        }
+        const { app } = require('electron');
+        app.setAppPath(${JSON.stringify(process.cwd())});
+        app.setPath('userData', ${JSON.stringify(path.join(fixtureHome, 'electron-user-data'))});
+        import(${JSON.stringify(path.resolve('dist-electron/main.js'))});
+    `,
+    );
+    const env = {
+        ...process.env,
+        APPDATA: path.join(fixtureHome, 'AppData', 'Roaming'),
+        LOCALAPPDATA: path.join(fixtureHome, 'AppData', 'Local'),
+        GODOT_LAUNCHER_E2E_FIXTURES: '1',
+        GODOT_LAUNCHER_E2E_HOME_DIR: fixtureHome,
+    };
+    delete env.ELECTRON_RUN_AS_NODE;
+    const app = await _electron.launch({ args: [bootstrapPath], env });
+    try {
+        const page = await getMainWindow(app);
+        await page.getByTestId('btnProjects').click();
+        await page.getByTestId('btnProjectSettings').first().click();
+        await page
+            .getByRole('tab', { name: 'Code Editor', exact: true })
+            .click();
+        await expect(page.getByTestId('selectProjectCodeEditor')).toContainText(
+            'Visual Studio Code',
+        );
+        const [stored] = JSON.parse(await fs.readFile(projectsPath, 'utf-8'));
+        expect(stored.codeEditorId).toBe('vscode');
+        expect(stored).not.toHaveProperty('withVSCode');
+        expect(stored.path).toBe(legacyProject.path);
+    } finally {
+        await app.close();
+        await fs.rm(fixtureHome, { recursive: true, force: true });
+    }
+});

--- a/main/src/app-migrations/app-migrations.module.test.ts
+++ b/main/src/app-migrations/app-migrations.module.test.ts
@@ -19,6 +19,7 @@ import {
 import { MIGRATE_CODE_EDITOR_PREFERENCES_ID } from './migrations/code-editor-preferences.migration.js';
 import { MIGRATE_CODE_EDITOR_PROJECTS_ID } from './migrations/code-editor-projects.migration.js';
 import { REMOVE_LEGACY_INSTALLED_TOOLS_PREFERENCE_ID } from './migrations/remove-legacy-installed-tools-preference.migration.js';
+import { REMOVE_LEGACY_VSCODE_FLAG_ID } from './migrations/remove-legacy-vscode-flag.migration.js';
 import { REMOVE_WINDOWS_SYMLINK_NOTICE_PREFERENCE_ID } from './migrations/remove-windows-symlink-notice-preference.migration.js';
 
 const operationMocks = vi.hoisted(() => ({
@@ -121,6 +122,7 @@ describe('AppMigrationsModule', () => {
             'projects',
             'remove-installed-tools',
             'remove-symlink-notice',
+            'projects',
         ]);
         expect(readCompletedIds(statePath)).toEqual([
             CLEAR_RELEASE_CACHE_MIGRATION_ID,
@@ -128,6 +130,7 @@ describe('AppMigrationsModule', () => {
             MIGRATE_CODE_EDITOR_PROJECTS_ID,
             REMOVE_LEGACY_INSTALLED_TOOLS_PREFERENCE_ID,
             REMOVE_WINDOWS_SYMLINK_NOTICE_PREFERENCE_ID,
+            REMOVE_LEGACY_VSCODE_FLAG_ID,
         ]);
         expect(readMigrationState(statePath)).toMatchObject({
             lastSeenVersion: '1.12.0',
@@ -152,6 +155,10 @@ describe('AppMigrationsModule', () => {
                     id: REMOVE_WINDOWS_SYMLINK_NOTICE_PREFERENCE_ID,
                     launcherVersion: '1.12.0',
                 },
+                {
+                    id: REMOVE_LEGACY_VSCODE_FLAG_ID,
+                    launcherVersion: '1.12.0',
+                },
             ],
         });
         for (const migration of readMigrationState(statePath).completed) {
@@ -172,7 +179,9 @@ describe('AppMigrationsModule', () => {
         expect(
             operationMocks.migrateCodeEditorPreferences,
         ).toHaveBeenCalledOnce();
-        expect(operationMocks.migrateCodeEditorProjects).toHaveBeenCalledOnce();
+        expect(operationMocks.migrateCodeEditorProjects).toHaveBeenCalledTimes(
+            2,
+        );
         expect(operationMocks.writePreferences).toHaveBeenCalledTimes(2);
         expect(readMigrationState(statePath)).toEqual({
             lastSeenVersion: '1.12.0',
@@ -198,6 +207,11 @@ describe('AppMigrationsModule', () => {
                     executedAt: expect.any(String),
                     launcherVersion: '1.12.0',
                 },
+                {
+                    id: REMOVE_LEGACY_VSCODE_FLAG_ID,
+                    executedAt: expect.any(String),
+                    launcherVersion: '1.12.0',
+                },
             ],
         });
     });
@@ -214,6 +228,7 @@ describe('AppMigrationsModule', () => {
             MIGRATE_CODE_EDITOR_PROJECTS_ID,
             REMOVE_LEGACY_INSTALLED_TOOLS_PREFERENCE_ID,
             REMOVE_WINDOWS_SYMLINK_NOTICE_PREFERENCE_ID,
+            REMOVE_LEGACY_VSCODE_FLAG_ID,
         ]);
 
         await bootstrapMigrations(statePath);
@@ -221,12 +236,15 @@ describe('AppMigrationsModule', () => {
         expect(
             operationMocks.migrateCodeEditorPreferences,
         ).toHaveBeenCalledTimes(2);
-        expect(operationMocks.migrateCodeEditorProjects).toHaveBeenCalledOnce();
+        expect(operationMocks.migrateCodeEditorProjects).toHaveBeenCalledTimes(
+            2,
+        );
         expect(readCompletedIds(statePath)).toEqual([
             CLEAR_RELEASE_CACHE_MIGRATION_ID,
             MIGRATE_CODE_EDITOR_PROJECTS_ID,
             REMOVE_LEGACY_INSTALLED_TOOLS_PREFERENCE_ID,
             REMOVE_WINDOWS_SYMLINK_NOTICE_PREFERENCE_ID,
+            REMOVE_LEGACY_VSCODE_FLAG_ID,
             MIGRATE_CODE_EDITOR_PREFERENCES_ID,
         ]);
     });
@@ -238,6 +256,30 @@ describe('AppMigrationsModule', () => {
         await expect(new ClearReleaseCacheMigration().execute()).rejects.toBe(
             error,
         );
+    });
+
+    it('cleans profiles whose original code editor migration already completed', async () => {
+        writeMigrationState(statePath, {
+            lastSeenVersion: '1.11.1',
+            completed: [
+                CLEAR_RELEASE_CACHE_MIGRATION_ID,
+                MIGRATE_CODE_EDITOR_PREFERENCES_ID,
+                MIGRATE_CODE_EDITOR_PROJECTS_ID,
+                REMOVE_LEGACY_INSTALLED_TOOLS_PREFERENCE_ID,
+                REMOVE_WINDOWS_SYMLINK_NOTICE_PREFERENCE_ID,
+            ],
+        });
+
+        await bootstrapMigrations(statePath);
+        await bootstrapMigrations(statePath);
+
+        expect(operationMocks.migrateCodeEditorProjects).toHaveBeenCalledOnce();
+        expect(readCompletedIds(statePath)).toContain(
+            REMOVE_LEGACY_VSCODE_FLAG_ID,
+        );
+        expect(
+            operationMocks.migrateCodeEditorPreferences,
+        ).not.toHaveBeenCalled();
     });
 });
 

--- a/main/src/app-migrations/app-migrations.module.ts
+++ b/main/src/app-migrations/app-migrations.module.ts
@@ -5,6 +5,7 @@ import { ClearReleaseCacheMigration } from './migrations/clear-release-cache.mig
 import { MigrateCodeEditorPreferencesMigration } from './migrations/code-editor-preferences.migration.js';
 import { MigrateCodeEditorProjectsMigration } from './migrations/code-editor-projects.migration.js';
 import { RemoveLegacyInstalledToolsPreferenceMigration } from './migrations/remove-legacy-installed-tools-preference.migration.js';
+import { RemoveLegacyVSCodeFlagMigration } from './migrations/remove-legacy-vscode-flag.migration.js';
 import { RemoveWindowsSymlinkNoticePreferenceMigration } from './migrations/remove-windows-symlink-notice-preference.migration.js';
 
 @Module({
@@ -19,6 +20,7 @@ import { RemoveWindowsSymlinkNoticePreferenceMigration } from './migrations/remo
         MigrateCodeEditorProjectsMigration,
         RemoveLegacyInstalledToolsPreferenceMigration,
         RemoveWindowsSymlinkNoticePreferenceMigration,
+        RemoveLegacyVSCodeFlagMigration,
     ],
 })
 export class AppMigrationsModule {}

--- a/main/src/app-migrations/code-editor-persistence.util.test.ts
+++ b/main/src/app-migrations/code-editor-persistence.util.test.ts
@@ -37,14 +37,12 @@ describe('code editor persistence migrations', () => {
         vi.clearAllMocks();
     });
 
-    it('canonicalizes missing project selections and retains the mirror', () => {
+    it('canonicalises missing project selections without the mirror', () => {
         expect(migrateStoredProjectRecord({ withVSCode: true })).toEqual({
             codeEditorId: 'vscode',
-            withVSCode: true,
         });
         expect(migrateStoredProjectRecord({ withVSCode: false })).toEqual({
             codeEditorId: null,
-            withVSCode: false,
         });
     });
 
@@ -54,7 +52,7 @@ describe('code editor persistence migrations', () => {
                 codeEditorId: null,
                 withVSCode: true,
             }),
-        ).toEqual({ codeEditorId: null, withVSCode: false });
+        ).toEqual({ codeEditorId: null });
     });
 
     it('copies a pre-v4 legacy path and removes the old field', () => {
@@ -92,7 +90,7 @@ describe('code editor persistence migrations', () => {
         });
     });
 
-    it('migrates project files and keeps legacy fields on disk', async () => {
+    it('migrates project files and removes legacy fields from disk', async () => {
         writeFileSync(
             projectsPath,
             JSON.stringify([{ path: '/project', withVSCode: true }]),
@@ -104,7 +102,6 @@ describe('code editor persistence migrations', () => {
             {
                 path: '/project',
                 codeEditorId: 'vscode',
-                withVSCode: true,
             },
         ]);
     });
@@ -116,6 +113,54 @@ describe('code editor persistence migrations', () => {
         await expect(migrateCodeEditorProjects()).rejects.toThrow();
         expect(readFileSync(projectsPath, 'utf-8')).toBe(malformed);
     });
+
+    it('preserves selections, unrelated fields and order across repeated runs', async () => {
+        const records = [
+            { path: '/z', codeEditorId: 'vscodium', withVSCode: true },
+            { path: '/a', codeEditorId: 'vscode', withVSCode: false },
+            { path: '/b', codeEditorId: null, withVSCode: true },
+            { path: '/c', withVSCode: false },
+            {
+                path: '/d',
+                last_opened: '2026-09-01T10:00:00.000Z',
+                extra: { keep: true },
+            },
+        ];
+        writeFileSync(projectsPath, JSON.stringify(records));
+
+        await migrateCodeEditorProjects();
+        const first = readFileSync(projectsPath, 'utf-8');
+        await migrateCodeEditorProjects();
+
+        expect(readFileSync(projectsPath, 'utf-8')).toBe(first);
+        expect(JSON.parse(first)).toEqual([
+            { path: '/z', codeEditorId: 'vscodium' },
+            { path: '/a', codeEditorId: 'vscode' },
+            { path: '/b', codeEditorId: null },
+            { path: '/c', codeEditorId: null },
+            {
+                path: '/d',
+                codeEditorId: null,
+                last_opened: '2026-09-01T10:00:00.000Z',
+                extra: { keep: true },
+            },
+        ]);
+    });
+
+    it('leaves a missing project file absent', async () => {
+        await expect(migrateCodeEditorProjects()).resolves.toBeUndefined();
+        expect(() => readFileSync(projectsPath)).toThrow();
+    });
+
+    it.each([{}, [null], [{ withVSCode: true }, 42]])(
+        'rejects an invalid project list without a partial rewrite: %j',
+        async (value) => {
+            const original = JSON.stringify(value);
+            writeFileSync(projectsPath, original);
+            await expect(migrateCodeEditorProjects()).rejects.toThrow();
+            expect(readFileSync(projectsPath, 'utf-8')).toBe(original);
+        },
+    );
 
     it('migrates preferences independently from project data', async () => {
         writeFileSync(

--- a/main/src/app-migrations/code-editor-persistence.util.ts
+++ b/main/src/app-migrations/code-editor-persistence.util.ts
@@ -37,18 +37,24 @@ async function writeJsonIfChanged(
     await fs.writeFile(filePath, JSON.stringify(migrated, null, 4), 'utf-8');
 }
 
+/**
+ * Converts legacy editor input to the canonical selection without its mirror.
+ *
+ * @param project - Stored project record to migrate.
+ * @returns The canonical record with unrelated fields preserved.
+ */
 export function migrateStoredProjectRecord(project: JsonRecord): JsonRecord {
+    const { withVSCode, ...canonicalProject } = project;
     const codeEditorId =
         project.codeEditorId !== undefined
             ? project.codeEditorId
-            : project.withVSCode === true
+            : withVSCode === true
               ? 'vscode'
               : null;
 
     return {
-        ...project,
+        ...canonicalProject,
         codeEditorId,
-        withVSCode: codeEditorId === 'vscode',
     };
 }
 

--- a/main/src/app-migrations/migrations/remove-legacy-vscode-flag.migration.ts
+++ b/main/src/app-migrations/migrations/remove-legacy-vscode-flag.migration.ts
@@ -1,0 +1,19 @@
+import {
+    AppMigration,
+    type AppMigrationRunnable,
+} from '@mariodebono/di-app-migrations';
+import { migrateCodeEditorProjects } from '../code-editor-persistence.util.js';
+
+export const REMOVE_LEGACY_VSCODE_FLAG_ID = '2026-09-remove-legacy-vscode-flag';
+
+@AppMigration({
+    id: REMOVE_LEGACY_VSCODE_FLAG_ID,
+    fatal: false,
+    description: 'Remove the legacy VS Code project flag.',
+})
+export class RemoveLegacyVSCodeFlagMigration implements AppMigrationRunnable {
+    /** Removes the persisted mirror while preserving code editor selections. */
+    async execute(): Promise<void> {
+        await migrateCodeEditorProjects();
+    }
+}

--- a/main/src/projects/projects.store.test.ts
+++ b/main/src/projects/projects.store.test.ts
@@ -73,6 +73,56 @@ describe('ProjectsStore', () => {
         expect(projects[1].last_opened).toBeInstanceOf(Date);
     });
 
+    it.each(['vscode', 'vscodium', null] as const)(
+        'preserves canonical %s through legacy reads and subsequent writes',
+        async (codeEditorId) => {
+            await fs.writeFile(
+                projectsPath,
+                JSON.stringify([
+                    {
+                        ...createProject('/projects/game', null),
+                        codeEditorId,
+                        withVSCode: codeEditorId !== 'vscode',
+                    },
+                ]),
+            );
+
+            const [project] = await store.list();
+            expect(project.codeEditorId).toBe(codeEditorId);
+            await store.put(project);
+
+            const [stored] = JSON.parse(
+                await fs.readFile(projectsPath, 'utf-8'),
+            );
+            expect(stored.codeEditorId).toBe(codeEditorId);
+            expect(stored).not.toHaveProperty('withVSCode');
+        },
+    );
+
+    it.each([true, false, undefined])(
+        'rewrites legacy %s without the flag',
+        async (withVSCode) => {
+            await fs.writeFile(
+                projectsPath,
+                JSON.stringify([
+                    {
+                        ...createProject('/projects/legacy', null),
+                        codeEditorId: undefined,
+                        withVSCode,
+                    },
+                ]),
+            );
+
+            await store.replace(await store.list());
+
+            const [stored] = JSON.parse(
+                await fs.readFile(projectsPath, 'utf-8'),
+            );
+            expect(stored.codeEditorId).toBe(withVSCode ? 'vscode' : null);
+            expect(stored).not.toHaveProperty('withVSCode');
+        },
+    );
+
     it('replaces duplicate paths and removes exact paths', async () => {
         await store.put(createProject('/projects/game', null));
         await store.put({

--- a/main/src/projects/projects.store.ts
+++ b/main/src/projects/projects.store.ts
@@ -4,7 +4,7 @@ import { JsonFileStore } from '../json-store/json-file.store.js';
 import type { JsonStoreWriteOptions } from '../json-store/json-store.types.js';
 import type { JsonStoreCoordinatorService } from '../json-store/json-store-coordinator.service.js';
 
-/** Describes the on-disk project shape retained for compatibility. */
+/** Describes stored projects, including input from older profiles. */
 export type StoredProjectDetails = Omit<
     ProjectDetails,
     'added_at' | 'codeEditorId' | 'last_opened'
@@ -50,10 +50,10 @@ export function fromStoredProject(
 }
 
 /**
- * Converts one project into the existing on-disk shape.
+ * Converts one project into the canonical on-disk shape.
  *
  * @param project - Application project to convert.
- * @returns The compatible stored project.
+ * @returns The canonical stored project.
  */
 export function toStoredProject(project: ProjectDetails): StoredProjectDetails {
     return {
@@ -61,7 +61,6 @@ export function toStoredProject(project: ProjectDetails): StoredProjectDetails {
         pinned_order: project.pinned
             ? normalizePinnedOrder(project.pinned_order)
             : undefined,
-        withVSCode: project.codeEditorId === 'vscode',
     };
 }
 


### PR DESCRIPTION
Persist only codeEditorId and migrate existing records to remove withVSCode, preserving editor selections and unrelated project data.

Legacy profiles remain supported on upgrade. Downgrading to versions before 1.11 no longer restores VS Code selections through the retired flag.