### PR TITLE
fix(settings): Align Settings location selectors and isolate E2E preferences

### DIFF
--- a/e2e/SettingsView.spec.ts
+++ b/e2e/SettingsView.spec.ts
@@ -1,6 +1,7 @@
 import { _electron, expect, test } from '@playwright/test';
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import type { UserPreferences } from '@shared/contracts';
 import {
     createFixtureHome,
     setAppLanguage,
@@ -30,6 +31,31 @@ test.beforeEach(async () => {
 test.afterEach(async () => {
     await electronApp?.close();
     await fs.rm(fixtureHome, { recursive: true, force: true });
+});
+
+test('isolates persisted preferences and Electron user data', async () => {
+    const userDataPath = await electronApp.evaluate(({ app }) =>
+        app.getPath('userData'),
+    );
+    const preferences = JSON.parse(
+        await fs.readFile(
+            path.join(fixtureHome, '.gd-launcher', 'prefs.json'),
+            'utf-8',
+        ),
+    ) as UserPreferences;
+
+    expect(await fs.realpath(userDataPath)).toBe(
+        await fs.realpath(path.join(fixtureHome, 'electron-user-data')),
+    );
+    expect(preferences.projects_location).toBe(
+        path.join(fixtureHome, 'Godot', 'Projects'),
+    );
+    expect(preferences.install_location).toBe(
+        path.join(fixtureHome, 'Godot', 'Editors'),
+    );
+    expect(preferences.config_location).toBe(
+        path.join(fixtureHome, '.gd-launcher'),
+    );
 });
 
 test('Can set theme light', async () => {
@@ -75,6 +101,201 @@ test('Can open the Connections presentation from its shortcut', async () => {
     ).toBeEnabled();
 });
 
+const locationConfigurations = [
+    {
+        name: 'Projects',
+        tabTestId: 'tabProjects',
+        pathTestId: 'projectLocationPath',
+        browseTestId: 'btnSelectProjectDir',
+        preferenceKey: 'projects_location' as const,
+        currentPath: (homeDir: string) =>
+            path.join(homeDir, 'Godot', 'Projects'),
+        selectedPath: '/Users/docs/Work/Projects',
+        dialogTitle: 'Select Project Directory',
+    },
+    {
+        name: 'Installs',
+        tabTestId: 'tabInstalls',
+        pathTestId: 'editorInstallLocationPath',
+        browseTestId: 'btnSelectInstallDir',
+        preferenceKey: 'install_location' as const,
+        currentPath: (homeDir: string) =>
+            path.join(homeDir, 'Godot', 'Editors'),
+        selectedPath: '/Users/docs/Work/Editors',
+        dialogTitle: 'Select Install Directory',
+    },
+];
+
+for (const configuration of locationConfigurations) {
+    test(`${configuration.name} location preserves dialog, focus, and layout behaviour`, async () => {
+        const currentPath = configuration.currentPath(fixtureHome);
+        await mainPage.getByTestId(configuration.tabTestId).click();
+        const pathField = mainPage.getByTestId(configuration.pathTestId);
+        const browseButton = mainPage.getByTestId(
+            configuration.browseTestId,
+        );
+
+        await expect(pathField).toHaveValue(currentPath);
+        await expect(pathField).toHaveAttribute('readonly', '');
+        await pathField.selectText();
+        expect(
+            await pathField.evaluate((input: HTMLInputElement) => ({
+                start: input.selectionStart,
+                end: input.selectionEnd,
+                length: input.value.length,
+            })),
+        ).toEqual({
+            start: 0,
+            end: currentPath.length,
+            length: currentPath.length,
+        });
+
+        await stubSettingsLocationHandlers({
+            result: { canceled: true, filePaths: [] },
+            pending: true,
+        });
+        await browseButton.focus();
+        await browseButton.press('Enter');
+
+        const waitingMessage = mainPage.getByText('Waiting for dialog...', {
+            exact: true,
+        });
+        await expect(waitingMessage).toBeVisible();
+        await expect
+            .poll(() => readSettingsLocationCalls('directory'))
+            .toEqual([
+                [currentPath, configuration.dialogTitle],
+            ]);
+
+        await releaseSettingsLocationDialog();
+        await expect(waitingMessage).not.toBeVisible();
+        await expect(pathField).toHaveValue(currentPath);
+        await expect(browseButton).toBeFocused();
+        expect(await readSettingsLocationCalls('preferences')).toEqual([]);
+
+        await stubSettingsLocationHandlers({
+            result: {
+                canceled: false,
+                filePaths: [configuration.selectedPath],
+            },
+        });
+        await browseButton.click();
+
+        await expect(pathField).toHaveValue(configuration.selectedPath);
+        await expect
+            .poll(() => readSettingsLocationCalls('preferences'))
+            .toHaveLength(1);
+        const savedPreferences = (
+            await readSettingsLocationCalls('preferences')
+        )[0]?.[0] as UserPreferences;
+        expect(savedPreferences[configuration.preferenceKey]).toBe(
+            configuration.selectedPath,
+        );
+
+        await mainPage.setViewportSize({ width: 1024, height: 600 });
+        const viewportWidth = await mainPage.evaluate(() => window.innerWidth);
+        for (const locator of [pathField, browseButton]) {
+            const box = await locator.boundingBox();
+            expect(box).not.toBeNull();
+            expect(box?.x).toBeGreaterThanOrEqual(0);
+            expect((box?.x ?? 0) + (box?.width ?? 0)).toBeLessThanOrEqual(
+                viewportWidth,
+            );
+        }
+    });
+}
+
+type SettingsLocationHandlerOptions = {
+    result: { canceled: boolean; filePaths: string[] };
+    pending?: boolean;
+};
+
+/**
+ * Stubs and records Settings directory selection and preference saves.
+ *
+ * @param options - Directory result and optional pending state.
+ */
+async function stubSettingsLocationHandlers(
+    options: SettingsLocationHandlerOptions,
+): Promise<void> {
+    await electronApp.evaluate(
+        ({ ipcMain }, injected: SettingsLocationHandlerOptions) => {
+            const state = globalThis as typeof globalThis & {
+                __settingsLocationE2E?: {
+                    directoryCalls: unknown[][];
+                    preferenceCalls: unknown[][];
+                    release?: () => void;
+                };
+            };
+            const handlerState = {
+                directoryCalls: [],
+                preferenceCalls: [],
+            } as NonNullable<typeof state.__settingsLocationE2E>;
+            state.__settingsLocationE2E = handlerState;
+
+            ipcMain.removeHandler('app.openDirectoryDialog');
+            ipcMain.handle(
+                'app.openDirectoryDialog',
+                async (_event, ...args) => {
+                    handlerState.directoryCalls.push(args);
+                    if (injected.pending) {
+                        await new Promise<void>((resolve) => {
+                            handlerState.release = resolve;
+                        });
+                    }
+                    return { success: true, data: injected.result };
+                },
+            );
+
+            ipcMain.removeHandler('app.setUserPreferences');
+            ipcMain.handle(
+                'app.setUserPreferences',
+                async (_event, nextPreferences: UserPreferences) => {
+                    handlerState.preferenceCalls.push([nextPreferences]);
+                    return { success: true, data: nextPreferences };
+                },
+            );
+        },
+        options,
+    );
+}
+
+/**
+ * Reads recorded Settings location IPC arguments.
+ *
+ * @param kind - Handler whose calls should be returned.
+ * @returns Recorded argument arrays.
+ */
+async function readSettingsLocationCalls(
+    kind: 'directory' | 'preferences',
+): Promise<unknown[][]> {
+    return await electronApp.evaluate((_electron, injectedKind) => {
+        const state = globalThis as typeof globalThis & {
+            __settingsLocationE2E?: {
+                directoryCalls: unknown[][];
+                preferenceCalls: unknown[][];
+            };
+        };
+        return injectedKind === 'directory'
+            ? (state.__settingsLocationE2E?.directoryCalls ?? [])
+            : (state.__settingsLocationE2E?.preferenceCalls ?? []);
+    }, kind);
+}
+
+/** Releases the pending Settings directory dialog response. */
+async function releaseSettingsLocationDialog(): Promise<void> {
+    await electronApp.evaluate(() => {
+        const state = globalThis as typeof globalThis & {
+            __settingsLocationE2E?: { release?: () => void };
+        };
+        const release = state.__settingsLocationE2E?.release;
+        if (!release) {
+            throw new Error('No pending Settings directory dialog.');
+        }
+        release();
+    });
+}
+
 /**
  * Creates an isolated environment for one Electron E2E app.
  *
@@ -84,14 +305,6 @@ test('Can open the Connections presentation from its shortcut', async () => {
 function createIsolatedLaunchEnvironment(
     homeDir: string,
 ): Record<string, string> {
-    const overrideHomeScript = path.resolve(
-        process.cwd(),
-        'e2e',
-        'support',
-        'overrideHome.cjs',
-    );
-    const existingNodeOptions = process.env.NODE_OPTIONS?.trim();
-    const requireOverrideOption = `--require "${overrideHomeScript}"`;
     const launchEnvironment: Record<string, string> = {
         ...Object.fromEntries(
             Object.entries(process.env).filter(
@@ -100,12 +313,15 @@ function createIsolatedLaunchEnvironment(
             ),
         ),
         APPDATA: path.join(homeDir, 'AppData', 'Roaming'),
+        HOME: homeDir,
         LOCALAPPDATA: path.join(homeDir, 'AppData', 'Local'),
+        USERPROFILE: homeDir,
+        XDG_CACHE_HOME: path.join(homeDir, '.cache'),
+        XDG_CONFIG_HOME: path.join(homeDir, '.config'),
+        XDG_DATA_HOME: path.join(homeDir, '.local', 'share'),
+        XDG_STATE_HOME: path.join(homeDir, '.local', 'state'),
         GODOT_LAUNCHER_E2E_FIXTURES: '1',
         GODOT_LAUNCHER_E2E_HOME_DIR: homeDir,
-        NODE_OPTIONS: existingNodeOptions
-            ? `${existingNodeOptions} ${requireOverrideOption}`
-            : requireOverrideOption,
     };
     delete launchEnvironment.ELECTRON_RUN_AS_NODE;
     return launchEnvironment;

--- a/e2e/codeEditorIntegration.spec.ts
+++ b/e2e/codeEditorIntegration.spec.ts
@@ -32,7 +32,7 @@ test.describe.configure({ mode: 'serial' });
 test.beforeAll(async () => {
     fixtureHome = await createFixtureHome();
     electronApp = await _electron.launch({
-        args: ['.'],
+        args: ['.', `--user-data-dir=${path.join(fixtureHome, 'electron-user-data')}`],
         env: createIsolatedLaunchEnvironment(fixtureHome),
     });
     mainPage = await getMainWindow(electronApp);
@@ -907,14 +907,6 @@ async function openCodeEditorSettings() {
 }
 
 function createIsolatedLaunchEnvironment(homeDir: string) {
-    const overrideHomeScript = path.resolve(
-        process.cwd(),
-        'e2e',
-        'support',
-        'overrideHome.cjs',
-    );
-    const existingNodeOptions = process.env.NODE_OPTIONS?.trim();
-    const requireOverrideOption = `--require "${overrideHomeScript}"`;
     const launchEnv: Record<string, string> = {
         ...Object.fromEntries(
             Object.entries(process.env).filter(
@@ -923,12 +915,15 @@ function createIsolatedLaunchEnvironment(homeDir: string) {
             ),
         ),
         APPDATA: path.join(homeDir, 'AppData', 'Roaming'),
+        HOME: homeDir,
         LOCALAPPDATA: path.join(homeDir, 'AppData', 'Local'),
+        USERPROFILE: homeDir,
+        XDG_CACHE_HOME: path.join(homeDir, '.cache'),
+        XDG_CONFIG_HOME: path.join(homeDir, '.config'),
+        XDG_DATA_HOME: path.join(homeDir, '.local', 'share'),
+        XDG_STATE_HOME: path.join(homeDir, '.local', 'state'),
         GODOT_LAUNCHER_E2E_FIXTURES: '1',
         GODOT_LAUNCHER_E2E_HOME_DIR: homeDir,
-        NODE_OPTIONS: existingNodeOptions
-            ? `${existingNodeOptions} ${requireOverrideOption}`
-            : requireOverrideOption,
     };
     delete launchEnv.ELECTRON_RUN_AS_NODE;
     return launchEnv;

--- a/e2e/create-project-catalogue-recovery.spec.ts
+++ b/e2e/create-project-catalogue-recovery.spec.ts
@@ -25,7 +25,7 @@ test.describe.configure({ mode: 'serial' });
 test.beforeAll(async () => {
     fixtureHome = await createFixtureHome();
     electronApp = await _electron.launch({
-        args: ['.'],
+        args: ['.', `--user-data-dir=${path.join(fixtureHome, 'electron-user-data')}`],
         env: createIsolatedLaunchEnvironment(fixtureHome),
     });
     mainPage = await getMainWindow(electronApp);
@@ -164,14 +164,6 @@ function createRecoveredCatalogue(): EditorCatalogResult {
 function createIsolatedLaunchEnvironment(
     homeDir: string,
 ): Record<string, string> {
-    const overrideHomeScript = path.resolve(
-        process.cwd(),
-        'e2e',
-        'support',
-        'overrideHome.cjs',
-    );
-    const existingNodeOptions = process.env.NODE_OPTIONS?.trim();
-    const requireOverrideOption = `--require "${overrideHomeScript}"`;
     const environment: Record<string, string> = {
         ...Object.fromEntries(
             Object.entries(process.env).filter(
@@ -180,12 +172,15 @@ function createIsolatedLaunchEnvironment(
             ),
         ),
         APPDATA: path.join(homeDir, 'AppData', 'Roaming'),
+        HOME: homeDir,
         LOCALAPPDATA: path.join(homeDir, 'AppData', 'Local'),
+        USERPROFILE: homeDir,
+        XDG_CACHE_HOME: path.join(homeDir, '.cache'),
+        XDG_CONFIG_HOME: path.join(homeDir, '.config'),
+        XDG_DATA_HOME: path.join(homeDir, '.local', 'share'),
+        XDG_STATE_HOME: path.join(homeDir, '.local', 'state'),
         GODOT_LAUNCHER_E2E_FIXTURES: '1',
         GODOT_LAUNCHER_E2E_HOME_DIR: homeDir,
-        NODE_OPTIONS: existingNodeOptions
-            ? `${existingNodeOptions} ${requireOverrideOption}`
-            : requireOverrideOption,
     };
     delete environment.ELECTRON_RUN_AS_NODE;
     return environment;

--- a/e2e/create-project-progress.spec.ts
+++ b/e2e/create-project-progress.spec.ts
@@ -33,7 +33,7 @@ test.describe.configure({ mode: 'serial' });
 test.beforeAll(async () => {
     fixtureHome = await createFixtureHome();
     electronApp = await _electron.launch({
-        args: ['.'],
+        args: ['.', `--user-data-dir=${path.join(fixtureHome, 'electron-user-data')}`],
         env: createIsolatedLaunchEnvironment(fixtureHome),
     });
     mainPage = await getMainWindow(electronApp);
@@ -493,14 +493,6 @@ async function readSubmittedProjectPath(): Promise<string | undefined> {
 function createIsolatedLaunchEnvironment(
     homeDir: string,
 ): Record<string, string> {
-    const overrideHomeScript = path.resolve(
-        process.cwd(),
-        'e2e',
-        'support',
-        'overrideHome.cjs',
-    );
-    const existingNodeOptions = process.env.NODE_OPTIONS?.trim();
-    const requireOverrideOption = `--require "${overrideHomeScript}"`;
     const environment: Record<string, string> = {
         ...Object.fromEntries(
             Object.entries(process.env).filter(
@@ -509,12 +501,15 @@ function createIsolatedLaunchEnvironment(
             ),
         ),
         APPDATA: path.join(homeDir, 'AppData', 'Roaming'),
+        HOME: homeDir,
         LOCALAPPDATA: path.join(homeDir, 'AppData', 'Local'),
+        USERPROFILE: homeDir,
+        XDG_CACHE_HOME: path.join(homeDir, '.cache'),
+        XDG_CONFIG_HOME: path.join(homeDir, '.config'),
+        XDG_DATA_HOME: path.join(homeDir, '.local', 'share'),
+        XDG_STATE_HOME: path.join(homeDir, '.local', 'state'),
         GODOT_LAUNCHER_E2E_FIXTURES: '1',
         GODOT_LAUNCHER_E2E_HOME_DIR: homeDir,
-        NODE_OPTIONS: existingNodeOptions
-            ? `${existingNodeOptions} ${requireOverrideOption}`
-            : requireOverrideOption,
     };
     delete environment.ELECTRON_RUN_AS_NODE;
     return environment;

--- a/e2e/create-project-session.spec.ts
+++ b/e2e/create-project-session.spec.ts
@@ -28,7 +28,7 @@ test.describe.configure({ mode: 'serial' });
 test.beforeAll(async () => {
     fixtureHome = await createFixtureHome();
     electronApp = await _electron.launch({
-        args: ['.'],
+        args: ['.', `--user-data-dir=${path.join(fixtureHome, 'electron-user-data')}`],
         env: createIsolatedLaunchEnvironment(fixtureHome),
     });
     mainPage = await getMainWindow(electronApp);
@@ -492,14 +492,6 @@ async function readCreateProjectCalls(): Promise<unknown[][]> {
 function createIsolatedLaunchEnvironment(
     homeDir: string,
 ): Record<string, string> {
-    const overrideHomeScript = path.resolve(
-        process.cwd(),
-        'e2e',
-        'support',
-        'overrideHome.cjs',
-    );
-    const existingNodeOptions = process.env.NODE_OPTIONS?.trim();
-    const requireOverrideOption = `--require "${overrideHomeScript}"`;
     const environment: Record<string, string> = {
         ...Object.fromEntries(
             Object.entries(process.env).filter(
@@ -508,12 +500,15 @@ function createIsolatedLaunchEnvironment(
             ),
         ),
         APPDATA: path.join(homeDir, 'AppData', 'Roaming'),
+        HOME: homeDir,
         LOCALAPPDATA: path.join(homeDir, 'AppData', 'Local'),
+        USERPROFILE: homeDir,
+        XDG_CACHE_HOME: path.join(homeDir, '.cache'),
+        XDG_CONFIG_HOME: path.join(homeDir, '.config'),
+        XDG_DATA_HOME: path.join(homeDir, '.local', 'share'),
+        XDG_STATE_HOME: path.join(homeDir, '.local', 'state'),
         GODOT_LAUNCHER_E2E_FIXTURES: '1',
         GODOT_LAUNCHER_E2E_HOME_DIR: homeDir,
-        NODE_OPTIONS: existingNodeOptions
-            ? `${existingNodeOptions} ${requireOverrideOption}`
-            : requireOverrideOption,
     };
     delete environment.ELECTRON_RUN_AS_NODE;
     return environment;

--- a/e2e/createProjectGithubPublishing.spec.ts
+++ b/e2e/createProjectGithubPublishing.spec.ts
@@ -803,14 +803,6 @@ test('shows local completion when a parent repository appears after preflight', 
 function createIsolatedLaunchEnvironment(
     homeDir: string,
 ): Record<string, string> {
-    const overrideHomeScript = path.resolve(
-        process.cwd(),
-        'e2e',
-        'support',
-        'overrideHome.cjs',
-    );
-    const existingNodeOptions = process.env.NODE_OPTIONS?.trim();
-    const requireOverrideOption = `--require "${overrideHomeScript}"`;
     const environment: Record<string, string> = {
         ...Object.fromEntries(
             Object.entries(process.env).filter(
@@ -819,12 +811,15 @@ function createIsolatedLaunchEnvironment(
             ),
         ),
         APPDATA: path.join(homeDir, 'AppData', 'Roaming'),
+        HOME: homeDir,
         LOCALAPPDATA: path.join(homeDir, 'AppData', 'Local'),
+        USERPROFILE: homeDir,
+        XDG_CACHE_HOME: path.join(homeDir, '.cache'),
+        XDG_CONFIG_HOME: path.join(homeDir, '.config'),
+        XDG_DATA_HOME: path.join(homeDir, '.local', 'share'),
+        XDG_STATE_HOME: path.join(homeDir, '.local', 'state'),
         GODOT_LAUNCHER_E2E_FIXTURES: '1',
         GODOT_LAUNCHER_E2E_HOME_DIR: homeDir,
-        NODE_OPTIONS: existingNodeOptions
-            ? `${existingNodeOptions} ${requireOverrideOption}`
-            : requireOverrideOption,
     };
     delete environment.ELECTRON_RUN_AS_NODE;
     return environment;

--- a/e2e/gitLfsCreateProject.spec.ts
+++ b/e2e/gitLfsCreateProject.spec.ts
@@ -25,7 +25,7 @@ test.describe.configure({ mode: 'serial' });
 test.beforeAll(async () => {
     fixtureHome = await createFixtureHome();
     electronApp = await _electron.launch({
-        args: ['.'],
+        args: ['.', `--user-data-dir=${path.join(fixtureHome, 'electron-user-data')}`],
         env: createIsolatedLaunchEnvironment(fixtureHome),
     });
     mainPage = await getMainWindow(electronApp);
@@ -140,14 +140,6 @@ async function openCreateProject(): Promise<void> {
 function createIsolatedLaunchEnvironment(
     homeDir: string,
 ): Record<string, string> {
-    const overrideHomeScript = path.resolve(
-        process.cwd(),
-        'e2e',
-        'support',
-        'overrideHome.cjs',
-    );
-    const existingNodeOptions = process.env.NODE_OPTIONS?.trim();
-    const requireOverrideOption = `--require "${overrideHomeScript}"`;
     const environment: Record<string, string> = {
         ...Object.fromEntries(
             Object.entries(process.env).filter(
@@ -156,12 +148,15 @@ function createIsolatedLaunchEnvironment(
             ),
         ),
         APPDATA: path.join(homeDir, 'AppData', 'Roaming'),
+        HOME: homeDir,
         LOCALAPPDATA: path.join(homeDir, 'AppData', 'Local'),
+        USERPROFILE: homeDir,
+        XDG_CACHE_HOME: path.join(homeDir, '.cache'),
+        XDG_CONFIG_HOME: path.join(homeDir, '.config'),
+        XDG_DATA_HOME: path.join(homeDir, '.local', 'share'),
+        XDG_STATE_HOME: path.join(homeDir, '.local', 'state'),
         GODOT_LAUNCHER_E2E_FIXTURES: '1',
         GODOT_LAUNCHER_E2E_HOME_DIR: homeDir,
-        NODE_OPTIONS: existingNodeOptions
-            ? `${existingNodeOptions} ${requireOverrideOption}`
-            : requireOverrideOption,
     };
     delete environment.ELECTRON_RUN_AS_NODE;
     return environment;

--- a/e2e/guided-empty-states.spec.ts
+++ b/e2e/guided-empty-states.spec.ts
@@ -41,7 +41,7 @@ test.describe.configure({ mode: 'serial' });
 test.beforeAll(async () => {
     fixtureHome = await createFixtureHome();
     electronApp = await _electron.launch({
-        args: ['.'],
+        args: ['.', `--user-data-dir=${path.join(fixtureHome, 'electron-user-data')}`],
         env: createIsolatedLaunchEnvironment(fixtureHome),
     });
     mainPage = await getMainWindow(electronApp);
@@ -2312,14 +2312,6 @@ async function publishReleaseInstallProgress(
 function createIsolatedLaunchEnvironment(
     homeDir: string,
 ): Record<string, string> {
-    const overrideHomeScript = path.resolve(
-        process.cwd(),
-        'e2e',
-        'support',
-        'overrideHome.cjs',
-    );
-    const existingNodeOptions = process.env.NODE_OPTIONS?.trim();
-    const requireOverrideOption = `--require "${overrideHomeScript}"`;
     const launchEnvironment: Record<string, string> = {
         ...Object.fromEntries(
             Object.entries(process.env).filter(
@@ -2328,12 +2320,15 @@ function createIsolatedLaunchEnvironment(
             ),
         ),
         APPDATA: path.join(homeDir, 'AppData', 'Roaming'),
+        HOME: homeDir,
         LOCALAPPDATA: path.join(homeDir, 'AppData', 'Local'),
+        USERPROFILE: homeDir,
+        XDG_CACHE_HOME: path.join(homeDir, '.cache'),
+        XDG_CONFIG_HOME: path.join(homeDir, '.config'),
+        XDG_DATA_HOME: path.join(homeDir, '.local', 'share'),
+        XDG_STATE_HOME: path.join(homeDir, '.local', 'state'),
         GODOT_LAUNCHER_E2E_FIXTURES: '1',
         GODOT_LAUNCHER_E2E_HOME_DIR: homeDir,
-        NODE_OPTIONS: existingNodeOptions
-            ? `${existingNodeOptions} ${requireOverrideOption}`
-            : requireOverrideOption,
     };
     delete launchEnvironment.ELECTRON_RUN_AS_NODE;
     return launchEnvironment;

--- a/e2e/legacy-code-editor-migration.spec.ts
+++ b/e2e/legacy-code-editor-migration.spec.ts
@@ -35,7 +35,13 @@ test('upgrades a legacy VS Code selection without retaining its flag', async () 
     const env = {
         ...process.env,
         APPDATA: path.join(fixtureHome, 'AppData', 'Roaming'),
+        HOME: fixtureHome,
         LOCALAPPDATA: path.join(fixtureHome, 'AppData', 'Local'),
+        USERPROFILE: fixtureHome,
+        XDG_CACHE_HOME: path.join(fixtureHome, '.cache'),
+        XDG_CONFIG_HOME: path.join(fixtureHome, '.config'),
+        XDG_DATA_HOME: path.join(fixtureHome, '.local', 'share'),
+        XDG_STATE_HOME: path.join(fixtureHome, '.local', 'state'),
         GODOT_LAUNCHER_E2E_FIXTURES: '1',
         GODOT_LAUNCHER_E2E_HOME_DIR: fixtureHome,
     };

--- a/e2e/mainWindow.spec.ts
+++ b/e2e/mainWindow.spec.ts
@@ -18,7 +18,7 @@ test.describe.configure({ mode: 'serial' });
 test.beforeAll(async () => {
     fixtureHome = await createFixtureHome();
     electronApp = await _electron.launch({
-        args: ['.'],
+        args: ['.', `--user-data-dir=${path.join(fixtureHome, 'electron-user-data')}`],
         env: createIsolatedLaunchEnvironment(fixtureHome),
     });
     mainPage = await getMainWindow(electronApp);
@@ -234,14 +234,6 @@ async function publishInstallProgress(
 function createIsolatedLaunchEnvironment(
     homeDir: string,
 ): Record<string, string> {
-    const overrideHomeScript = path.resolve(
-        process.cwd(),
-        'e2e',
-        'support',
-        'overrideHome.cjs',
-    );
-    const existingNodeOptions = process.env.NODE_OPTIONS?.trim();
-    const requireOverrideOption = `--require "${overrideHomeScript}"`;
     const launchEnvironment: Record<string, string> = {
         ...Object.fromEntries(
             Object.entries(process.env).filter(
@@ -250,13 +242,16 @@ function createIsolatedLaunchEnvironment(
             ),
         ),
         APPDATA: path.join(homeDir, 'AppData', 'Roaming'),
+        HOME: homeDir,
         LOCALAPPDATA: path.join(homeDir, 'AppData', 'Local'),
+        USERPROFILE: homeDir,
+        XDG_CACHE_HOME: path.join(homeDir, '.cache'),
+        XDG_CONFIG_HOME: path.join(homeDir, '.config'),
+        XDG_DATA_HOME: path.join(homeDir, '.local', 'share'),
+        XDG_STATE_HOME: path.join(homeDir, '.local', 'state'),
         GODOT_LAUNCHER_E2E_FIXTURES: '1',
         GODOT_LAUNCHER_E2E_HOME_DIR: homeDir,
         NODE_ENV: 'production',
-        NODE_OPTIONS: existingNodeOptions
-            ? `${existingNodeOptions} ${requireOverrideOption}`
-            : requireOverrideOption,
     };
     delete launchEnvironment.ELECTRON_RUN_AS_NODE;
     return launchEnvironment;

--- a/e2e/project-editor-download.spec.ts
+++ b/e2e/project-editor-download.spec.ts
@@ -41,7 +41,7 @@ test.describe.configure({ mode: 'serial' });
 test.beforeAll(async () => {
     fixtureHome = await createFixtureHome();
     electronApp = await _electron.launch({
-        args: ['.'],
+        args: ['.', `--user-data-dir=${path.join(fixtureHome, 'electron-user-data')}`],
         env: createIsolatedLaunchEnvironment(fixtureHome),
     });
     mainPage = await getMainWindow(electronApp);
@@ -342,14 +342,6 @@ async function readLaunchCalls(): Promise<number> {
 function createIsolatedLaunchEnvironment(
     homeDir: string,
 ): Record<string, string> {
-    const overrideHomeScript = path.resolve(
-        process.cwd(),
-        'e2e',
-        'support',
-        'overrideHome.cjs',
-    );
-    const existingNodeOptions = process.env.NODE_OPTIONS?.trim();
-    const requireOverrideOption = `--require "${overrideHomeScript}"`;
     const environment: Record<string, string> = {
         ...Object.fromEntries(
             Object.entries(process.env).filter(
@@ -358,12 +350,15 @@ function createIsolatedLaunchEnvironment(
             ),
         ),
         APPDATA: path.join(homeDir, 'AppData', 'Roaming'),
+        HOME: homeDir,
         LOCALAPPDATA: path.join(homeDir, 'AppData', 'Local'),
+        USERPROFILE: homeDir,
+        XDG_CACHE_HOME: path.join(homeDir, '.cache'),
+        XDG_CONFIG_HOME: path.join(homeDir, '.config'),
+        XDG_DATA_HOME: path.join(homeDir, '.local', 'share'),
+        XDG_STATE_HOME: path.join(homeDir, '.local', 'state'),
         GODOT_LAUNCHER_E2E_FIXTURES: '1',
         GODOT_LAUNCHER_E2E_HOME_DIR: homeDir,
-        NODE_OPTIONS: existingNodeOptions
-            ? `${existingNodeOptions} ${requireOverrideOption}`
-            : requireOverrideOption,
     };
     delete environment.ELECTRON_RUN_AS_NODE;
     return environment;

--- a/e2e/project-settings-catalogue.spec.ts
+++ b/e2e/project-settings-catalogue.spec.ts
@@ -18,7 +18,10 @@ const nextRelease: ReleaseSummary = {
 
 test.beforeAll(async () => {
     fixtureHome = await createFixtureHome();
-    electronApp = await _electron.launch({ args: ['.'], env: createIsolatedLaunchEnvironment(fixtureHome) });
+    electronApp = await _electron.launch({
+        args: ['.', `--user-data-dir=${path.join(fixtureHome, 'electron-user-data')}`],
+        env: createIsolatedLaunchEnvironment(fixtureHome),
+    });
     page = await getMainWindow(electronApp);
     await setAppLanguage(page, 'English');
 });
@@ -244,14 +247,6 @@ async function completeSettingsInstall(): Promise<void> {
 function createIsolatedLaunchEnvironment(
     homeDir: string,
 ): Record<string, string> {
-    const overrideHomeScript = path.resolve(
-        process.cwd(),
-        'e2e',
-        'support',
-        'overrideHome.cjs',
-    );
-    const existingNodeOptions = process.env.NODE_OPTIONS?.trim();
-    const requireOverrideOption = `--require "${overrideHomeScript}"`;
     const environment: Record<string, string> = {
         ...Object.fromEntries(
             Object.entries(process.env).filter(
@@ -260,12 +255,15 @@ function createIsolatedLaunchEnvironment(
             ),
         ),
         APPDATA: path.join(homeDir, 'AppData', 'Roaming'),
+        HOME: homeDir,
         LOCALAPPDATA: path.join(homeDir, 'AppData', 'Local'),
+        USERPROFILE: homeDir,
+        XDG_CACHE_HOME: path.join(homeDir, '.cache'),
+        XDG_CONFIG_HOME: path.join(homeDir, '.config'),
+        XDG_DATA_HOME: path.join(homeDir, '.local', 'share'),
+        XDG_STATE_HOME: path.join(homeDir, '.local', 'state'),
         GODOT_LAUNCHER_E2E_FIXTURES: '1',
         GODOT_LAUNCHER_E2E_HOME_DIR: homeDir,
-        NODE_OPTIONS: existingNodeOptions
-            ? `${existingNodeOptions} ${requireOverrideOption}`
-            : requireOverrideOption,
     };
     delete environment.ELECTRON_RUN_AS_NODE;
     return environment;

--- a/e2e/projects-compact-view.spec.ts
+++ b/e2e/projects-compact-view.spec.ts
@@ -13,7 +13,10 @@ test.describe.configure({ mode: 'serial' });
 
 test.beforeAll(async () => {
     fixtureHome = await createFixtureHome();
-    electronApp = await _electron.launch({ args: ['.'], env: createIsolatedLaunchEnvironment(fixtureHome) });
+    electronApp = await _electron.launch({
+        args: ['.', `--user-data-dir=${path.join(fixtureHome, 'electron-user-data')}`],
+        env: createIsolatedLaunchEnvironment(fixtureHome),
+    });
     mainPage = await getMainWindow(electronApp);
     await setAppLanguage(mainPage, 'English');
     await capturePreferences();
@@ -84,7 +87,10 @@ test('switches accessibly, preserves search, and remembers the view after restar
     await expect(list).toHaveAttribute('aria-selected', 'true');
 
     await electronApp.close();
-    electronApp = await _electron.launch({ args: ['.'], env: createIsolatedLaunchEnvironment(fixtureHome) });
+    electronApp = await _electron.launch({
+        args: ['.', `--user-data-dir=${path.join(fixtureHome, 'electron-user-data')}`],
+        env: createIsolatedLaunchEnvironment(fixtureHome),
+    });
     mainPage = await getMainWindow(electronApp);
     await capturePreferences();
     await prepareAppWithStubbedData(mainPage, electronApp);
@@ -290,14 +296,6 @@ async function readLaunches() {
  * @param homeDir - Temporary home for this test.
  */
 function createIsolatedLaunchEnvironment(homeDir: string) {
-    const overrideHomeScript = path.resolve(
-        process.cwd(),
-        'e2e',
-        'support',
-        'overrideHome.cjs',
-    );
-    const existingNodeOptions = process.env.NODE_OPTIONS?.trim();
-    const requireOverrideOption = `--require "${overrideHomeScript}"`;
     const launchEnv: Record<string, string> = {
         ...Object.fromEntries(
             Object.entries(process.env).filter(
@@ -306,12 +304,15 @@ function createIsolatedLaunchEnvironment(homeDir: string) {
             ),
         ),
         APPDATA: path.join(homeDir, 'AppData', 'Roaming'),
+        HOME: homeDir,
         LOCALAPPDATA: path.join(homeDir, 'AppData', 'Local'),
+        USERPROFILE: homeDir,
+        XDG_CACHE_HOME: path.join(homeDir, '.cache'),
+        XDG_CONFIG_HOME: path.join(homeDir, '.config'),
+        XDG_DATA_HOME: path.join(homeDir, '.local', 'share'),
+        XDG_STATE_HOME: path.join(homeDir, '.local', 'state'),
         GODOT_LAUNCHER_E2E_FIXTURES: '1',
         GODOT_LAUNCHER_E2E_HOME_DIR: homeDir,
-        NODE_OPTIONS: existingNodeOptions
-            ? `${existingNodeOptions} ${requireOverrideOption}`
-            : requireOverrideOption,
     };
     delete launchEnv.ELECTRON_RUN_AS_NODE;
     return launchEnv;

--- a/e2e/projects-ordering.spec.ts
+++ b/e2e/projects-ordering.spec.ts
@@ -23,7 +23,7 @@ let fixtureHome: string;
 test.beforeAll(async () => {
     fixtureHome = await createFixtureHome();
     electronApp = await _electron.launch({
-        args: ['.'],
+        args: ['.', `--user-data-dir=${path.join(fixtureHome, 'electron-user-data')}`],
         env: createIsolatedLaunchEnvironment(fixtureHome),
     });
     mainPage = await getMainWindow(electronApp);
@@ -209,14 +209,6 @@ async function installStatefulPinnedOrderHandlers(
 }
 
 function createIsolatedLaunchEnvironment(homeDir: string) {
-    const overrideHomeScript = path.resolve(
-        process.cwd(),
-        'e2e',
-        'support',
-        'overrideHome.cjs',
-    );
-    const existingNodeOptions = process.env.NODE_OPTIONS?.trim();
-    const requireOverrideOption = `--require "${overrideHomeScript}"`;
     const launchEnv: Record<string, string> = {
         ...Object.fromEntries(
             Object.entries(process.env).filter(
@@ -225,12 +217,15 @@ function createIsolatedLaunchEnvironment(homeDir: string) {
             ),
         ),
         APPDATA: path.join(homeDir, 'AppData', 'Roaming'),
+        HOME: homeDir,
         LOCALAPPDATA: path.join(homeDir, 'AppData', 'Local'),
+        USERPROFILE: homeDir,
+        XDG_CACHE_HOME: path.join(homeDir, '.cache'),
+        XDG_CONFIG_HOME: path.join(homeDir, '.config'),
+        XDG_DATA_HOME: path.join(homeDir, '.local', 'share'),
+        XDG_STATE_HOME: path.join(homeDir, '.local', 'state'),
         GODOT_LAUNCHER_E2E_FIXTURES: '1',
         GODOT_LAUNCHER_E2E_HOME_DIR: homeDir,
-        NODE_OPTIONS: existingNodeOptions
-            ? `${existingNodeOptions} ${requireOverrideOption}`
-            : requireOverrideOption,
     };
     delete launchEnv.ELECTRON_RUN_AS_NODE;
     return launchEnv;

--- a/e2e/support/e2e-fixture-data.ts
+++ b/e2e/support/e2e-fixture-data.ts
@@ -1,4 +1,5 @@
 // Shared deterministic data for ordinary Electron E2E fixtures.
+import path from 'node:path';
 import type {
     CodeEditorIntegrationSettings,
     GitLfsTrackingPolicyDescriptor,
@@ -257,6 +258,7 @@ export const SAMPLE_EDITOR_RESOLUTION_AVAILABLE_RELEASE: ReleaseSummary = {
 export const SAMPLE_AVAILABLE_RELEASES_WITH_EDITOR_RESOLUTION: ReleaseSummary[] =
     [SAMPLE_EDITOR_RESOLUTION_AVAILABLE_RELEASE, ...SAMPLE_AVAILABLE_RELEASES];
 
+/** Realistic fictional preferences for in-memory presentation fixtures. */
 export const SAMPLE_PREFS: UserPreferences = {
     prefs_version: 3,
     install_location: '/Users/docs/Godot/Editors',
@@ -272,6 +274,23 @@ export const SAMPLE_PREFS: UserPreferences = {
     windows_enable_symlinks: true,
     language: 'system',
 };
+
+/**
+ * Creates preferences whose filesystem locations stay inside one E2E home.
+ *
+ * @param homeDir - Isolated home directory used by the Electron test run.
+ * @returns Preferences suitable for tests that exercise real filesystem handlers.
+ */
+export function createFilesystemPreferences(
+    homeDir: string,
+): UserPreferences {
+    return {
+        ...SAMPLE_PREFS,
+        install_location: path.join(homeDir, 'Godot', 'Editors'),
+        config_location: path.join(homeDir, '.gd-launcher'),
+        projects_location: path.join(homeDir, 'Godot', 'Projects'),
+    };
+}
 
 /**
  * Creates user preferences by applying fixture overrides to the defaults.

--- a/e2e/support/e2e-fixture-runtime.ts
+++ b/e2e/support/e2e-fixture-runtime.ts
@@ -27,6 +27,7 @@ import type {
     UserPreferences,
 } from '@shared/contracts';
 import {
+    createFilesystemPreferences,
     createPreferences,
     DEFAULT_TOOL_INTEGRATIONS,
     SAMPLE_AVAILABLE_PRERELEASES,
@@ -296,7 +297,10 @@ export async function seedLauncherData(homeDir: string): Promise<void> {
             SAMPLE_AVAILABLE_PRERELEASES,
         ),
     );
-    await writeJson(path.join(configDir, 'prefs.json'), SAMPLE_PREFS);
+    await writeJson(
+        path.join(configDir, 'prefs.json'),
+        createFilesystemPreferences(homeDir),
+    );
 }
 
 /**

--- a/main/src/commands/shellFolders.test.ts
+++ b/main/src/commands/shellFolders.test.ts
@@ -64,4 +64,25 @@ describe('shellFolders dialog helpers', () => {
             properties: ['openDirectory', 'createDirectory', 'promptToCreate'],
         });
     });
+
+    it('falls back to an existing parent when the preferred folder cannot be created', async () => {
+        const preferredPath = path.resolve('/Users/docs/Godot/Projects');
+        const fallbackPath = path.resolve('/Users');
+        fsMocks.existsSync.mockImplementation(
+            (candidate) => candidate === fallbackPath,
+        );
+        fsMocks.mkdir.mockRejectedValueOnce(new Error('permission denied'));
+
+        await openDirectoryDialog(preferredPath, 'Select Folder');
+
+        expect(fsMocks.mkdir).toHaveBeenCalledWith(preferredPath, {
+            recursive: true,
+        });
+        expect(dialog.showOpenDialog).toHaveBeenCalledWith(mainWindowMock, {
+            defaultPath: fallbackPath,
+            filters: [],
+            title: 'Select Folder',
+            properties: ['openDirectory', 'createDirectory', 'promptToCreate'],
+        });
+    });
 });

--- a/main/src/commands/shellFolders.ts
+++ b/main/src/commands/shellFolders.ts
@@ -50,7 +50,19 @@ export async function openDirectoryDialog(
     defaultPath = path.resolve(defaultPath + path.sep);
 
     if (!fs.existsSync(defaultPath)) {
-        await fs.promises.mkdir(defaultPath, { recursive: true });
+        try {
+            await fs.promises.mkdir(defaultPath, { recursive: true });
+        } catch {
+            let existingParent = path.dirname(defaultPath);
+            while (!fs.existsSync(existingParent)) {
+                const parentPath = path.dirname(existingParent);
+                if (parentPath === existingParent) {
+                    break;
+                }
+                existingParent = parentPath;
+            }
+            defaultPath = existingParent;
+        }
     }
 
     return await dialog.showOpenDialog(getMainWindow(), {

--- a/main/src/config/app-config.env.ts
+++ b/main/src/config/app-config.env.ts
@@ -20,6 +20,7 @@ export const AppEnvConfigSchema = z.object({
     GODOT_LAUNCHER_DISABLE_SANDBOX: BooleanFromEnvSchema,
     GODOT_LAUNCHER_NO_DEV_MENU: BooleanFromEnvSchema,
     GODOT_LAUNCHER_E2E_FIXTURES: BooleanFromEnvSchema,
+    GODOT_LAUNCHER_E2E_HOME_DIR: z.string().optional(),
     GODOT_LAUNCHER_USE_LOCAL_GITHUB_BROKER: BooleanFromEnvSchema,
 });
 

--- a/main/src/config/app-config.test.ts
+++ b/main/src/config/app-config.test.ts
@@ -18,6 +18,7 @@ describe('configuration', () => {
             ),
             env: {
                 GODOT_LAUNCHER_E2E_FIXTURES: '1',
+                GODOT_LAUNCHER_E2E_HOME_DIR: '/tmp/launcher-e2e',
             },
             isPackaged: false,
             appPath: '/workspace/launcher',
@@ -60,19 +61,115 @@ describe('configuration', () => {
     it('ignores E2E fixtures in a packaged runtime', () => {
         const development = configuration({
             args: argv(),
-            env: { GODOT_LAUNCHER_E2E_FIXTURES: '1' },
+            env: {
+                GODOT_LAUNCHER_E2E_FIXTURES: '1',
+                GODOT_LAUNCHER_E2E_HOME_DIR: '/tmp/launcher-e2e',
+            },
             isPackaged: false,
             appPath: '/workspace/launcher',
         });
         const packaged = configuration({
             args: argv(),
-            env: { GODOT_LAUNCHER_E2E_FIXTURES: '1' },
+            env: {
+                GODOT_LAUNCHER_E2E_FIXTURES: '1',
+                GODOT_LAUNCHER_E2E_HOME_DIR: '/tmp/launcher-e2e',
+            },
             isPackaged: true,
             appPath: '/opt/launcher/app.asar',
         });
 
         expect(development.e2eFixtures).toBe(true);
         expect(packaged.e2eFixtures).toBe(false);
+    });
+
+    it('isolates all development E2E paths under the fixture home', () => {
+        const fixtureHome = '/tmp/gd-launcher-e2e-run';
+        const config = configuration({
+            args: argv(),
+            env: {
+                GODOT_LAUNCHER_E2E_FIXTURES: '1',
+                GODOT_LAUNCHER_E2E_HOME_DIR: fixtureHome,
+            },
+            isPackaged: false,
+            appPath: '/workspace/launcher',
+            platform: 'linux',
+            homedir: '/home/real-user',
+        });
+
+        expect(config.paths).toEqual(
+            resolveAppPaths({
+                platform: 'linux',
+                homedir: fixtureHome,
+            }),
+        );
+    });
+
+    it('fails closed when development E2E fixtures have no isolated home', () => {
+        expect(() =>
+            configuration({
+                args: argv(),
+                env: { GODOT_LAUNCHER_E2E_FIXTURES: '1' },
+                isPackaged: false,
+                appPath: '/workspace/launcher',
+            }),
+        ).toThrow('GODOT_LAUNCHER_E2E_HOME_DIR is required');
+    });
+
+    it('fails closed when the development E2E home is relative', () => {
+        expect(() =>
+            configuration({
+                args: argv(),
+                env: {
+                    GODOT_LAUNCHER_E2E_FIXTURES: '1',
+                    GODOT_LAUNCHER_E2E_HOME_DIR: '.debug/e2e/run',
+                },
+                isPackaged: false,
+                appPath: '/workspace/launcher',
+                platform: 'linux',
+            }),
+        ).toThrow('GODOT_LAUNCHER_E2E_HOME_DIR must be an absolute path');
+    });
+
+    it('ignores the E2E home outside fixture mode', () => {
+        const config = configuration({
+            args: argv(),
+            env: {
+                GODOT_LAUNCHER_E2E_HOME_DIR: '/tmp/launcher-e2e',
+            },
+            isPackaged: false,
+            appPath: '/workspace/launcher',
+            platform: 'linux',
+            homedir: '/home/real-user',
+        });
+
+        expect(config.paths).toEqual(
+            resolveAppPaths({
+                platform: 'linux',
+                homedir: '/home/real-user',
+            }),
+        );
+    });
+
+    it('ignores an invalid E2E home in packaged mode', () => {
+        const config = configuration({
+            args: argv(),
+            env: {
+                GODOT_LAUNCHER_E2E_FIXTURES: '1',
+                GODOT_LAUNCHER_E2E_HOME_DIR: '   ',
+            },
+            isPackaged: true,
+            appPath: '/opt/launcher/app.asar',
+            platform: 'linux',
+            homedir: '/home/real-user',
+        });
+
+        expect(config.e2eFixtures).toBe(false);
+        expect(config.paths).toEqual(
+            resolveAppPaths({
+                platform: 'linux',
+                homedir: '/home/real-user',
+            }),
+        );
     });
 
     it('keeps cli true when env explicitly parses false', () => {

--- a/main/src/config/app-config.ts
+++ b/main/src/config/app-config.ts
@@ -77,6 +77,24 @@ export function configuration(
         isPackaged: options.isPackaged ?? false,
         appPath: options.appPath ?? process.cwd(),
     });
+    const e2eFixtures =
+        isDev && (envConfig.GODOT_LAUNCHER_E2E_FIXTURES ?? false);
+    const e2eHomeDir = envConfig.GODOT_LAUNCHER_E2E_HOME_DIR?.trim();
+
+    if (e2eFixtures && !e2eHomeDir) {
+        throw new Error(
+            'GODOT_LAUNCHER_E2E_HOME_DIR is required when E2E fixtures are enabled.',
+        );
+    }
+    const appPathModule =
+        (options.platform ?? os.platform()) === 'win32'
+            ? path.win32
+            : path.posix;
+    if (e2eFixtures && !appPathModule.isAbsolute(e2eHomeDir ?? '')) {
+        throw new Error(
+            'GODOT_LAUNCHER_E2E_HOME_DIR must be an absolute path.',
+        );
+    }
 
     return AppConfigSchema.parse({
         appName: 'Godot Launcher',
@@ -90,13 +108,13 @@ export function configuration(
             (cliConfig.disableDevMenu ?? false),
         startHidden: cliConfig.startHidden ?? false,
         // Fixture behaviour is only available to unpackaged development runs.
-        e2eFixtures: isDev && (envConfig.GODOT_LAUNCHER_E2E_FIXTURES ?? false),
+        e2eFixtures,
         useLocalGitHubBroker:
             isDev &&
             (envConfig.GODOT_LAUNCHER_USE_LOCAL_GITHUB_BROKER ?? false),
         paths: resolveAppPaths({
             platform: options.platform,
-            homedir: options.homedir,
+            homedir: e2eFixtures ? e2eHomeDir : options.homedir,
         }),
     });
 }

--- a/renderer/src/components/settings/EditorLocation.component.tsx
+++ b/renderer/src/components/settings/EditorLocation.component.tsx
@@ -1,74 +1,23 @@
-import { Folder } from 'lucide-react';
-import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { appBridge } from '../../bridge.ts';
-import { usePreferences } from '../../hooks/usePreferences';
-import { WaitingForDialogOverlay } from '../waitingForDialogOverlay.component';
+import { SettingsLocationSelector } from './settings-location-selector.component';
 
+/** Renders the editor installs location preference. */
 export const EditorsLocation: React.FC = () => {
     const { t } = useTranslation('settings');
-    const [dialogOpen, setDialogOpen] = useState<boolean>(false);
-    const { preferences, savePreferences } = usePreferences();
-
-    const selectInstallDir = async (currentPath: string) => {
-        setDialogOpen(true);
-        const result = await appBridge.openDirectoryDialog(
-            currentPath,
-            'Select Install Directory',
-        );
-        if (!result.canceled) {
-            if (preferences) {
-                await savePreferences({
-                    ...preferences,
-                    install_location: result.filePaths[0],
-                });
-            }
-        }
-        setDialogOpen(false);
-    };
 
     return (
-        <>
-            {dialogOpen && (
-                <WaitingForDialogOverlay
-                    message={t('behavior.editorsLocation.waitingForDialog')}
-                />
-            )}
-            <div className="flex flex-col gap-4 ">
-                <div className="flex flex-col">
-                    <h1
-                        data-testid="editorInstallLocationHeader"
-                        className="font-bold"
-                    >
-                        {t('behavior.editorsLocation.title')}
-                    </h1>
-                    <p
-                        data-testid="editoInstallLocationSubHeader"
-                        className="text-sm"
-                    >
-                        {t('behavior.editorsLocation.description')}
-                    </p>
-                </div>
-                <button
-                    type="button"
-                    data-testid="btnSelectInstallDir"
-                    className="flex flex-row p-2 gap-2 bg-base-content/10 rounded-md items-center"
-                    onClick={() =>
-                        selectInstallDir(preferences?.install_location || '')
-                    }
-                >
-                    <div className="flex flex-col flex-1 items-start">
-                        <div className="flex flex-row  items-center gap-2 text-sm text-base-content/50">
-                            <Folder className="fill-base-content/50 self-start stroke-none" />
-                            {t('behavior.editorsLocation.installLocation')}
-                        </div>
-                        <div className="pl-0">
-                            {' '}
-                            {preferences?.install_location}{' '}
-                        </div>
-                    </div>
-                </button>
-            </div>
-        </>
+        <SettingsLocationSelector
+            preferenceKey="install_location"
+            title={t('behavior.editorsLocation.title')}
+            description={t('behavior.editorsLocation.description')}
+            fieldLabel={t('behavior.editorsLocation.installLocation')}
+            browseLabel={t('codeEditors.drawer.path.browse')}
+            waitingMessage={t('behavior.editorsLocation.waitingForDialog')}
+            dialogTitle="Select Install Directory"
+            headerTestId="editorInstallLocationHeader"
+            descriptionTestId="editoInstallLocationSubHeader"
+            pathTestId="editorInstallLocationPath"
+            browseTestId="btnSelectInstallDir"
+        />
     );
 };

--- a/renderer/src/components/settings/projectsLocation.component.tsx
+++ b/renderer/src/components/settings/projectsLocation.component.tsx
@@ -1,74 +1,23 @@
-import { Folder } from 'lucide-react';
-import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { appBridge } from '../../bridge.ts';
-import { usePreferences } from '../../hooks/usePreferences';
-import { WaitingForDialogOverlay } from '../waitingForDialogOverlay.component';
+import { SettingsLocationSelector } from './settings-location-selector.component';
 
+/** Renders the projects location preference. */
 export const ProjectsLocation: React.FC = () => {
     const { t } = useTranslation('settings');
-    const [dialogOpen, setDialogOpen] = useState<boolean>(false);
-    const { preferences, savePreferences } = usePreferences();
-
-    const selectProjectDir = async (currentPath: string) => {
-        setDialogOpen(true);
-        const result = await appBridge.openDirectoryDialog(
-            currentPath,
-            'Select Project Directory',
-        );
-        if (!result.canceled) {
-            if (preferences) {
-                await savePreferences({
-                    ...preferences,
-                    projects_location: result.filePaths[0],
-                });
-            }
-        }
-        setDialogOpen(false);
-    };
 
     return (
-        <>
-            {dialogOpen && (
-                <WaitingForDialogOverlay
-                    message={t('behavior.projectsLocation.waitingForDialog')}
-                />
-            )}
-            <div className="flex flex-col gap-4 ">
-                <div className="flex flex-col">
-                    <h1
-                        data-testid="projectLocationHeader"
-                        className="font-bold"
-                    >
-                        {t('behavior.projectsLocation.title')}
-                    </h1>
-                    <p
-                        data-testid="projectLocationSubHeader"
-                        className="text-sm"
-                    >
-                        {t('behavior.projectsLocation.description')}
-                    </p>
-                </div>
-                <button
-                    type="button"
-                    data-testid="btnSelectProjectDir"
-                    className="flex flex-row p-2 gap-2 bg-base-content/10 rounded-md items-center"
-                    onClick={() =>
-                        selectProjectDir(preferences?.projects_location || '')
-                    }
-                >
-                    <div className="flex flex-col flex-1 items-start">
-                        <div className="flex flex-row  items-center gap-2 text-sm text-base-content/50">
-                            <Folder className="fill-base-content/50 self-start stroke-none" />
-                            {t('behavior.projectsLocation.defaultLocation')}
-                        </div>
-                        <div className="pl-0">
-                            {' '}
-                            {preferences?.projects_location}{' '}
-                        </div>
-                    </div>
-                </button>
-            </div>
-        </>
+        <SettingsLocationSelector
+            preferenceKey="projects_location"
+            title={t('behavior.projectsLocation.title')}
+            description={t('behavior.projectsLocation.description')}
+            fieldLabel={t('behavior.projectsLocation.defaultLocation')}
+            browseLabel={t('codeEditors.drawer.path.browse')}
+            waitingMessage={t('behavior.projectsLocation.waitingForDialog')}
+            dialogTitle="Select Project Directory"
+            headerTestId="projectLocationHeader"
+            descriptionTestId="projectLocationSubHeader"
+            pathTestId="projectLocationPath"
+            browseTestId="btnSelectProjectDir"
+        />
     );
 };

--- a/renderer/src/components/settings/settings-location-selector.component.test.tsx
+++ b/renderer/src/components/settings/settings-location-selector.component.test.tsx
@@ -1,0 +1,126 @@
+import type { UserPreferences } from '@shared/contracts';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { usePreferences } from '../../hooks/usePreferences';
+import {
+    SettingsLocationSelector,
+    selectSettingsLocation,
+} from './settings-location-selector.component';
+
+vi.mock('../../hooks/usePreferences', () => ({
+    usePreferences: vi.fn(),
+}));
+vi.mock('../../bridge.ts', () => ({
+    appBridge: { openDirectoryDialog: vi.fn() },
+}));
+
+const preferences = {
+    projects_location: '/Users/test/GodotProjects',
+    install_location: '/Users/test/GodotEditors',
+} as UserPreferences;
+
+describe('SettingsLocationSelector', () => {
+    beforeEach(() => {
+        vi.mocked(usePreferences).mockReturnValue({
+            preferences,
+            savePreferences: vi.fn(),
+        } as unknown as ReturnType<typeof usePreferences>);
+    });
+
+    it.each([
+        {
+            preferenceKey: 'projects_location' as const,
+            title: 'Project Location',
+            fieldLabel: 'Default Location',
+            pathTestId: 'projectLocationPath',
+            browseTestId: 'btnSelectProjectDir',
+            value: preferences.projects_location,
+        },
+        {
+            preferenceKey: 'install_location' as const,
+            title: 'Editor Installs Location',
+            fieldLabel: 'Install Location',
+            pathTestId: 'editorInstallLocationPath',
+            browseTestId: 'btnSelectInstallDir',
+            value: preferences.install_location,
+        },
+    ])('renders the $preferenceKey configuration', (configuration) => {
+        const html = renderToStaticMarkup(
+            <SettingsLocationSelector
+                preferenceKey={configuration.preferenceKey}
+                title={configuration.title}
+                description="Location description"
+                fieldLabel={configuration.fieldLabel}
+                browseLabel="Browse"
+                waitingMessage="Waiting for dialog..."
+                dialogTitle="Select Directory"
+                headerTestId="locationHeader"
+                descriptionTestId="locationDescription"
+                pathTestId={configuration.pathTestId}
+                browseTestId={configuration.browseTestId}
+            />,
+        );
+
+        expect(html).toContain(configuration.title);
+        expect(html).toContain(configuration.fieldLabel);
+        expect(html).toContain(`value="${configuration.value}"`);
+        expect(html).toContain(`data-testid="${configuration.pathTestId}"`);
+        expect(html).toContain(`data-testid="${configuration.browseTestId}"`);
+        expect(html).toContain('readOnly=""');
+        expect(html).toContain('aria-label="Browse"');
+        expect(html).toContain('>Browse</span>');
+    });
+
+    it('does not save a cancelled selection and always clears waiting state', async () => {
+        const savePath = vi.fn();
+        const setDialogOpen = vi.fn();
+
+        await selectSettingsLocation({
+            currentPath: '/current',
+            dialogTitle: 'Select Directory',
+            setDialogOpen,
+            openDirectoryDialog: vi.fn().mockResolvedValue({
+                canceled: true,
+                filePaths: [],
+            }),
+            savePath,
+        });
+
+        expect(savePath).not.toHaveBeenCalled();
+        expect(setDialogOpen.mock.calls).toEqual([[true], [false]]);
+    });
+
+    it('saves only a returned path', async () => {
+        const savePath = vi.fn().mockResolvedValue(undefined);
+
+        await selectSettingsLocation({
+            currentPath: '/current',
+            dialogTitle: 'Select Directory',
+            setDialogOpen: vi.fn(),
+            openDirectoryDialog: vi.fn().mockResolvedValue({
+                canceled: false,
+                filePaths: ['/selected'],
+            }),
+            savePath,
+        });
+
+        expect(savePath).toHaveBeenCalledWith('/selected');
+    });
+
+    it('clears waiting state when the dialog fails', async () => {
+        const setDialogOpen = vi.fn();
+
+        await expect(
+            selectSettingsLocation({
+                currentPath: '/current',
+                dialogTitle: 'Select Directory',
+                setDialogOpen,
+                openDirectoryDialog: vi
+                    .fn()
+                    .mockRejectedValue(new Error('Dialog failed')),
+                savePath: vi.fn(),
+            }),
+        ).rejects.toThrow('Dialog failed');
+        expect(setDialogOpen.mock.calls).toEqual([[true], [false]]);
+    });
+});

--- a/renderer/src/components/settings/settings-location-selector.component.tsx
+++ b/renderer/src/components/settings/settings-location-selector.component.tsx
@@ -1,0 +1,129 @@
+import type { UserPreferences } from '@shared/contracts';
+import { useState } from 'react';
+import { appBridge } from '../../bridge.ts';
+import { usePreferences } from '../../hooks/usePreferences';
+import { PathField } from '../ui/pathField.component';
+import { WaitingForDialogOverlay } from '../waitingForDialogOverlay.component';
+
+type LocationPreferenceKey = 'projects_location' | 'install_location';
+
+type SettingsLocationSelectorProps = {
+    preferenceKey: LocationPreferenceKey;
+    title: string;
+    description: string;
+    fieldLabel: string;
+    browseLabel: string;
+    waitingMessage: string;
+    dialogTitle: string;
+    headerTestId: string;
+    descriptionTestId: string;
+    pathTestId: string;
+    browseTestId: string;
+};
+
+type SelectSettingsLocationOptions = {
+    currentPath: string;
+    dialogTitle: string;
+    setDialogOpen: (open: boolean) => void;
+    openDirectoryDialog: typeof appBridge.openDirectoryDialog;
+    savePath: (path: string) => Promise<void>;
+};
+
+/**
+ * Selects and saves one Settings location while maintaining dialog state.
+ *
+ * @param options - Dialog dependencies, current path, and save callback.
+ */
+export async function selectSettingsLocation({
+    currentPath,
+    dialogTitle,
+    setDialogOpen,
+    openDirectoryDialog,
+    savePath,
+}: SelectSettingsLocationOptions): Promise<void> {
+    setDialogOpen(true);
+    try {
+        const result = await openDirectoryDialog(currentPath, dialogTitle);
+        const selectedPath = result.filePaths[0];
+        if (!result.canceled && selectedPath) {
+            await savePath(selectedPath);
+        }
+    } finally {
+        setDialogOpen(false);
+    }
+}
+
+/**
+ * Renders a Settings location as a shared read-only path field.
+ *
+ * @param props - Preference, translated copy, dialog, and test configuration.
+ * @returns A Settings location selector.
+ */
+export const SettingsLocationSelector: React.FC<
+    SettingsLocationSelectorProps
+> = ({
+    preferenceKey,
+    title,
+    description,
+    fieldLabel,
+    browseLabel,
+    waitingMessage,
+    dialogTitle,
+    headerTestId,
+    descriptionTestId,
+    pathTestId,
+    browseTestId,
+}) => {
+    const [dialogOpen, setDialogOpen] = useState(false);
+    const { preferences, savePreferences } = usePreferences();
+    const currentPath = preferences?.[preferenceKey] ?? '';
+
+    /** Opens the directory picker and saves a completed selection. */
+    const selectLocation = () =>
+        selectSettingsLocation({
+            currentPath,
+            dialogTitle,
+            setDialogOpen,
+            openDirectoryDialog: appBridge.openDirectoryDialog,
+            savePath: async (selectedPath) => {
+                if (!preferences) return;
+                await savePreferences({
+                    ...preferences,
+                    [preferenceKey]: selectedPath,
+                } as UserPreferences);
+            },
+        });
+
+    return (
+        <>
+            {dialogOpen && <WaitingForDialogOverlay message={waitingMessage} />}
+            <div className="flex min-w-0 flex-col gap-4">
+                <div className="flex flex-col">
+                    <h1 data-testid={headerTestId} className="font-bold">
+                        {title}
+                    </h1>
+                    <p data-testid={descriptionTestId} className="text-sm">
+                        {description}
+                    </p>
+                </div>
+                <div className="min-w-0 max-w-full">
+                    <PathField
+                        id={pathTestId}
+                        label={fieldLabel}
+                        value={currentPath}
+                        onChange={() => undefined}
+                        onSelect={() => void selectLocation()}
+                        title={currentPath}
+                        testId={pathTestId}
+                        readOnly
+                        browseKind="directory"
+                        browseTestId={browseTestId}
+                        browseLabel={browseLabel}
+                        browseText={browseLabel}
+                        regularText
+                    />
+                </div>
+            </div>
+        </>
+    );
+};

--- a/renderer/src/components/ui/formField.component.test.tsx
+++ b/renderer/src/components/ui/formField.component.test.tsx
@@ -149,6 +149,22 @@ describe('UI form primitives', () => {
         expect(html.match(/disabled=""/g)).toHaveLength(1);
     });
 
+    it('keeps a read-only path focusable and selectable', () => {
+        const html = renderToStaticMarkup(
+            <PathField
+                id="savedPath"
+                label="Saved path"
+                value="/projects"
+                onChange={vi.fn()}
+                onSelect={vi.fn()}
+                readOnly
+            />,
+        );
+
+        expect(html).toContain('readOnly=""');
+        expect(html).not.toContain('disabled=""');
+    });
+
     it('renders search field with an internal clear action', () => {
         const html = renderToStaticMarkup(
             <SearchField

--- a/renderer/src/components/ui/pathField.component.tsx
+++ b/renderer/src/components/ui/pathField.component.tsx
@@ -26,6 +26,7 @@ export type PathFieldProps = {
     placeholder?: string;
     error?: string;
     disabled?: boolean;
+    readOnly?: boolean;
     browseDisabled?: boolean;
     compact?: boolean;
     regularText?: boolean;
@@ -62,6 +63,7 @@ export const PathField: React.FC<PathFieldProps> = ({
     placeholder,
     error,
     disabled = false,
+    readOnly = false,
     browseDisabled = false,
     compact = false,
     regularText = false,
@@ -109,6 +111,7 @@ export const PathField: React.FC<PathFieldProps> = ({
                         aria-label={ariaLabel}
                         title={title}
                         disabled={disabled}
+                        readOnly={readOnly}
                     />
                     {suffix && (
                         <span


### PR DESCRIPTION
- Reuses the shared path-field pattern for Projects and Installs, with accessible Browse actions.
- Opens the nearest existing folder when a saved location is unavailable.