### PR TITLE
fix: detect Linuxbrew VSCodium installations

### DIFF
--- a/main/src/codeEditorIntegration/integrations/vscodium/vscodiumInstallation.linux.ts
+++ b/main/src/codeEditorIntegration/integrations/vscodium/vscodiumInstallation.linux.ts
@@ -133,6 +133,7 @@ export async function findLinuxVSCodium(): Promise<CodeEditorInstallation | null
         '/usr/bin/vscodium',
         '/usr/local/bin/codium',
         '/usr/local/bin/vscodium',
+        '/home/linuxbrew/.linuxbrew/bin/codium',
     ];
 
     if (home) {


### PR DESCRIPTION
- Add the default Linuxbrew location to VSCodium discovery on Linux.