### PR TITLE
fix(installs): show unique editor catalogue versions

### DIFF
--- a/e2e/mainWindow.spec.ts
+++ b/e2e/mainWindow.spec.ts
@@ -219,6 +219,25 @@ test('Can navigate the main window', async () => {
         await expect(
             allReleaseList.getByTestId('inputInstallSearch'),
         ).toHaveCount(0);
+        const exactStableRelease = drawer.getByText('4.7.1-stable', {
+            exact: true,
+        });
+        const exactPrerelease = drawer.getByText('4.7.1-rc2', {
+            exact: true,
+        });
+        await expect(exactStableRelease).toHaveCount(1);
+
+        for (let switchIndex = 0; switchIndex < 2; switchIndex += 1) {
+            await drawer.getByTestId('tabInstallsPrerelease').click();
+            await expect(exactStableRelease).toHaveCount(0);
+            await expect(exactPrerelease).toHaveCount(1);
+            await drawer.getByTestId('tabInstallsRelease').click();
+            await expect(exactStableRelease).toHaveCount(1);
+            await expect(exactPrerelease).toHaveCount(0);
+        }
+
+        await reloadButton.click();
+        await expect(exactStableRelease).toHaveCount(1);
         await drawerSearch.fill('4.5');
         await drawer.getByTestId('tabInstallsPrerelease').click();
         await expect(
@@ -246,6 +265,9 @@ test('Can navigate the main window', async () => {
         await drawer.getByTestId('tabInstallsAll').click();
         await expect(drawer.getByTestId('inputInstallSearch')).toBeFocused();
         await expect(drawer.getByTestId('inputInstallSearch')).toHaveValue('');
+        await expect(
+            drawer.getByText('4.7.1-stable', { exact: true }),
+        ).toHaveCount(1);
         await drawer.getByTestId('btnCloseInstallEditor').click();
     });
 

--- a/renderer/src/hooks/editor-catalog-release.mapper.test.ts
+++ b/renderer/src/hooks/editor-catalog-release.mapper.test.ts
@@ -39,22 +39,68 @@ describe('editor catalog release mapper', () => {
         ]);
     });
 
-    it('splits channels and keeps provider refresh errors', () => {
+    it('deduplicates stable versions using the stable provider release', () => {
         const mapped = mapEditorCatalogResult({
             releases: [
-                createRelease('official-stable', false),
-                createRelease('official-prerelease', true),
                 {
                     ...createRelease('official-prerelease', false),
-                    prerelease: true,
+                    variants: createRelease(
+                        'official-prerelease',
+                        false,
+                    ).variants.map((variant) => ({
+                        ...variant,
+                        assets: variant.assets.map((asset) => ({
+                            ...asset,
+                            downloadUrl: `https://fallback.example/${asset.name}`,
+                        })),
+                    })),
                 },
+                createRelease('official-stable', false),
+            ],
+            providers: [],
+        });
+
+        expect(mapped.availableReleases).toHaveLength(1);
+        expect(mapped.availableReleases[0]?.assets[0]?.download_url).toBe(
+            'https://example.com/godot-windows.zip',
+        );
+    });
+
+    it('deduplicates prereleases using the prerelease provider release', () => {
+        const mapped = mapEditorCatalogResult({
+            releases: [
+                createRelease('official-stable', true),
+                createRelease('official-prerelease', true),
+            ],
+            providers: [],
+        });
+
+        expect(mapped.availablePrereleases).toHaveLength(1);
+        expect(mapped.availablePrereleases[0]?.tag).toBe('4.6-beta1');
+        expect(mapped.availablePrereleases[0]?.name).toBe(
+            'official-prerelease 4.6-beta1',
+        );
+    });
+
+    it('keeps fallback providers and distinct exact versions', () => {
+        const fallbackStable = createRelease('official-prerelease', false);
+        const patchRelease = {
+            ...createRelease('official-stable', false),
+            id: 'official-stable:4.5.1-stable',
+            tag: '4.5.1-stable',
+            version: '4.5.1-stable',
+            versionParts: {
+                ...createRelease('official-stable', false).versionParts,
+                patch: 1,
+            },
+        };
+        const mapped = mapEditorCatalogResult({
+            releases: [
+                fallbackStable,
+                patchRelease,
+                createRelease('official-stable', true),
             ],
             providers: [
-                {
-                    id: 'official-stable',
-                    lastFetchedAt: 1,
-                    isStale: false,
-                },
                 {
                     id: 'official-prerelease',
                     lastFetchedAt: 1,
@@ -64,7 +110,9 @@ describe('editor catalog release mapper', () => {
             ],
         });
 
-        expect(mapped.availableReleases).toHaveLength(2);
+        expect(
+            mapped.availableReleases.map((release) => release.version),
+        ).toEqual(['4.5-stable', '4.5.1-stable']);
         expect(mapped.availablePrereleases).toHaveLength(1);
         expect(mapped.refreshError).toBe('Builds are unavailable');
     });
@@ -90,7 +138,7 @@ function createRelease(
         tag: version,
         version,
         baseVersion: prerelease ? '4.6' : '4.5',
-        name: `Godot ${version}`,
+        name: `${providerId} ${version}`,
         publishedAt: '2026-01-01T00:00:00.000Z',
         prerelease,
         versionParts: {

--- a/renderer/src/hooks/editor-catalog-release.mapper.ts
+++ b/renderer/src/hooks/editor-catalog-release.mapper.ts
@@ -50,7 +50,9 @@ export function mapEditorCatalogRelease(
 export function mapEditorCatalogResult(
     result: EditorCatalogResult,
 ): LegacyEditorCatalog {
-    const releases = result.releases.map(mapEditorCatalogRelease);
+    const releases = deduplicateEditorCatalogReleases(result.releases).map(
+        mapEditorCatalogRelease,
+    );
 
     return {
         availableReleases: releases.filter((release) => !release.prerelease),
@@ -58,4 +60,42 @@ export function mapEditorCatalogResult(
         refreshError: result.providers.find((provider) => provider.refreshError)
             ?.refreshError,
     };
+}
+
+/**
+ * Keeps one coherent catalog release for each exact version.
+ *
+ * @param releases - Catalog releases in provider order.
+ * @returns Unique releases in the order their versions first appeared.
+ */
+function deduplicateEditorCatalogReleases(
+    releases: EditorCatalogRelease[],
+): EditorCatalogRelease[] {
+    const releasesByVersion = new Map<string, EditorCatalogRelease>();
+
+    for (const release of releases) {
+        const existingRelease = releasesByVersion.get(release.version);
+
+        if (
+            !existingRelease ||
+            (!isPreferredProvider(existingRelease) &&
+                isPreferredProvider(release))
+        ) {
+            releasesByVersion.set(release.version, release);
+        }
+    }
+
+    return [...releasesByVersion.values()];
+}
+
+/**
+ * Checks whether a release comes from the provider responsible for its channel.
+ *
+ * @param release - The release whose provider should be checked.
+ * @returns Whether the provider is preferred for the release channel.
+ */
+function isPreferredProvider(release: EditorCatalogRelease): boolean {
+    return release.versionParts.channel === 'stable'
+        ? release.providerId === 'official-stable'
+        : release.providerId === 'official-prerelease';
 }


### PR DESCRIPTION
- Show each exact editor version once across overlapping official catalogues.
- Prefer the appropriate channel source while keeping complete download and integrity metadata.
- Prevent stale releases remaining after channel switches, searches, refreshes and reopening.