### PR TITLE
fix(installs): use shared custom editor action menu

### DIFF
--- a/e2e/guided-empty-states.spec.ts
+++ b/e2e/guided-empty-states.spec.ts
@@ -53,7 +53,7 @@ test.afterAll(async () => {
     await fs.rm(fixtureHome, { recursive: true, force: true });
 });
 
-test('Installs empty actions open the editor drawer and both custom editor workflows', async () => {
+test('Installs empty primary action opens and closes the editor drawer', async () => {
     await prepareEmptyApp([]);
     await mainPage.getByTestId('btnInstalls').click();
 
@@ -78,32 +78,143 @@ test('Installs empty actions open the editor drawer and both custom editor workf
     await installDrawer.getByTestId('btnCloseInstallEditor').click();
     await expect(mainPage).toHaveURL(/#\/installs$/);
     await expect(installDrawer).not.toBeVisible();
+});
 
-    await mainPage.getByTestId('btnEmptyStateSecondary').click();
-    const customEditorMenu = mainPage.getByRole('dialog', {
-        name: 'Custom Editor',
-    });
-    await expect(customEditorMenu).toBeVisible();
-    await customEditorMenu
-        .getByTestId('btnEmptyStateCreateCustomEditorManifest')
-        .click();
+test('Installs custom editor actions share the accessible action menu contract', async () => {
+    for (const scenario of [
+        {
+            name: 'the populated state at the standard desktop size',
+            installedReleases: SAMPLE_INSTALLED_RELEASES_WITH_CUSTOM,
+            triggerTestId: 'btnAddCustomEngineMenu',
+            selectManifestTestId: 'btnAddCustomEngine',
+            createManifestTestId: 'btnCreateCustomEditorManifest',
+            exposesExpandedState: true,
+            viewport: { width: 1440, height: 900 },
+        },
+        {
+            name: 'the populated state at the narrow desktop size',
+            installedReleases: SAMPLE_INSTALLED_RELEASES_WITH_CUSTOM,
+            triggerTestId: 'btnAddCustomEngineMenu',
+            selectManifestTestId: 'btnAddCustomEngine',
+            createManifestTestId: 'btnCreateCustomEditorManifest',
+            exposesExpandedState: true,
+            viewport: { width: 1024, height: 600 },
+        },
+        {
+            name: 'the empty state at the standard desktop size',
+            installedReleases: [],
+            triggerTestId: 'btnEmptyStateSecondary',
+            selectManifestTestId: 'btnEmptyStateSelectCustomEditorManifest',
+            createManifestTestId: 'btnEmptyStateCreateCustomEditorManifest',
+            exposesExpandedState: false,
+            viewport: { width: 1440, height: 900 },
+        },
+        {
+            name: 'the empty state at the narrow desktop size',
+            installedReleases: [],
+            triggerTestId: 'btnEmptyStateSecondary',
+            selectManifestTestId: 'btnEmptyStateSelectCustomEditorManifest',
+            createManifestTestId: 'btnEmptyStateCreateCustomEditorManifest',
+            exposesExpandedState: false,
+            viewport: { width: 1024, height: 600 },
+        },
+    ]) {
+        await test.step(scenario.name, async () => {
+            await prepareEmptyApp(scenario.installedReleases);
+            await mainPage.getByTestId('btnInstalls').click();
+            await mainPage.setViewportSize(scenario.viewport);
 
-    const customEditorDrawer = mainPage.getByRole('dialog', {
-        name: 'Create Custom Editor Manifest',
-    });
-    await expect(customEditorDrawer).toBeVisible();
-    await expect(mainPage).toHaveURL(/#\/installs$/);
-    await customEditorDrawer
-        .getByRole('button', { name: 'Close drawer' })
-        .click();
-    await expect(customEditorDrawer).not.toBeVisible();
+            const trigger = mainPage.getByTestId(scenario.triggerTestId);
+            const customEditorMenu = mainPage.getByRole('dialog', {
+                name: 'Custom Editor',
+                exact: true,
+            });
+            const selectManifest = customEditorMenu.getByTestId(
+                scenario.selectManifestTestId,
+            );
+            const createManifest = customEditorMenu.getByTestId(
+                scenario.createManifestTestId,
+            );
 
-    await stubOpenFileDialog();
-    await mainPage.getByTestId('btnEmptyStateSecondary').click();
-    await mainPage
-        .getByTestId('btnEmptyStateSelectCustomEditorManifest')
-        .click();
-    await expect.poll(readOpenFileDialogCallCount).toBe(1);
+            await trigger.focus();
+            if (scenario.exposesExpandedState) {
+                await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+            }
+            await trigger.press('Enter');
+            await expect(customEditorMenu).toBeVisible();
+            if (scenario.exposesExpandedState) {
+                await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+            }
+            await expect(selectManifest).toHaveAccessibleName(
+                'Select manifest file',
+            );
+            await expect(createManifest).toHaveAccessibleName(
+                'Create custom editor manifest',
+            );
+            await expect(selectManifest).toBeFocused();
+
+            await mainPage.keyboard.press('Tab');
+            await expect(createManifest).toBeFocused();
+            await mainPage.keyboard.press('Tab');
+            await expect(selectManifest).toBeFocused();
+            await mainPage.keyboard.press('Shift+Tab');
+            await expect(createManifest).toBeFocused();
+
+            const menuBounds = await customEditorMenu.boundingBox();
+            expect(menuBounds).not.toBeNull();
+            expect(menuBounds!.x).toBeGreaterThanOrEqual(8);
+            expect(menuBounds!.y).toBeGreaterThanOrEqual(8);
+            expect(menuBounds!.x + menuBounds!.width).toBeLessThanOrEqual(
+                scenario.viewport.width - 8,
+            );
+            expect(menuBounds!.y + menuBounds!.height).toBeLessThanOrEqual(
+                scenario.viewport.height - 8,
+            );
+
+            await mainPage.keyboard.press('Escape');
+            await expect(customEditorMenu).not.toBeVisible();
+            await expect(trigger).toBeFocused();
+            if (scenario.exposesExpandedState) {
+                await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+            }
+
+            await trigger.press('Enter');
+            await expect(customEditorMenu).toBeVisible();
+            await mainPage.getByRole('button', { name: 'Close menu' }).click();
+            await expect(customEditorMenu).not.toBeVisible();
+            await expect(trigger).toBeFocused();
+
+            await trigger.press('Enter');
+            await expect(customEditorMenu).toBeVisible();
+            await createManifest.click();
+            await expect(customEditorMenu).not.toBeVisible();
+
+            const customEditorDrawer = mainPage.getByRole('dialog', {
+                name: 'Create Custom Editor Manifest',
+                exact: true,
+            });
+            await expect(customEditorDrawer).toBeVisible();
+            await expect(customEditorDrawer.locator(':focus')).toHaveCount(1);
+            await customEditorDrawer
+                .getByRole('button', { name: 'Close drawer' })
+                .click();
+            await expect(customEditorDrawer).not.toBeVisible();
+            await expect(trigger).toBeFocused();
+
+            await stubOpenFileDialog();
+            await trigger.press('Enter');
+            await expect(customEditorMenu).toBeVisible();
+            await selectManifest.click();
+            await expect(customEditorMenu).not.toBeVisible();
+            await expect.poll(readOpenFileDialogCallCount).toBe(1);
+            await expect(trigger).toBeFocused();
+
+            await trigger.press('Enter');
+            await expect(customEditorMenu).toBeVisible();
+            await mainPage.keyboard.press('Escape');
+            await expect(customEditorMenu).not.toBeVisible();
+        });
+    }
 });
 
 test('Projects welcome supports creation and local import without an installed editor', async () => {

--- a/renderer/src/views/installs.view.test.tsx
+++ b/renderer/src/views/installs.view.test.tsx
@@ -143,8 +143,10 @@ describe('InstallsView', () => {
         expect(html).toContain('Remove');
         expect(html).toContain('Custom Editor');
         expect(html).toContain('/Users/test/GodotEditors');
-        expect(html).toContain('Select manifest file');
-        expect(html).toContain('Create custom editor manifest');
+        expect(html).toContain('aria-haspopup="dialog"');
+        expect(html).toContain('aria-expanded="false"');
+        expect(html).not.toContain('Select manifest file');
+        expect(html).not.toContain('Create custom editor manifest');
     });
 
     it('renders the guided empty state without duplicate list controls', () => {

--- a/renderer/src/views/installs.view.tsx
+++ b/renderer/src/views/installs.view.tsx
@@ -38,6 +38,11 @@ type InstallsViewProps = {
     onInstallOpenChange?: (open: boolean) => void;
 };
 
+type CustomEditorMenuState = {
+    anchorRect: ActionMenuAnchorRect;
+    source: 'header' | 'empty';
+};
+
 /**
  * Renders installed editors and the editor catalog drawer.
  *
@@ -71,8 +76,8 @@ export const InstallsView: React.FC<InstallsViewProps> = ({
         useState<boolean>(false);
     const [customEditorManifestDrawerOpen, setCustomEditorManifestDrawerOpen] =
         useState<boolean>(false);
-    const [customEditorMenuAnchorRect, setCustomEditorMenuAnchorRect] =
-        useState<ActionMenuAnchorRect | null>(null);
+    const [customEditorMenu, setCustomEditorMenu] =
+        useState<CustomEditorMenuState | null>(null);
 
     const { addAlert, addConfirm } = useAlerts();
     const { preferences } = usePreferences();
@@ -165,19 +170,18 @@ export const InstallsView: React.FC<InstallsViewProps> = ({
                     searchValue={textSearch}
                     onSearchChange={setTextSearch}
                     addCustomEditorLabel={t('buttons.addCustomEditor')}
-                    selectManifestLabel={t(
-                        'buttons.selectCustomEditorManifest',
-                    )}
-                    createManifestLabel={t(
-                        'buttons.createCustomEditorManifest',
-                    )}
+                    customEditorMenuOpen={customEditorMenu?.source === 'header'}
                     installLabel={t('buttons.install')}
                     copyPathLabel={t('common:buttons.copyPath')}
                     copiedLabel={t('common:success')}
                     showControls={viewState !== 'empty'}
-                    onSelectManifest={() => void handleAddCustomEngine()}
-                    onCreateManifest={() =>
-                        setCustomEditorManifestDrawerOpen(true)
+                    onOpenCustomEditorMenu={(event) =>
+                        setCustomEditorMenu({
+                            anchorRect: getActionMenuAnchorRect(
+                                event.currentTarget,
+                            ),
+                            source: 'header',
+                        })
                     }
                     onInstall={() => setInstallOpen(true)}
                 />
@@ -190,9 +194,12 @@ export const InstallsView: React.FC<InstallsViewProps> = ({
                         secondaryActionLabel={t('emptyState.addCustomEditor')}
                         onPrimaryAction={() => setInstallOpen(true)}
                         onSecondaryAction={(event) =>
-                            setCustomEditorMenuAnchorRect(
-                                getActionMenuAnchorRect(event.currentTarget),
-                            )
+                            setCustomEditorMenu({
+                                anchorRect: getActionMenuAnchorRect(
+                                    event.currentTarget,
+                                ),
+                                source: 'empty',
+                            })
                         }
                     />
                 ) : (
@@ -230,24 +237,30 @@ export const InstallsView: React.FC<InstallsViewProps> = ({
                 onRemoveRelease={handleRemoveReleaseFromMenu}
             />
             <ActionMenu
-                open={customEditorMenuAnchorRect !== null}
-                anchorRect={customEditorMenuAnchorRect}
+                open={customEditorMenu !== null}
+                anchorRect={customEditorMenu?.anchorRect ?? null}
                 ariaLabel={t('buttons.addCustomEditor')}
                 items={[
                     {
                         key: 'select-manifest',
                         label: t('buttons.selectCustomEditorManifest'),
-                        testId: 'btnEmptyStateSelectCustomEditorManifest',
+                        testId:
+                            customEditorMenu?.source === 'header'
+                                ? 'btnAddCustomEngine'
+                                : 'btnEmptyStateSelectCustomEditorManifest',
                         onSelect: handleAddCustomEngine,
                     },
                     {
                         key: 'create-manifest',
                         label: t('buttons.createCustomEditorManifest'),
-                        testId: 'btnEmptyStateCreateCustomEditorManifest',
+                        testId:
+                            customEditorMenu?.source === 'header'
+                                ? 'btnCreateCustomEditorManifest'
+                                : 'btnEmptyStateCreateCustomEditorManifest',
                         onSelect: () => setCustomEditorManifestDrawerOpen(true),
                     },
                 ]}
-                onClose={() => setCustomEditorMenuAnchorRect(null)}
+                onClose={() => setCustomEditorMenu(null)}
             />
             <InstallEditorDrawer
                 open={installOpen}

--- a/renderer/src/views/installs/components/installsHeader.component.test.tsx
+++ b/renderer/src/views/installs/components/installsHeader.component.test.tsx
@@ -12,14 +12,12 @@ describe('InstallsHeader', () => {
                 searchValue=""
                 onSearchChange={vi.fn()}
                 addCustomEditorLabel="Custom Editor"
-                selectManifestLabel="Select manifest"
-                createManifestLabel="Create manifest"
+                customEditorMenuOpen={false}
                 installLabel="Install Editor"
                 copyPathLabel="Copy path"
                 copiedLabel="Copied"
                 showControls={false}
-                onSelectManifest={vi.fn()}
-                onCreateManifest={vi.fn()}
+                onOpenCustomEditorMenu={vi.fn()}
                 onInstall={vi.fn()}
             />,
         );
@@ -29,5 +27,30 @@ describe('InstallsHeader', () => {
         expect(html).not.toContain('btnAddCustomEngineMenu');
         expect(html).not.toContain('btnInstallEditor');
         expect(html).not.toContain('inputInstallSearch');
+    });
+
+    it('exposes the shared custom editor menu state from its trigger', () => {
+        const html = renderToStaticMarkup(
+            <InstallsHeader
+                title="Editor Installs"
+                installLocation="/Editors"
+                searchPlaceholder="Search"
+                searchValue=""
+                onSearchChange={vi.fn()}
+                addCustomEditorLabel="Custom Editor"
+                customEditorMenuOpen
+                installLabel="Install Editor"
+                copyPathLabel="Copy path"
+                copiedLabel="Copied"
+                onOpenCustomEditorMenu={vi.fn()}
+                onInstall={vi.fn()}
+            />,
+        );
+
+        expect(html).toContain('data-testid="btnAddCustomEngineMenu"');
+        expect(html).toContain('aria-haspopup="dialog"');
+        expect(html).toContain('aria-expanded="true"');
+        expect(html).not.toContain('btnAddCustomEngine"');
+        expect(html).not.toContain('btnCreateCustomEditorManifest');
     });
 });

--- a/renderer/src/views/installs/components/installsHeader.component.tsx
+++ b/renderer/src/views/installs/components/installsHeader.component.tsx
@@ -1,5 +1,6 @@
 import { ChevronDown } from 'lucide-react';
 import type React from 'react';
+import type { MouseEventHandler } from 'react';
 import { CopyBadge } from '../../../components/ui/copyBadge.component';
 import { SearchField } from '../../../components/ui/searchField.component';
 
@@ -10,14 +11,12 @@ type InstallsHeaderProps = {
     searchValue: string;
     onSearchChange: (value: string) => void;
     addCustomEditorLabel: string;
-    selectManifestLabel: string;
-    createManifestLabel: string;
+    customEditorMenuOpen: boolean;
     installLabel: string;
     copyPathLabel: string;
     copiedLabel: string;
     showControls?: boolean;
-    onSelectManifest: () => void;
-    onCreateManifest: () => void;
+    onOpenCustomEditorMenu: MouseEventHandler<HTMLButtonElement>;
     onInstall: () => void;
 };
 
@@ -34,14 +33,12 @@ export const InstallsHeader: React.FC<InstallsHeaderProps> = ({
     searchValue,
     onSearchChange,
     addCustomEditorLabel,
-    selectManifestLabel,
-    createManifestLabel,
+    customEditorMenuOpen,
     installLabel,
     copyPathLabel,
     copiedLabel,
     showControls = true,
-    onSelectManifest,
-    onCreateManifest,
+    onOpenCustomEditorMenu,
     onInstall,
 }) => (
     <div className="flex flex-col gap-2 w-full">
@@ -61,37 +58,17 @@ export const InstallsHeader: React.FC<InstallsHeaderProps> = ({
             </div>
             {showControls && (
                 <div className="flex gap-2">
-                    <div className="dropdown dropdown-end">
-                        <button
-                            type="button"
-                            tabIndex={0}
-                            data-testid="btnAddCustomEngineMenu"
-                            className="btn btn-neutral"
-                        >
-                            {addCustomEditorLabel}
-                            <ChevronDown size={14} aria-hidden="true" />
-                        </button>
-                        <ul className="dropdown-content menu bg-base-300 rounded-box z-1 min-w-64 p-1 shadow-sm border border-base-100">
-                            <li>
-                                <button
-                                    type="button"
-                                    data-testid="btnAddCustomEngine"
-                                    onClick={onSelectManifest}
-                                >
-                                    {selectManifestLabel}
-                                </button>
-                            </li>
-                            <li>
-                                <button
-                                    type="button"
-                                    data-testid="btnCreateCustomEditorManifest"
-                                    onClick={onCreateManifest}
-                                >
-                                    {createManifestLabel}
-                                </button>
-                            </li>
-                        </ul>
-                    </div>
+                    <button
+                        type="button"
+                        data-testid="btnAddCustomEngineMenu"
+                        className="btn btn-neutral"
+                        aria-haspopup="dialog"
+                        aria-expanded={customEditorMenuOpen}
+                        onClick={onOpenCustomEditorMenu}
+                    >
+                        {addCustomEditorLabel}
+                        <ChevronDown size={14} aria-hidden="true" />
+                    </button>
                     <button
                         type="button"
                         data-testid="btnInstallEditor"


### PR DESCRIPTION
- Replace the populated Installs dropdown with the shared anchored action menu.
- Preserve the existing select-manifest and create-manifest workflows and labels.
- Keep focus, dismissal, keyboard, and narrow-window behaviour consistent across Installs states.