### PR TITLE
fix(projects): save editor selection before downloading

### DIFF
--- a/e2e/project-settings-catalogue.spec.ts
+++ b/e2e/project-settings-catalogue.spec.ts
@@ -229,6 +229,127 @@ test('offers the matching missing editor from the catalogue', async () => {
     ]);
 });
 
+test('retains staged settings across tabs and discards them when closed', async () => {
+    await prepareAppWithStubbedData(page, electronApp, {
+        projects: [project], installedReleases: [installedRelease],
+        availableReleases: [catalogueRelease], availablePrereleases: [],
+    });
+    await stubCatalogueEditorSave();
+    await electronApp.evaluate(({ ipcMain }) => {
+        ipcMain.removeHandler('projects.getProjectGodotName');
+        ipcMain.handle('projects.getProjectGodotName', async (_event, selected) => new Promise((resolve) => {
+            (globalThis as typeof globalThis & { __finishSettingsName?: () => void }).__finishSettingsName =
+                () => resolve({ success: true, data: selected.name });
+        }));
+    });
+    await page.getByTestId('btnProjects').click();
+    await page.getByTestId('btnProjectSettings').click();
+    const drawer = page.getByRole('dialog', { name: 'Settings catalogue Settings' });
+    await expect.poll(() => electronApp.evaluate(() => Boolean(
+        (globalThis as typeof globalThis & { __finishSettingsName?: () => void }).__finishSettingsName,
+    ))).toBe(true);
+    await electronApp.evaluate(({ BrowserWindow }, selected) => {
+        for (const window of BrowserWindow.getAllWindows()) {
+            const contents = window.webContents as typeof window.webContents & { __e2eFixtureProjects?: ProjectDetails[] };
+            contents.__e2eFixtureProjects = [selected];
+            contents.send('projects-updated', [selected]);
+        }
+    }, project);
+    await drawer.locator('#projectEditName').fill('Unsaved draft');
+    await electronApp.evaluate(() => {
+        (globalThis as typeof globalThis & { __finishSettingsName?: () => void }).__finishSettingsName?.();
+    });
+    await expect(drawer.getByRole('button', { name: 'Update', exact: true })).toBeEnabled();
+    await drawer.getByTestId('tabProjectSettings_launch').click();
+    const windowed = drawer.getByRole('checkbox');
+    await windowed.setChecked(!Boolean(project.open_windowed));
+    await drawer.getByTestId('tabProjectSettings_codeEditor').click();
+    await drawer.getByTestId('tabProjectSettings_project').click();
+    await expect(drawer.locator('#projectEditName')).toHaveValue('Unsaved draft');
+    await drawer.getByTestId('tabProjectSettings_launch').click();
+    await expect(windowed).toBeChecked({ checked: !Boolean(project.open_windowed) });
+    await drawer.getByRole('button', { name: 'Cancel', exact: true }).click();
+    await expect(drawer).not.toBeVisible();
+    await electronApp.evaluate(({ ipcMain }) => {
+        ipcMain.removeHandler('projects.getProjectGodotName');
+        ipcMain.handle('projects.getProjectGodotName', async (_event, selected) => ({ success: true, data: selected.name }));
+    });
+    await page.getByTestId('btnProjectSettings').click();
+    await expect(drawer.locator('#projectEditName')).toHaveValue(project.name);
+    await drawer.getByTestId('tabProjectSettings_launch').click();
+    await expect(windowed).toBeChecked({ checked: Boolean(project.open_windowed) });
+    await expect.poll(readSettingsEvents).toEqual([]);
+    await drawer.getByRole('button', { name: 'Cancel', exact: true }).click();
+});
+
+test('retains a Git identity draft across tabs and saves it independently', async () => {
+    const gitProject = { ...project, withGit: true };
+    await prepareAppWithStubbedData(page, electronApp, {
+        projects: [gitProject], installedReleases: [installedRelease],
+        availableReleases: [catalogueRelease], availablePrereleases: [],
+    });
+    await stubCatalogueEditorSave({ initialProject: gitProject });
+    await electronApp.evaluate(({ ipcMain }, projectPath) => {
+        let identity = {
+            status: 'available', canUpdate: true,
+            repository: { root: projectPath, isProjectRoot: true, kind: 'standard' },
+            name: { value: 'Original identity', source: 'repository' },
+            email: { value: 'original@example.invalid', source: 'repository' },
+        };
+        const state = globalThis as typeof globalThis & {
+            __settingsIdentityReads?: number;
+            __finishStaleSettingsIdentity?: () => void;
+        };
+        state.__settingsIdentityReads = 0;
+        ipcMain.removeHandler('projects.getProjectGitIdentity');
+        ipcMain.handle('projects.getProjectGitIdentity', async () => {
+            state.__settingsIdentityReads = (state.__settingsIdentityReads ?? 0) + 1;
+            if (state.__settingsIdentityReads === 1) {
+                return new Promise((resolve) => {
+                    state.__finishStaleSettingsIdentity = () => resolve({
+                        success: true,
+                        data: { ...identity, name: { value: 'Stale response', source: 'repository' } },
+                    });
+                });
+            }
+            return { success: true, data: identity };
+        });
+        ipcMain.removeHandler('projects.setProjectGitIdentity');
+        ipcMain.handle('projects.setProjectGitIdentity', async (_event, _project, next) => {
+            identity = { ...identity, name: { value: next.name, source: 'repository' }, email: { value: next.email, source: 'repository' } };
+            return { success: true, data: identity };
+        });
+    }, gitProject.path);
+    await page.getByTestId('btnProjects').click();
+    await page.getByTestId('btnProjectSettings').click();
+    const drawer = page.getByRole('dialog', { name: 'Settings catalogue Settings' });
+    await drawer.getByTestId('tabProjectSettings_sourceControl').click();
+    await expect.poll(() => electronApp.evaluate(() =>
+        (globalThis as typeof globalThis & { __settingsIdentityReads?: number }).__settingsIdentityReads ?? 0,
+    )).toBeGreaterThanOrEqual(1);
+    await drawer.getByTestId('tabProjectSettings_project').click();
+    await drawer.getByTestId('tabProjectSettings_sourceControl').click();
+    const sourceControl = drawer.locator('section').filter({ hasText: 'Original identity' });
+    await expect(sourceControl).toBeVisible();
+    await electronApp.evaluate(() => {
+        (globalThis as typeof globalThis & { __finishStaleSettingsIdentity?: () => void }).__finishStaleSettingsIdentity?.();
+    });
+    await expect(drawer.getByText('Stale response', { exact: true })).not.toBeVisible();
+    await sourceControl.getByRole('button', { name: 'Update', exact: true }).click();
+    await drawer.locator('#projectGitIdentityName').fill('Saved identity');
+    await drawer.locator('#projectGitIdentityEmail').fill('saved@example.invalid');
+    await drawer.getByTestId('tabProjectSettings_project').click();
+    await drawer.getByTestId('tabProjectSettings_sourceControl').click();
+    await expect(drawer.locator('#projectGitIdentityName')).toHaveValue('Saved identity');
+    await expect(drawer.locator('#projectGitIdentityEmail')).toHaveValue('saved@example.invalid');
+    await drawer.getByRole('button', { name: 'Save identity' }).click();
+    await expect(drawer.locator('#projectGitIdentityName')).not.toBeVisible();
+    await expect(drawer.getByText('Saved identity', { exact: true })).toBeVisible();
+    await expect(drawer.getByText('saved@example.invalid', { exact: true })).toBeVisible();
+    await expect.poll(readSettingsEvents).toEqual([]);
+    await drawer.getByRole('button', { name: 'Cancel', exact: true }).click();
+});
+
 /**
  * Replaces project saves and installation with a delayed, stateful fixture flow.
  *

--- a/e2e/project-settings-catalogue.spec.ts
+++ b/e2e/project-settings-catalogue.spec.ts
@@ -1,21 +1,36 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { _electron, type ElectronApplication, expect, type Page, test } from '@playwright/test';
-import type { InstalledRelease, ProjectDetails, ReleaseSummary } from '@shared/contracts';
+import type {
+    InstalledRelease,
+    ProjectDetails,
+    ReleaseInstallProgress,
+    ReleaseSummary,
+} from '@shared/contracts';
+import { SAMPLE_INSTALLED_RELEASES, SAMPLE_PROJECTS } from './support/e2e-fixture-data';
 import { createFixtureHome, prepareAppWithStubbedData, setAppLanguage } from './support/e2e-fixture-runtime';
-import { SAMPLE_PROJECTS, SAMPLE_INSTALLED_RELEASES, SAMPLE_CUSTOM_RELEASE } from './support/e2e-fixture-data';
 import { getMainWindow } from './splashscreen/getMainWindow';
 
 let electronApp: ElectronApplication;
 let page: Page;
 let fixtureHome: string;
-const original = SAMPLE_INSTALLED_RELEASES[0];
-const project: ProjectDetails = { ...SAMPLE_PROJECTS[0], name: 'Settings Catalogue', release: original, version: original.version, version_number: original.version_number, codeEditorId: null };
-const nextRelease: ReleaseSummary = {
-    version: '4.9.3-stable', version_number: 4.9, name: '4.9.3-stable', published_at: '2026-09-05T00:00:00Z', draft: false, prerelease: false,
-    assets: [{ name: 'Godot_mono.zip', download_url: 'https://example.invalid/godot.zip', platform_tags: ['darwin', 'universal'], mono: true }],
+
+const installedRelease = SAMPLE_INSTALLED_RELEASES[0];
+const project: ProjectDetails = {
+    ...SAMPLE_PROJECTS[0],
+    codeEditorId: null,
+    name: 'Settings catalogue',
+    release: installedRelease,
+    version: installedRelease.version,
+    version_number: installedRelease.version_number,
+};
+const catalogueRelease: ReleaseSummary = {
+    version: '4.9.3-stable', version_number: 4.9, name: '4.9.3-stable',
+    published_at: '2026-09-05T00:00:00Z', draft: false, prerelease: false,
+    assets: [{ name: 'Godot_v4.9.3-stable_mono_macos.universal.zip', download_url: 'https://example.invalid/godot.zip', platform_tags: ['darwin', 'universal'], mono: true }],
 };
 
+test.describe.configure({ mode: 'serial' });
 test.beforeAll(async () => {
     fixtureHome = await createFixtureHome();
     electronApp = await _electron.launch({
@@ -30,240 +45,344 @@ test.afterAll(async () => {
     await fs.rm(fixtureHome, { recursive: true, force: true });
 });
 
-test('closes immediately and reports installation failures before saving in the background', async () => {
-    await prepareAppWithStubbedData(page, electronApp, { projects: [project], installedReleases: [original, SAMPLE_CUSTOM_RELEASE], availableReleases: [nextRelease, { ...nextRelease, version: '3.6-stable', version_number: 3.6 }], availablePrereleases: [] });
-    await stubSettingsOperations();
-    await page.getByTestId('btnProjects').click();
-    await page.getByTestId('btnProjectSettings').click();
-    const drawer = page.getByRole('dialog').filter({ has: page.getByTestId('selectProjectGodotEditor') });
-    await expect(drawer).toBeVisible();
-    const name = drawer.locator('#projectEditName');
-    await name.fill('Preserved Settings Name');
-    await drawer.getByTestId('selectProjectGodotEditor').click({ trial: true });
-    const openingFrames = await drawer.getByTestId('selectProjectGodotEditor').evaluate(async (trigger) => {
-        const panel = document.getElementById(trigger.getAttribute('aria-controls')!)!;
-        const frames: { x: number; y: number; width: number; height: number }[] = [];
-        (trigger as HTMLButtonElement).click();
-        for (let frame = 0; frame < 4; frame += 1) {
-            await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
-            if (getComputedStyle(panel).visibility === 'visible') {
-                const { x, y, width, height } = panel.getBoundingClientRect();
-                frames.push({ x, y, width, height });
-            }
-        }
-        return frames;
+test('saves a catalogue editor before its delayed download and recovers both project views', async () => {
+    await prepareAppWithStubbedData(page, electronApp, {
+        projects: [project], installedReleases: [installedRelease], availableReleases: [catalogueRelease], availablePrereleases: [],
     });
-    expect(openingFrames.length).toBeGreaterThan(0);
-    for (const frame of openingFrames) expect(frame).toEqual(openingFrames[0]);
-    const picker = drawer.getByTestId('createProjectEditorPickerPopover');
-    await expect(picker.getByRole('option', { name: /Acme 4.7 Custom Editor/ })).toBeVisible();
-    const installedBounds = await picker.boundingBox();
-    await picker.getByTestId('tabCreateProjectBrowseEditors').click();
-    await expect.poll(() => picker.boundingBox()).toEqual(installedBounds);
-    await picker.getByTestId('inputCreateProjectEditorSearch').fill('no-matching-editor');
-    await expect(picker.getByText('No matching releases', { exact: true })).toBeVisible();
-    await expect.poll(() => picker.boundingBox()).toEqual(installedBounds);
-    await picker.getByTestId('inputCreateProjectEditorSearch').fill('');
-
-    await expect(picker.getByTestId('createProjectCatalogueEditor_catalogue:3.6-stable:mono')).toHaveCount(0);
-    await picker.getByTestId('createProjectCatalogueEditor_catalogue:4.9.3-stable:mono').click();
-    await expect.poll(readSettingsEvents).toEqual([]);
-    await drawer.getByRole('button', { name: 'Install and save', exact: true }).click();
-    await expect(drawer).not.toBeVisible();
-    await expect(page.getByText('Simulated installation failure', { exact: true })).toBeVisible();
-    await page.getByTestId('btnAlertOk').click();
-    await page.getByTestId('btnProjectSettings').click();
-    await expect(name).toHaveValue('Preserved Settings Name');
-    await expect(drawer.getByTestId('selectProjectGodotEditor')).toContainText('4.9.3-stable');
-    await expect.poll(readSettingsEvents).toEqual(['install:4.9.3-stable:true']);
-    await drawer.getByRole('button', { name: 'Install and save', exact: true }).click();
-    await expect.poll(readSettingsEvents).toEqual(['install:4.9.3-stable:true', 'install:4.9.3-stable:true']);
-    await expect(drawer).not.toBeVisible();
-    await page.getByTestId('btnProjectSettings').click();
-    await expect(drawer.getByTestId('selectProjectGodotEditor')).toBeDisabled();
-    await completeSettingsInstall();
-    await expect(drawer).toBeVisible();
-    await expect(drawer.getByTestId('selectProjectGodotEditor')).toBeEnabled();
-    await expect(drawer.getByTestId('selectProjectGodotEditor')).toContainText('4.9.3-stable');
-    await expect(name).toHaveValue('Preserved Settings Name');
-    await expect(drawer.getByRole('button', { name: 'Update', exact: true })).toBeDisabled();
-    await page.keyboard.press('Escape');
-    await expect(drawer).not.toBeVisible();
-    await expect.poll(readSettingsEvents).toEqual(['install:4.9.3-stable:true', 'install:4.9.3-stable:true', 'rename:Preserved Settings Name', 'editor:4.9.3-stable:true']);
-});
-
-test('keeps installed custom editor selection staged until settings are saved', async () => {
-    await prepareAppWithStubbedData(page, electronApp, { projects: [project], installedReleases: [original, SAMPLE_CUSTOM_RELEASE], availableReleases: [nextRelease], availablePrereleases: [] });
-    await stubSettingsOperations();
+    await stubCatalogueEditorSave();
     await page.getByTestId('btnProjects').click();
     await page.getByTestId('btnProjectSettings').click();
-    const drawer = page.getByRole('dialog').filter({ has: page.getByTestId('selectProjectGodotEditor') });
-    await drawer.getByTestId('selectProjectGodotEditor').click();
-    const picker = drawer.getByTestId('createProjectEditorPickerPopover');
-    await expect(picker).toBeVisible();
-    await page.keyboard.press('Escape');
-    await expect(picker).not.toBeVisible();
-    await expect(drawer).toBeVisible();
-    await drawer.getByTestId('selectProjectGodotEditor').click();
-    await picker.getByRole('option', { selected: true }).click();
-    await expect(picker).not.toBeVisible();
-    await expect(drawer.getByRole('button', { name: 'Update', exact: true })).toBeDisabled();
-    await drawer.getByTestId('selectProjectGodotEditor').click();
-    await picker.getByRole('option', { name: /Acme 4.7 Custom Editor/ }).click();
-    await expect.poll(readSettingsEvents).toEqual([]);
-    await drawer.getByRole('button', { name: 'Update', exact: true }).click();
-    await expect(drawer).not.toBeVisible();
-    await expect.poll(readSettingsEvents).toEqual([`editor:${SAMPLE_CUSTOM_RELEASE.version}:false`]);
-});
-
-test('offers installation when the selected catalogue version matches the missing current editor', async () => {
-    const missingProject: ProjectDetails = { ...project, valid: false, invalid_reason: 'missing_editor', release: { ...original, valid: false, editor_path: '', install_path: '' } };
-    const requiredRelease: ReleaseSummary = { ...nextRelease, version: original.version, version_number: original.version_number, assets: nextRelease.assets.map((asset) => ({ ...asset, mono: false })) };
-    await prepareAppWithStubbedData(page, electronApp, { projects: [missingProject], installedReleases: [], availableReleases: [requiredRelease], availablePrereleases: [] });
-    await stubSettingsOperations(missingProject);
-    await page.getByTestId('btnProjects').click();
-    await page.getByTestId('btnProjectSettings').click();
-    const drawer = page.getByRole('dialog').filter({ has: page.getByTestId('selectProjectGodotEditor') });
-    await drawer.getByTestId('selectProjectGodotEditor').click();
-    await expect(drawer.getByTestId('selectProjectGodotEditor')).toContainText('Not installed');
-    const picker = drawer.getByTestId('createProjectEditorPickerPopover');
-    await expect(picker.getByRole('tab', { name: 'Browse releases' })).toHaveAttribute('aria-selected', 'true');
-    await picker.getByRole('tab', { name: 'Installed', exact: true }).click();
-    await expect(picker.getByText('No installed editors', { exact: true })).toBeVisible();
-    await expect(picker.getByRole('option')).toHaveCount(0);
-    await picker.getByRole('button', { name: 'Browse releases', exact: true }).click();
-    await drawer.getByTestId(`createProjectCatalogueEditor_catalogue:${original.version}:std`).click();
-    await drawer.getByRole('button', { name: 'Install and save', exact: true }).click();
-    await expect(drawer).not.toBeVisible();
-    await expect(page.getByText('Simulated installation failure', { exact: true })).toBeVisible();
-    await page.getByTestId('btnAlertOk').click();
-    await expect.poll(readSettingsEvents).toEqual([`install:${original.version}:false`]);
-});
-
-test('finishes submitted settings when an installation completes after navigation', async () => {
-    await prepareAppWithStubbedData(page, electronApp, { projects: [project], installedReleases: [original], availableReleases: [nextRelease], availablePrereleases: [] });
-    await stubSettingsOperations();
-    await page.getByTestId('btnProjects').click();
-    await page.getByTestId('btnProjectSettings').click();
-    const drawer = page.getByRole('dialog').filter({ has: page.getByTestId('selectProjectGodotEditor') });
-    await drawer.locator('#projectEditName').fill('Abandoned Settings Name');
+    const drawer = page.getByRole('dialog', {
+        name: 'Settings catalogue Settings',
+    });
+    await drawer.locator('#projectEditName').fill('Saved before download');
+    await drawer.getByTestId('tabProjectSettings_launch').click();
+    await drawer.getByRole('checkbox').check();
+    await drawer.getByTestId('tabProjectSettings_project').click();
     await drawer.getByTestId('selectProjectGodotEditor').click();
     await drawer.getByTestId('tabCreateProjectBrowseEditors').click();
     await drawer.getByTestId('createProjectCatalogueEditor_catalogue:4.9.3-stable:mono').click();
-    await drawer.getByRole('button', { name: 'Install and save', exact: true }).click();
+    await drawer.getByRole('button', { name: 'Install and save' }).click();
+
     await expect(drawer).not.toBeVisible();
-    await expect(page.getByText('Simulated installation failure', { exact: true })).toBeVisible();
-    await page.getByTestId('btnAlertOk').click();
+    await expect.poll(readSettingsEvents).toEqual([
+        'rename:Saved before download', 'editor:4.9.3-stable:true',
+        'windowed:true', 'install:4.9.3-stable:true',
+    ]);
+    const card = page.locator('[data-project-path]').filter({ hasText: 'Saved before download' });
+    await expect(card).toContainText('4.9.3-stable (.NET)');
+    await expect(card.getByTestId('projectBadges').locator('.loading-spinner')).toBeVisible();
+    await expect(card.getByTestId('btnEditProjectInGodot')).toBeDisabled();
+
+    await page.getByTestId('tabProjectList').click();
+    const row = page.locator('[data-project-path]').filter({ hasText: 'Saved before download' });
+    await expect(row.getByTestId('compactProjectEditorVersion')).toContainText('4.9.3-stable (.NET)');
+    await expect(row.getByTestId('compactProjectEditorVersion').locator('.loading-spinner')).toBeVisible();
+    await expect(row.getByTestId('btnLaunchCompactProject')).toBeDisabled();
+
+    await completeCatalogueEditorInstall();
+    await expect.poll(readSettingsEvents).toEqual([
+        'rename:Saved before download', 'editor:4.9.3-stable:true',
+        'windowed:true', 'install:4.9.3-stable:true', 'repair:4.9.3-stable:true',
+    ]);
+    await expect(row.getByTestId('compactProjectEditorVersion')).toContainText('4.9.3-stable (.NET)');
+    await expect(row.getByTestId('btnLaunchCompactProject')).toBeEnabled();
+    await page.getByTestId('tabProjectCards').click();
+    await expect(card.getByTestId('btnEditProjectInGodot')).toBeEnabled();
+});
+
+test('keeps the saved missing selection after a download failure', async () => {
+    await prepareAppWithStubbedData(page, electronApp, {
+        projects: [project], installedReleases: [installedRelease], availableReleases: [catalogueRelease], availablePrereleases: [],
+    });
+    await stubCatalogueEditorSave({ failInstall: true });
+    await page.getByTestId('btnProjects').click();
     await page.getByTestId('btnProjectSettings').click();
-    await drawer.locator('#projectEditName').fill('Submitted Settings Name');
+    const drawer = page.getByRole('dialog', {
+        name: 'Settings catalogue Settings',
+    });
     await drawer.getByTestId('selectProjectGodotEditor').click();
     await drawer.getByTestId('tabCreateProjectBrowseEditors').click();
     await drawer.getByTestId('createProjectCatalogueEditor_catalogue:4.9.3-stable:mono').click();
-    await drawer.getByRole('button', { name: 'Install and save', exact: true }).click();
-    await expect.poll(readSettingsEvents).toHaveLength(2);
-    await page.evaluate(() => { window.location.hash = '#/installs'; });
+    await drawer.getByRole('button', { name: 'Install and save' }).click();
     await expect(drawer).not.toBeVisible();
+    await expect(page.getByText('Simulated installation failure')).toBeVisible();
+    const card = page.locator('[data-project-path]');
+    await expect(card).toContainText('4.9.3-stable (.NET)');
+    await expect(card.getByTestId('btnEditProjectInGodot')).toBeDisabled();
+});
+
+test('keeps Settings open when a combined save fails before download starts', async () => {
+    await prepareAppWithStubbedData(page, electronApp, {
+        projects: [project], installedReleases: [installedRelease], availableReleases: [catalogueRelease], availablePrereleases: [],
+    });
+    await stubCatalogueEditorSave({ failRename: true });
     await page.getByTestId('btnProjects').click();
     await page.getByTestId('btnProjectSettings').click();
-    await expect(drawer.getByTestId('selectProjectGodotEditor')).toBeDisabled();
-    await expect(drawer.locator('#projectEditName')).toBeDisabled();
-    await expect(drawer.locator('#projectEditName')).toHaveValue('Submitted Settings Name');
-    await expect(drawer.getByRole('status')).toContainText('Installing editor');
-    await page.keyboard.press('Escape');
-    await expect(drawer).not.toBeVisible();
+    const drawer = page.getByRole('dialog', {
+        name: 'Settings catalogue Settings',
+    });
+    await drawer.locator('#projectEditName').fill('Rejected save');
+    await drawer.getByTestId('tabProjectSettings_launch').click();
+    await drawer.getByRole('checkbox').check();
+    await drawer.getByTestId('tabProjectSettings_project').click();
+    await drawer.getByTestId('selectProjectGodotEditor').click();
+    await drawer.getByTestId('tabCreateProjectBrowseEditors').click();
+    await drawer.getByTestId('createProjectCatalogueEditor_catalogue:4.9.3-stable:mono').click();
+    await drawer.getByRole('button', { name: 'Install and save' }).click();
+
+    await expect(drawer).toBeVisible();
+    await expect(drawer.getByRole('alert')).toContainText('Simulated save failure');
+    await expect.poll(readSettingsEvents).toEqual(['rename:Rejected save']);
+    await expect(page.getByTestId('btnEditProjectInGodot')).toBeEnabled();
+});
+
+test('keeps an installed custom editor staged until Settings is saved', async () => {
+    const customRelease: InstalledRelease = {
+        ...installedRelease,
+        version: '4.7.0-custom.1',
+        name: 'Studio custom editor',
+        mono: false,
+        source: 'custom',
+    };
+    await prepareAppWithStubbedData(page, electronApp, {
+        projects: [project],
+        installedReleases: [installedRelease, customRelease],
+        availableReleases: [catalogueRelease],
+        availablePrereleases: [],
+    });
+    await stubCatalogueEditorSave({
+        initialInstalledReleases: [installedRelease, customRelease],
+    });
+    await page.getByTestId('btnProjects').click();
     await page.getByTestId('btnProjectSettings').click();
-    await expect(drawer.getByTestId('selectProjectGodotEditor')).toBeDisabled();
-    await completeSettingsInstall();
-    await expect(drawer.getByTestId('selectProjectGodotEditor')).toBeEnabled();
-    await expect(drawer.getByTestId('selectProjectGodotEditor')).toContainText('4.9.3-stable');
-    await expect(drawer.getByRole('button', { name: 'Update', exact: true })).toBeDisabled();
-    await expect.poll(readSettingsEvents).toEqual(['install:4.9.3-stable:true', 'install:4.9.3-stable:true', 'rename:Submitted Settings Name', 'editor:4.9.3-stable:true']);
+    const drawer = page.getByRole('dialog', {
+        name: 'Settings catalogue Settings',
+    });
+    await drawer.getByTestId('selectProjectGodotEditor').click();
+    await drawer
+        .getByRole('option', { name: /Studio custom editor/ })
+        .click();
+    await expect.poll(readSettingsEvents).toEqual([]);
+    await drawer.getByRole('button', { name: 'Update' }).click();
+    await expect(drawer).not.toBeVisible();
+    await expect.poll(readSettingsEvents).toEqual([
+        'repair:4.7.0-custom.1:false',
+    ]);
+});
+
+test('offers the matching missing editor from the catalogue', async () => {
+    const missingProject: ProjectDetails = {
+        ...project,
+        valid: false,
+        invalid_reason: 'missing_editor',
+        release: {
+            ...installedRelease,
+            valid: false,
+            install_path: '',
+            editor_path: '',
+        },
+    };
+    const matchingRelease: ReleaseSummary = {
+        ...catalogueRelease,
+        version: installedRelease.version,
+        version_number: installedRelease.version_number,
+        assets: catalogueRelease.assets.map((asset) => ({
+            ...asset,
+            mono: false,
+        })),
+    };
+    await prepareAppWithStubbedData(page, electronApp, {
+        projects: [missingProject],
+        installedReleases: [],
+        availableReleases: [matchingRelease],
+        availablePrereleases: [],
+    });
+    await stubCatalogueEditorSave({
+        failInstall: true,
+        initialInstalledReleases: [],
+        initialProject: missingProject,
+    });
+    await page.getByTestId('btnProjects').click();
+    await page.getByTestId('btnProjectSettings').click();
+    const drawer = page.getByRole('dialog', {
+        name: 'Settings catalogue Settings',
+    });
+    await drawer.getByTestId('selectProjectGodotEditor').click();
+    await expect(drawer.getByTestId('selectProjectGodotEditor')).toContainText(
+        'Not installed',
+    );
+    const picker = drawer.getByTestId('createProjectEditorPickerPopover');
+    await expect(
+        picker.getByRole('tab', { name: 'Browse releases' }),
+    ).toHaveAttribute('aria-selected', 'true');
+    await drawer
+        .getByTestId(
+            `createProjectCatalogueEditor_catalogue:${installedRelease.version}:std`,
+        )
+        .click();
+    await drawer.getByRole('button', { name: 'Install and save' }).click();
+    await expect(drawer).not.toBeVisible();
+    await expect.poll(readSettingsEvents).toEqual([
+        `editor:${installedRelease.version}:false`,
+        `install:${installedRelease.version}:false`,
+    ]);
 });
 
 /**
- * Stubs installation failure, delayed retry and relevant project mutations.
- * @param initialProject - Project preserved until the settings save succeeds.
+ * Replaces project saves and installation with a delayed, stateful fixture flow.
+ *
+ * @param options - Whether the save or editor installation should fail.
+ * @returns A promise that resolves when fixture IPC handlers are ready.
  */
-async function stubSettingsOperations(initialProject = project): Promise<void> {
-    await electronApp.evaluate(({ ipcMain, BrowserWindow }, initialProject) => {
-        const state = globalThis as typeof globalThis & { __settingsEvents?: string[]; __settingsComplete?: () => void };
-        state.__settingsEvents = [];
-        let current = initialProject;
-        let installs = 0;
+async function stubCatalogueEditorSave(
+    options: {
+        failInstall?: boolean;
+        failRename?: boolean;
+        initialInstalledReleases?: InstalledRelease[];
+        initialProject?: ProjectDetails;
+    } = {},
+): Promise<void> {
+    await electronApp.evaluate(({ ipcMain, BrowserWindow }, injected) => {
+        type EditorSelection = { release: ReleaseSummary; mono: boolean };
+        const state = globalThis as typeof globalThis & {
+            __settingsCatalogueEvents?: string[];
+            __settingsCatalogueComplete?: () => void;
+        };
+        state.__settingsCatalogueEvents = [];
+        let currentProject = injected.options.initialProject ?? injected.initialProject;
+        let installedReleases =
+            injected.options.initialInstalledReleases ?? [injected.installedRelease];
+        const publishProjects = () => {
+            for (const window of BrowserWindow.getAllWindows()) {
+                const contents = window.webContents as typeof window.webContents & { __e2eFixtureProjects?: ProjectDetails[] };
+                contents.__e2eFixtureProjects = [currentProject];
+                contents.send('projects-updated', [currentProject]);
+            }
+        };
+        const createInstalledRelease = (release: ReleaseSummary, mono: boolean): InstalledRelease => ({
+            ...injected.installedRelease, version: release.version, version_number: release.version_number, mono,
+            install_path: `/editors/${release.version}`, editor_path: `/editors/${release.version}/Godot`, valid: true,
+        });
+        const publishInstallProgress = (progress: ReleaseInstallProgress) => {
+            for (const window of BrowserWindow.getAllWindows()) {
+                window.webContents.send('release-install-progress', progress);
+            }
+        };
+        ipcMain.removeHandler('projects.renameProject');
+        ipcMain.handle('projects.renameProject', async (_event, _project, saveOptions) => {
+            state.__settingsCatalogueEvents?.push(`rename:${saveOptions.name}`);
+            if (injected.options.failRename) {
+                return { success: true, data: { success: false, error: 'Simulated save failure' } };
+            }
+            currentProject = { ...currentProject, name: saveOptions.name };
+            publishProjects();
+            return { success: true, data: { success: true, project: currentProject, projects: [currentProject] } };
+        });
+        for (const channel of [
+            'editorInstalls.getInstalledEditors',
+            'editorInstalls.revalidateInstalledEditors',
+        ]) {
+            ipcMain.removeHandler(channel);
+            ipcMain.handle(channel, async () => ({
+                success: true,
+                data: installedReleases,
+            }));
+        }
+        ipcMain.removeHandler('projects.setProjectEditor');
+        ipcMain.handle('projects.setProjectEditor', async (_event, _project, selection: EditorSelection | InstalledRelease) => {
+            const selected = 'release' in selection ? selection.release : selection;
+            const mono = selection.mono;
+            const repairing = !('release' in selection);
+            state.__settingsCatalogueEvents?.push(`${repairing ? 'repair' : 'editor'}:${selected.version}:${mono}`);
+            currentProject = repairing ? {
+                ...currentProject, release: selected, version: selected.version, version_number: selected.version_number,
+                launch_path: selected.editor_path, valid: true, invalid_reason: undefined,
+            } : {
+                ...currentProject,
+                release: { ...selected, mono, install_path: '', editor_path: '', valid: false, source: 'official' },
+                version: selected.version, version_number: selected.version_number, launch_path: '', valid: false, invalid_reason: 'missing_editor',
+            };
+            publishProjects();
+            return { success: true, data: { success: true, projects: [currentProject] } };
+        });
+        ipcMain.removeHandler('projects.setProjectWindowed');
+        ipcMain.handle('projects.setProjectWindowed', async (_event, _project, openWindowed: boolean) => {
+            state.__settingsCatalogueEvents?.push(`windowed:${openWindowed}`);
+            currentProject = { ...currentProject, open_windowed: openWindowed };
+            publishProjects();
+            return { success: true, data: currentProject };
+        });
         ipcMain.removeHandler('editorInstalls.installEditor');
         ipcMain.handle('editorInstalls.installEditor', async (_event, release: ReleaseSummary, mono: boolean) => {
-            state.__settingsEvents!.push(`install:${release.version}:${mono}`);
-            installs += 1;
-            if (installs === 1) return { success: true, data: { success: false, error: 'Simulated installation failure' } };
-            return new Promise((resolve) => {
-                state.__settingsComplete = () => {
-                    const installed: InstalledRelease = { ...initialProject.release, version: release.version, version_number: release.version_number, mono, editor_path: '/editors/4.9.3/Godot', install_path: '/editors/4.9.3', valid: true };
+            state.__settingsCatalogueEvents?.push(`install:${release.version}:${mono}`);
+            const progress = {
+                id: 'settings-catalogue-install',
+                version: release.version,
+                mono,
+                prerelease: release.prerelease,
+                published_at: release.published_at,
+                canCancel: false,
+            };
+            publishInstallProgress({ ...progress, stage: 'queued', percent: 0, queuePosition: 1 });
+            publishInstallProgress({ ...progress, stage: 'downloading', percent: 42, receivedBytes: 42, totalBytes: 100 });
+            if (injected.options.failInstall) {
+                publishInstallProgress({ ...progress, stage: 'error', error: 'Simulated installation failure' });
+                return { success: true, data: { success: false, error: 'Simulated installation failure' } };
+            }
+            return await new Promise((resolve) => {
+                state.__settingsCatalogueComplete = () => {
+                    const installed = createInstalledRelease(release, mono);
+                    installedReleases = [injected.installedRelease, installed];
                     for (const window of BrowserWindow.getAllWindows()) {
                         const contents = window.webContents as typeof window.webContents & { __e2eFixtureInstalledReleases?: InstalledRelease[] };
-                        contents.__e2eFixtureInstalledReleases = [initialProject.release, installed];
-                        contents.send('releases-updated', [initialProject.release, installed]);
+                        contents.__e2eFixtureInstalledReleases = installedReleases;
+                        contents.send('releases-updated', installedReleases);
                     }
+                    publishInstallProgress({ ...progress, stage: 'complete', percent: 100, release: installed });
                     resolve({ success: true, data: { success: true, version: release.version, release: installed } });
                 };
             });
         });
-        ipcMain.removeHandler('projects.renameProject');
-        ipcMain.handle('projects.renameProject', async (_event, _project, options) => {
-            state.__settingsEvents!.push(`rename:${options.name}`);
-            current = { ...current, name: options.name };
-            return { success: true, data: { success: true, project: current, projects: [current] } };
-        });
-        ipcMain.removeHandler('projects.setProjectEditor');
-        ipcMain.handle('projects.setProjectEditor', async (_event, _project, release: InstalledRelease) => {
-            state.__settingsEvents!.push(`editor:${release.version}:${release.mono}`);
-            current = { ...current, release, version: release.version, version_number: release.version_number };
-            return { success: true, data: { success: true, projects: [current] } };
-        });
-        ipcMain.removeHandler('projects.launchProject');
-        ipcMain.handle('projects.launchProject', () => { state.__settingsEvents!.push('launch'); return { success: true, data: {} }; });
-    }, initialProject);
+    }, { options, initialProject: project, installedRelease });
 }
 
-/** Reads the ordered installation and mutation calls. */
-async function readSettingsEvents(): Promise<string[]> {
-    return electronApp.evaluate(() => (globalThis as typeof globalThis & { __settingsEvents?: string[] }).__settingsEvents ?? []);
-}
-
-/** Completes the pending successful editor installation. */
-async function completeSettingsInstall(): Promise<void> {
+/**
+ * Completes the delayed fixture installation.
+ *
+ * @returns A promise that resolves after the fixture install completes.
+ */
+async function completeCatalogueEditorInstall(): Promise<void> {
     await electronApp.evaluate(() => {
-        const complete = (globalThis as typeof globalThis & { __settingsComplete?: () => void }).__settingsComplete;
-        if (!complete) throw new Error('No pending settings installation');
+        const complete = (globalThis as typeof globalThis & { __settingsCatalogueComplete?: () => void }).__settingsCatalogueComplete;
+        if (!complete) throw new Error('No editor installation is pending.');
         complete();
     });
 }
 
 /**
- * Creates an isolated environment for one Electron E2E app.
+ * Reads the ordered fixture save and repair operations.
+ *
+ * @returns Recorded operation names.
+ */
+async function readSettingsEvents(): Promise<string[]> {
+    return electronApp.evaluate(() => (globalThis as typeof globalThis & { __settingsCatalogueEvents?: string[] }).__settingsCatalogueEvents ?? []);
+}
+
+/**
+ * Creates an isolated Electron fixture environment.
  *
  * @param homeDir - Fixture home used for launcher state.
  * @returns Environment variables for the fixture Electron process.
  */
-function createIsolatedLaunchEnvironment(
-    homeDir: string,
-): Record<string, string> {
+function createIsolatedLaunchEnvironment(homeDir: string): Record<string, string> {
     const environment: Record<string, string> = {
-        ...Object.fromEntries(
-            Object.entries(process.env).filter(
-                (entry): entry is [string, string] =>
-                    typeof entry[1] === 'string',
-            ),
-        ),
-        APPDATA: path.join(homeDir, 'AppData', 'Roaming'),
-        HOME: homeDir,
-        LOCALAPPDATA: path.join(homeDir, 'AppData', 'Local'),
-        USERPROFILE: homeDir,
-        XDG_CACHE_HOME: path.join(homeDir, '.cache'),
-        XDG_CONFIG_HOME: path.join(homeDir, '.config'),
-        XDG_DATA_HOME: path.join(homeDir, '.local', 'share'),
-        XDG_STATE_HOME: path.join(homeDir, '.local', 'state'),
-        GODOT_LAUNCHER_E2E_FIXTURES: '1',
-        GODOT_LAUNCHER_E2E_HOME_DIR: homeDir,
+        ...Object.fromEntries(Object.entries(process.env).filter((entry): entry is [string, string] => typeof entry[1] === 'string')),
+        APPDATA: path.join(homeDir, 'AppData', 'Roaming'), HOME: homeDir,
+        LOCALAPPDATA: path.join(homeDir, 'AppData', 'Local'), USERPROFILE: homeDir,
+        XDG_CACHE_HOME: path.join(homeDir, '.cache'), XDG_CONFIG_HOME: path.join(homeDir, '.config'),
+        XDG_DATA_HOME: path.join(homeDir, '.local', 'share'), XDG_STATE_HOME: path.join(homeDir, '.local', 'state'),
+        GODOT_LAUNCHER_E2E_FIXTURES: '1', GODOT_LAUNCHER_E2E_HOME_DIR: homeDir,
     };
     delete environment.ELECTRON_RUN_AS_NODE;
     return environment;

--- a/main/src/editor-installs/editor-project-repair.adapter.ts
+++ b/main/src/editor-installs/editor-project-repair.adapter.ts
@@ -74,6 +74,13 @@ export class EditorProjectRepairAdapter {
         newRelease: InstalledRelease,
     ): Promise<void> {
         const projects = await this.listProjects();
+        const expectedEditor =
+            previousRelease.source === 'custom'
+                ? undefined
+                : {
+                      version: previousRelease.version,
+                      mono: previousRelease.mono,
+                  };
         for (const project of projects.filter((candidate) =>
             projectUsesEditor(candidate, previousRelease),
         )) {
@@ -82,6 +89,7 @@ export class EditorProjectRepairAdapter {
                 newRelease,
                 this.codeEditorIntegrationService,
                 this.projectsStore,
+                expectedEditor,
             );
             if (!result.success) {
                 logger.warn(

--- a/main/src/editor-installs/project-editor-repair.util.test.ts
+++ b/main/src/editor-installs/project-editor-repair.util.test.ts
@@ -1,5 +1,9 @@
 import path from 'node:path';
-import type { InstalledRelease, ProjectDetails } from '@shared/contracts';
+import type {
+    InstalledRelease,
+    ProjectDetails,
+    ProjectEditorSelectionExpectation,
+} from '@shared/contracts';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { CodeEditorIntegrationService } from '../codeEditorIntegration/codeEditorIntegration.service.js';
 import type { ProjectsStore } from '../projects/projects.store.js';
@@ -139,17 +143,20 @@ const projectsStore = {
  * @param project - Project to update.
  * @param release - Replacement editor release.
  * @param codeEditors - Code editor integration facade.
+ * @param expectedEditor - Optional current selection required for repair.
  */
 function setProjectEditor(
     project: ProjectDetails,
     release: InstalledRelease,
     codeEditors: CodeEditorIntegrationService,
+    expectedEditor?: ProjectEditorSelectionExpectation,
 ) {
     return setProjectEditorForRepair(
         project,
         release,
         codeEditors,
         projectsStore,
+        expectedEditor,
     );
 }
 
@@ -244,7 +251,7 @@ describe('setProjectEditor', () => {
 
         SetProjectEditorRelease.mockResolvedValue('/fake/launch/new');
 
-        existsSync.mockReturnValue(false);
+        existsSync.mockReturnValue(true);
 
         writeProjectLauncherConfig.mockResolvedValue(undefined);
         integrationMocks.scanIntegration.mockResolvedValue({
@@ -497,6 +504,54 @@ describe('setProjectEditor', () => {
 
         expect(result.success).toBe(false);
         expect(result.error).toBeDefined();
+    });
+
+    it.each(['version', 'custom'] as const)(
+        'skips a repair after a %s selection change',
+        async (change) => {
+            const replacementProject = {
+                ...mockProject,
+                release: {
+                    ...mockProject.release,
+                    ...(change === 'version'
+                        ? { version: '4.4-stable' }
+                        : { source: 'custom' as const }),
+                },
+            };
+            getProjectsSnapshot.mockResolvedValue({
+                projects: [replacementProject],
+                version: 'v1',
+            });
+
+            const result = await setProjectEditor(
+                mockProject,
+                mockNewRelease,
+                codeEditorIntegrationService,
+                { version: mockOldRelease.version, mono: mockOldRelease.mono },
+            );
+
+            expect(result).toEqual({
+                success: true,
+                projects: [replacementProject],
+            });
+            expect(SetProjectEditorRelease).not.toHaveBeenCalled();
+            expect(writeProjectLauncherConfig).not.toHaveBeenCalled();
+        },
+    );
+
+    it('skips a repair when the project was removed', async () => {
+        getProjectsSnapshot.mockResolvedValue({ projects: [], version: 'v1' });
+
+        const result = await setProjectEditor(
+            mockProject,
+            mockNewRelease,
+            codeEditorIntegrationService,
+            { version: mockOldRelease.version, mono: mockOldRelease.mono },
+        );
+
+        expect(result).toEqual({ success: true, projects: [] });
+        expect(SetProjectEditorRelease).not.toHaveBeenCalled();
+        expect(writeProjectLauncherConfig).not.toHaveBeenCalled();
     });
 
     it('should return error when trying to change to different major version', async () => {

--- a/main/src/editor-installs/project-editor-repair.util.ts
+++ b/main/src/editor-installs/project-editor-repair.util.ts
@@ -1,8 +1,10 @@
+import { existsSync } from 'node:fs';
 import * as path from 'node:path';
 import type {
     ChangeProjectEditorResult,
     InstalledRelease,
     ProjectDetails,
+    ProjectEditorSelectionExpectation,
 } from '@shared/contracts';
 import { app } from 'electron';
 import logger from 'electron-log';
@@ -49,6 +51,7 @@ function resolveProjectEditorPath(
  * @param newRelease - Installed editor to assign.
  * @param codeEditorIntegrationService - Code editor integration facade.
  * @param projectsStore - Canonical project store.
+ * @param expectedEditor - Optional current selection required for repair.
  * @returns The bridge-compatible editor change result.
  */
 export async function setProjectEditor(
@@ -56,6 +59,7 @@ export async function setProjectEditor(
     newRelease: InstalledRelease,
     codeEditorIntegrationService: CodeEditorIntegrationService,
     projectsStore: ProjectsStore,
+    expectedEditor?: ProjectEditorSelectionExpectation,
 ): Promise<ChangeProjectEditorResult> {
     const { install_location: installLocation } = await getUserPreferences();
     const recoveredCodeEditorConfigFiles = new Set<string>();
@@ -67,6 +71,9 @@ export async function setProjectEditor(
             (candidate) => candidate.path === project.path,
         );
         if (projectIndex === -1) {
+            if (expectedEditor) {
+                return currentProjects;
+            }
             failure = {
                 success: false,
                 error: t('projects:changeEditor.errors.projectNotFound'),
@@ -75,6 +82,14 @@ export async function setProjectEditor(
         }
 
         const currentProject = currentProjects[projectIndex];
+        if (
+            expectedEditor &&
+            (currentProject.release.version !== expectedEditor.version ||
+                currentProject.release.mono !== expectedEditor.mono ||
+                currentProject.release.source === 'custom')
+        ) {
+            return currentProjects;
+        }
 
         if (
             currentProject.release.version === newRelease.version &&
@@ -162,6 +177,9 @@ export async function setProjectEditor(
             );
         }
 
+        const projectFileExists = existsSync(
+            path.resolve(currentProject.path, 'project.godot'),
+        );
         updatedProject = {
             ...currentProject,
             release: {
@@ -175,7 +193,10 @@ export async function setProjectEditor(
                 path.dirname(newEditorSettingsFile),
             ),
             editor_settings_file: newEditorSettingsFile,
-            valid: true,
+            valid: projectFileExists,
+            invalid_reason: projectFileExists
+                ? undefined
+                : 'missing_project_file',
         };
 
         await writeProjectLauncherConfig(updatedProject.path, {
@@ -192,18 +213,15 @@ export async function setProjectEditor(
         return failure;
     }
 
-    const latestProject =
-        projects.find((candidate) => candidate.path === project.path) ??
-        updatedProject;
-    if (latestProject) {
-        project.release = latestProject.release;
-        project.version = latestProject.version;
-        project.version_number = latestProject.version_number;
-        project.launch_path = latestProject.launch_path;
-        project.editor_settings_file = latestProject.editor_settings_file;
-        project.editor_settings_path = latestProject.editor_settings_path;
-        project.valid = latestProject.valid;
-        project.codeEditorId = latestProject.codeEditorId;
+    if (updatedProject) {
+        project.release = updatedProject.release;
+        project.version = updatedProject.version;
+        project.version_number = updatedProject.version_number;
+        project.launch_path = updatedProject.launch_path;
+        project.editor_settings_file = updatedProject.editor_settings_file;
+        project.editor_settings_path = updatedProject.editor_settings_path;
+        project.valid = updatedProject.valid;
+        project.codeEditorId = updatedProject.codeEditorId;
     }
 
     return {

--- a/main/src/projects/projects.controller.ts
+++ b/main/src/projects/projects.controller.ts
@@ -13,6 +13,8 @@ import type {
     InstalledRelease,
     LaunchProjectOptions,
     ProjectDetails,
+    ProjectEditorSelection,
+    ProjectEditorSelectionExpectation,
     ProjectPublicationRecoveryAction,
     ProjectsBridge,
     RemoteProjectImportRequest,
@@ -305,11 +307,18 @@ export class ProjectsController implements ProjectsBridge {
      * Changes the Godot editor assigned to a project.
      *
      * @param project - Project to update.
-     * @param release - Godot editor to assign.
+     * @param selection - Installed editor or official editor selection to assign.
+     * @param expectedEditor - Optional current selection required for repair.
      */
     @ProjectsHandler('setProjectEditor')
-    setProjectEditor(project: ProjectDetails, release: InstalledRelease) {
-        return this.projects.setProjectEditor(project, release);
+    setProjectEditor(
+        project: ProjectDetails,
+        selection: ProjectEditorSelection,
+        expectedEditor?: ProjectEditorSelectionExpectation,
+    ) {
+        return expectedEditor
+            ? this.projects.setProjectEditor(project, selection, expectedEditor)
+            : this.projects.setProjectEditor(project, selection);
     }
 
     /**

--- a/main/src/projects/projects.service.test.ts
+++ b/main/src/projects/projects.service.test.ts
@@ -32,6 +32,18 @@ const mocks = vi.hoisted(() => ({
     updateLinuxTray: vi.fn(),
     writeProjectLauncherConfig: vi.fn(),
     hasProjectHealthChanged: vi.fn(),
+    getInstalledEditors: vi.fn(),
+    getProjectDefinition: vi.fn(),
+    getUserPreferences: vi.fn(),
+    setProjectEditorRelease: vi.fn(),
+}));
+
+const fsMocks = vi.hoisted(() => ({
+    existsSync: vi.fn(),
+}));
+
+vi.mock('node:fs', () => ({
+    existsSync: fsMocks.existsSync,
 }));
 
 vi.mock('electron', () => ({
@@ -53,7 +65,7 @@ vi.mock('../commands/projectEditorSettings.js', () => ({
     importProjectEditorSettings: mocks.importProjectEditorSettings,
 }));
 vi.mock('../commands/userPreferences.js', () => ({
-    getUserPreferences: vi.fn(),
+    getUserPreferences: mocks.getUserPreferences,
 }));
 vi.mock('../codeEditorIntegration/codeEditorIntegration.service.js', () => ({
     CodeEditorIntegrationService: class CodeEditorIntegrationService {},
@@ -76,9 +88,9 @@ vi.mock('../tool-integration/integrations/git/git.service.js', () => ({
 }));
 vi.mock('../utils/godot.utils.js', () => ({
     DEFAULT_PROJECT_DEFINITION: new Map(),
-    getProjectDefinition: vi.fn(),
+    getProjectDefinition: mocks.getProjectDefinition,
     removeProjectEditor: mocks.removeProjectEditor,
-    SetProjectEditorRelease: vi.fn(),
+    SetProjectEditorRelease: mocks.setProjectEditorRelease,
 }));
 vi.mock('../utils/godotProject.utils.js', () => ({
     readGodotProjectName: mocks.getProjectGodotName,
@@ -103,7 +115,11 @@ vi.mock('./project-import.service.js', () => ({
 import { ProjectsService } from './projects.service.js';
 
 describe('ProjectsService', () => {
-    const codeEditors = { id: 'code-editors' };
+    const codeEditors = {
+        id: 'code-editors',
+        scanIntegration: vi.fn(),
+        disableForProject: vi.fn(),
+    };
     const projectImport = { addProject: mocks.addProject };
     const git = {
         getIdentity: vi.fn(),
@@ -118,6 +134,9 @@ describe('ProjectsService', () => {
         inspectCreateProjectRepository: mocks.inspectCreateProjectRepository,
     };
     const trayAvailability = { id: 'tray' };
+    const installedEditors = {
+        getInstalledEditors: mocks.getInstalledEditors,
+    };
     const store = {
         list: vi.fn(),
         put: vi.fn(),
@@ -150,6 +169,12 @@ describe('ProjectsService', () => {
         vi.clearAllMocks();
         mocks.addProject.mockResolvedValue({ success: false });
         mocks.createProject.mockResolvedValue({ success: true });
+        mocks.getInstalledEditors.mockResolvedValue([]);
+        mocks.getUserPreferences.mockResolvedValue({
+            install_location: '/install',
+        });
+        codeEditors.scanIntegration.mockResolvedValue(null);
+        fsMocks.existsSync.mockReturnValue(true);
         store.list.mockResolvedValue([]);
         store.remove.mockResolvedValue([]);
         mocks.checkProjectHealth.mockImplementation(async (project) => project);
@@ -164,6 +189,7 @@ describe('ProjectsService', () => {
             git as never,
             projectCreation as never,
             trayAvailability as never,
+            installedEditors as never,
             store as never,
             remoteSources as never,
             remoteImport as never,
@@ -641,5 +667,311 @@ describe('ProjectsService', () => {
         expect(mocks.removeProjectEditor).toHaveBeenCalledWith(project);
         expect(store.remove).toHaveBeenCalledWith(project.path);
         expect(mocks.ipcWebContentsSend).toHaveBeenCalledOnce();
+    });
+
+    it('persists an uninstalled official editor without installed-only setup', async () => {
+        const project = {
+            name: 'Game',
+            version: '4.4-stable',
+            version_number: 4.4,
+            path: '/projects/game',
+            editor_settings_path: '/projects/editor-data',
+            editor_settings_file:
+                '/projects/editor-data/editor_settings-4.4.tres',
+            release: {
+                version: '4.4-stable',
+                mono: false,
+                editor_path: '/editors/4.4/Godot',
+                valid: true,
+            },
+            launch_path: '/projects/editor/Godot',
+            config_version: 5,
+            codeEditorId: 'vscode',
+            valid: true,
+        } as ProjectDetails;
+        const selection = {
+            release: {
+                version: '4.5-stable',
+                version_number: 4.5,
+                name: 'Godot 4.5',
+                published_at: '2026-01-01T00:00:00Z',
+                draft: false,
+                prerelease: false,
+                assets: [],
+            },
+            mono: true,
+        };
+        store.update.mockImplementation(async (mutator) => mutator([project]));
+        mocks.getProjectDefinition.mockReturnValue({
+            editorConfigFilename: vi.fn(),
+            editorConfigFormat: 3,
+        });
+        fsMocks.existsSync.mockReturnValue(false);
+
+        const result = await service.setProjectEditor(project, selection);
+
+        expect(result).toMatchObject({
+            success: true,
+            projects: [
+                expect.objectContaining({
+                    valid: false,
+                    invalid_reason: 'missing_project_file',
+                    launch_path: '',
+                    editor_settings_path: '/projects/editor-data',
+                    editor_settings_file:
+                        '/projects/editor-data/editor_settings-4.4.tres',
+                    release: expect.objectContaining({
+                        version: '4.5-stable',
+                        mono: true,
+                        flavor: 'dotnet',
+                        editor_path: '',
+                        install_path: '',
+                        valid: false,
+                        source: 'official',
+                    }),
+                }),
+            ],
+        });
+        expect(mocks.getUserPreferences).not.toHaveBeenCalled();
+        expect(mocks.setProjectEditorRelease).not.toHaveBeenCalled();
+        expect(codeEditors.scanIntegration).not.toHaveBeenCalled();
+        expect(mocks.writeProjectLauncherConfig).toHaveBeenCalledOnce();
+    });
+
+    it('uses the registered official editor when it is already installed', async () => {
+        const missingProject = {
+            name: 'Game',
+            version: '4.5-stable',
+            version_number: 4.5,
+            path: '/projects/game',
+            editor_settings_path: '',
+            editor_settings_file: '',
+            release: {
+                version: '4.5-stable',
+                mono: false,
+                editor_path: '',
+                install_path: '',
+                valid: false,
+            },
+            launch_path: '',
+            config_version: 5,
+            codeEditorId: 'vscode',
+            valid: false,
+            invalid_reason: 'missing_editor',
+        } as ProjectDetails;
+        const installedRelease = {
+            version: '4.5-stable',
+            version_number: 4.5,
+            install_path: '/editors/4.5',
+            editor_path: '/editors/4.5/Godot',
+            platform: process.platform,
+            arch: process.arch,
+            mono: false,
+            prerelease: false,
+            config_version: 5 as const,
+            published_at: null,
+            valid: true,
+            source: 'official' as const,
+        } satisfies InstalledRelease;
+        const selection = {
+            release: {
+                version: installedRelease.version,
+                version_number: installedRelease.version_number,
+                name: 'Godot 4.5',
+                published_at: null,
+                draft: false,
+                prerelease: false,
+                assets: [],
+            },
+            mono: false,
+        };
+        const previousRelease = { ...missingProject.release };
+        store.update.mockImplementation(async (mutator) =>
+            mutator([missingProject]),
+        );
+        mocks.getInstalledEditors.mockResolvedValue([installedRelease]);
+        mocks.getProjectDefinition.mockReturnValue({
+            editorConfigFilename: vi.fn(() => 'editor_settings-4.5.tres'),
+            editorConfigFormat: 3,
+        });
+        mocks.setProjectEditorRelease.mockResolvedValue(
+            '/projects/editor/Godot',
+        );
+
+        const result = await service.setProjectEditor(
+            missingProject,
+            selection,
+        );
+
+        expect(mocks.setProjectEditorRelease).toHaveBeenCalledWith(
+            '/install/.editor_config/Game',
+            installedRelease,
+            previousRelease,
+        );
+        expect(result.projects?.[0]).toMatchObject({
+            valid: true,
+            invalid_reason: undefined,
+            release: installedRelease,
+        });
+    });
+
+    it('marks a present project as missing only its selected editor', async () => {
+        const project = {
+            name: 'Game',
+            version: '4.4-stable',
+            version_number: 4.4,
+            path: '/projects/game',
+            editor_settings_path: '/projects/editor-data',
+            editor_settings_file:
+                '/projects/editor-data/editor_settings-4.4.tres',
+            release: {
+                version: '4.4-stable',
+                mono: false,
+                editor_path: '/editors/4.4/Godot',
+                valid: true,
+            },
+            launch_path: '/projects/editor/Godot',
+            config_version: 5,
+            codeEditorId: null,
+            valid: true,
+        } as ProjectDetails;
+        store.update.mockImplementation(async (mutator) => mutator([project]));
+        mocks.getProjectDefinition.mockReturnValue({
+            editorConfigFilename: vi.fn(),
+            editorConfigFormat: 3,
+        });
+
+        const result = await service.setProjectEditor(project, {
+            release: {
+                version: '4.5-stable',
+                version_number: 4.5,
+                name: 'Godot 4.5',
+                published_at: null,
+                draft: false,
+                prerelease: false,
+                assets: [],
+            },
+            mono: false,
+        });
+
+        expect(result.projects?.[0]).toMatchObject({
+            valid: false,
+            invalid_reason: 'missing_editor',
+            release: expect.objectContaining({ valid: false }),
+        });
+    });
+
+    it('does not mutate the selected project when missing-editor metadata fails to write', async () => {
+        const project = {
+            name: 'Game',
+            version: '4.4-stable',
+            version_number: 4.4,
+            path: '/projects/game',
+            editor_settings_path: '',
+            editor_settings_file: '',
+            release: {
+                version: '4.4-stable',
+                mono: false,
+                editor_path: '/editors/4.4/Godot',
+                valid: true,
+            },
+            launch_path: '/projects/editor/Godot',
+            config_version: 5,
+            codeEditorId: null,
+            valid: true,
+        } as ProjectDetails;
+        store.update.mockImplementation(async (mutator) => mutator([project]));
+        mocks.getProjectDefinition.mockReturnValue({
+            editorConfigFilename: vi.fn(),
+            editorConfigFormat: 3,
+        });
+        mocks.writeProjectLauncherConfig.mockRejectedValueOnce(
+            new Error('metadata write failed'),
+        );
+
+        await expect(
+            service.setProjectEditor(project, {
+                release: {
+                    version: '4.5-stable',
+                    version_number: 4.5,
+                    name: 'Godot 4.5',
+                    published_at: null,
+                    draft: false,
+                    prerelease: false,
+                    assets: [],
+                },
+                mono: false,
+            }),
+        ).rejects.toThrow('metadata write failed');
+
+        expect(project).toMatchObject({
+            version: '4.4-stable',
+            valid: true,
+            release: expect.objectContaining({
+                editor_path: '/editors/4.4/Godot',
+                valid: true,
+            }),
+        });
+    });
+
+    it('does not repair a custom selection that matches an official install identity', async () => {
+        const project = {
+            path: '/projects/game',
+            release: {
+                version: '4.5-stable',
+                mono: false,
+                source: 'custom',
+            },
+        } as ProjectDetails;
+        const replacement = {
+            version: '4.5-stable',
+            mono: false,
+        } as InstalledRelease;
+        store.update.mockImplementation(async (mutator) => mutator([project]));
+
+        const result = await service.setProjectEditor(project, replacement, {
+            version: '4.5-stable',
+            mono: false,
+        });
+
+        expect(result).toEqual({ success: true, projects: [project] });
+        expect(mocks.setProjectEditorRelease).not.toHaveBeenCalled();
+        expect(mocks.writeProjectLauncherConfig).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        {
+            name: 'the project selected a newer editor',
+            projects: [
+                {
+                    path: '/projects/game',
+                    release: { version: '4.6-stable', mono: false },
+                } as ProjectDetails,
+            ],
+        },
+        {
+            name: 'the project was removed',
+            projects: [] as ProjectDetails[],
+        },
+    ])('skips a bridge repair when $name', async ({ projects }) => {
+        const staleProject = {
+            path: '/projects/game',
+            release: { version: '4.5-stable', mono: false },
+        } as ProjectDetails;
+        const installedRelease = {
+            version: '4.5-stable',
+            mono: false,
+        } as InstalledRelease;
+        store.update.mockImplementation(async (mutator) => mutator(projects));
+
+        const result = await service.setProjectEditor(
+            staleProject,
+            installedRelease,
+            { version: '4.5-stable', mono: false },
+        );
+
+        expect(result).toEqual({ success: true, projects });
+        expect(mocks.setProjectEditorRelease).not.toHaveBeenCalled();
+        expect(mocks.writeProjectLauncherConfig).not.toHaveBeenCalled();
     });
 });

--- a/main/src/projects/projects.service.ts
+++ b/main/src/projects/projects.service.ts
@@ -1,5 +1,6 @@
 import type { ChildProcess, ChildProcessByStdio } from 'node:child_process';
 import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { Injectable } from '@mariodebono/di';
 import type {
@@ -17,6 +18,8 @@ import type {
     LaunchProjectOptions,
     LaunchProjectResult,
     ProjectDetails,
+    ProjectEditorSelection,
+    ProjectEditorSelectionExpectation,
     ProjectGitIdentityResult,
     ProjectGitIdentityValue,
     ProjectPublicationRecoveryAction,
@@ -46,6 +49,8 @@ import {
 } from '../commands/projectEditorSettings.js';
 import { getUserPreferences } from '../commands/userPreferences.js';
 import { EDITOR_CONFIG_DIRNAME } from '../constants.js';
+// biome-ignore lint/style/useImportType: Required for DI constructor metadata
+import { InstalledEditorService } from '../editor-installs/installed-editor.service.js';
 import { updateLinuxTray } from '../helpers/tray.helper.js';
 import { t } from '../i18n/index.js';
 import { getMainWindow } from '../mainWindow.js';
@@ -81,6 +86,65 @@ import { ProjectRepositoryOriginIndexService } from './project-repository-origin
 // biome-ignore lint/style/useImportType: Required for DI constructor metadata
 import { ProjectsStore } from './projects.store.js';
 
+/**
+ * Identifies a catalogue selection that main must resolve before assignment.
+ * @param selection - Installed editor or official catalogue selection.
+ */
+function isOfficialEditorSelection(
+    selection: ProjectEditorSelection,
+): selection is Extract<ProjectEditorSelection, { release: unknown }> {
+    return 'release' in selection;
+}
+
+/**
+ * Builds the persisted missing-editor representation for an official selection.
+ *
+ * @param selection - Official release selected before its installation.
+ * @param project - Current project whose configuration format is retained.
+ * @returns Invalid editor data that preserves the requested download identity.
+ */
+function createMissingOfficialRelease(
+    selection: ProjectEditorSelection,
+    project: ProjectDetails,
+): InstalledRelease {
+    if (!isOfficialEditorSelection(selection)) {
+        throw new Error('An installed editor cannot be persisted as missing');
+    }
+
+    const { release, mono } = selection;
+    const baseVersion =
+        release.version.match(/^v?(\d+\.\d+)/)?.[1] ??
+        release.version_number.toFixed(1);
+
+    return {
+        version: release.version,
+        name: release.name,
+        base_version: baseVersion,
+        flavor: mono ? 'dotnet' : 'gdscript',
+        version_number: release.version_number,
+        install_path: '',
+        editor_path: '',
+        platform: process.platform,
+        arch: process.arch,
+        mono,
+        prerelease: release.prerelease,
+        config_version: project.config_version,
+        published_at: release.published_at,
+        valid: false,
+        source: 'official',
+    };
+}
+
+/**
+ * Checks whether the project's Godot configuration file currently exists.
+ *
+ * @param projectPath - Root directory of the project.
+ * @returns Whether project.godot is present at the project root.
+ */
+function hasProjectFile(projectPath: string): boolean {
+    return existsSync(path.resolve(projectPath, 'project.godot'));
+}
+
 /** Provides the application-facing boundary for existing project workflows. */
 @Injectable()
 export class ProjectsService {
@@ -92,6 +156,7 @@ export class ProjectsService {
      * @param git - Guarded Git command service.
      * @param projectCreation - Transactional Create Project workflow.
      * @param trayAvailability - System tray availability service.
+     * @param installedEditors - Registered Godot editor facade.
      * @param store - Canonical project persistence store.
      * @param remoteSources - Remote project source discovery boundary.
      * @param remoteImport - Cancellable remote clone transaction boundary.
@@ -104,6 +169,7 @@ export class ProjectsService {
         private readonly git: GitService,
         private readonly projectCreation: ProjectCreationService,
         private readonly trayAvailability: TrayAvailabilityService,
+        private readonly installedEditors: InstalledEditorService,
         private readonly store: ProjectsStore,
         private readonly remoteSources: ProjectRemoteSourceService,
         private readonly remoteImport: ProjectRemoteImportService,
@@ -535,14 +601,24 @@ export class ProjectsService {
      * Changes the Godot editor assigned to a project.
      *
      * @param project - Project to update.
-     * @param release - Godot editor to assign.
+     * @param selection - Installed editor or official editor selection to assign.
+     * @param expectedEditor - Optional current selection required for repair.
      */
     async setProjectEditor(
         project: ProjectDetails,
-        release: InstalledRelease,
+        selection: ProjectEditorSelection,
+        expectedEditor?: ProjectEditorSelectionExpectation,
     ): Promise<ChangeProjectEditorResult> {
-        const { install_location: installLocation } =
-            await getUserPreferences();
+        const installedRelease = isOfficialEditorSelection(selection)
+            ? (await this.installedEditors.getInstalledEditors()).find(
+                  (candidate) =>
+                      candidate.source !== 'custom' &&
+                      candidate.valid !== false &&
+                      Boolean(candidate.editor_path) &&
+                      candidate.version === selection.release.version &&
+                      candidate.mono === selection.mono,
+              )
+            : selection;
         const recoveredFiles = new Set<string>();
         let failure: ChangeProjectEditorResult | undefined;
         let updatedProject: ProjectDetails | undefined;
@@ -552,6 +628,9 @@ export class ProjectsService {
                 (candidate) => candidate.path === project.path,
             );
             if (projectIndex === -1) {
+                if (expectedEditor) {
+                    return currentProjects;
+                }
                 failure = {
                     success: false,
                     error: t('projects:changeEditor.errors.projectNotFound'),
@@ -561,10 +640,23 @@ export class ProjectsService {
 
             const currentProject = currentProjects[projectIndex];
             if (
+                expectedEditor &&
+                (currentProject.release.version !== expectedEditor.version ||
+                    currentProject.release.mono !== expectedEditor.mono ||
+                    currentProject.release.source === 'custom')
+            ) {
+                return currentProjects;
+            }
+
+            const release =
+                installedRelease ??
+                createMissingOfficialRelease(selection, currentProject);
+            if (
                 currentProject.release.version === release.version &&
                 currentProject.release.mono === release.mono &&
                 currentProject.release.editor_path === release.editor_path &&
-                currentProject.release.valid !== false
+                currentProject.release.valid === release.valid &&
+                installedRelease !== undefined
             ) {
                 logger.warn(
                     `Project already using the selected release, ${release.version} - ${release.mono ? 'mono' : ''}`,
@@ -598,6 +690,33 @@ export class ProjectsService {
                 return currentProjects;
             }
 
+            if (!installedRelease) {
+                updatedProject = {
+                    ...currentProject,
+                    release,
+                    version: release.version,
+                    version_number: release.version_number,
+                    launch_path: '',
+                    valid: false,
+                    invalid_reason:
+                        !hasProjectFile(currentProject.path) ||
+                        currentProject.invalid_reason === 'missing_project_file'
+                            ? 'missing_project_file'
+                            : 'missing_editor',
+                };
+                await writeProjectLauncherConfig(updatedProject.path, {
+                    release: updatedProject.release,
+                    projectName: updatedProject.name,
+                    launcherVersion: app.getVersion(),
+                });
+
+                const updatedProjects = [...currentProjects];
+                updatedProjects[projectIndex] = updatedProject;
+                return updatedProjects;
+            }
+
+            const { install_location: installLocation } =
+                await getUserPreferences();
             const projectEditorPath = resolveProjectEditorPath(
                 currentProject,
                 installLocation,
@@ -645,6 +764,7 @@ export class ProjectsService {
                 );
             }
 
+            const projectFileExists = hasProjectFile(currentProject.path);
             updatedProject = {
                 ...currentProject,
                 release: { ...release, valid: true },
@@ -655,7 +775,10 @@ export class ProjectsService {
                     path.dirname(newEditorSettingsFile),
                 ),
                 editor_settings_file: newEditorSettingsFile,
-                valid: true,
+                valid: projectFileExists,
+                invalid_reason: projectFileExists
+                    ? undefined
+                    : 'missing_project_file',
             };
             await writeProjectLauncherConfig(updatedProject.path, {
                 release: updatedProject.release,
@@ -672,18 +795,15 @@ export class ProjectsService {
             return failure;
         }
 
-        const latestProject =
-            projects.find((candidate) => candidate.path === project.path) ??
-            updatedProject;
-        if (latestProject) {
-            project.release = latestProject.release;
-            project.version = latestProject.version;
-            project.version_number = latestProject.version_number;
-            project.launch_path = latestProject.launch_path;
-            project.editor_settings_file = latestProject.editor_settings_file;
-            project.editor_settings_path = latestProject.editor_settings_path;
-            project.valid = latestProject.valid;
-            project.codeEditorId = latestProject.codeEditorId;
+        if (updatedProject) {
+            project.release = updatedProject.release;
+            project.version = updatedProject.version;
+            project.version_number = updatedProject.version_number;
+            project.launch_path = updatedProject.launch_path;
+            project.editor_settings_file = updatedProject.editor_settings_file;
+            project.editor_settings_path = updatedProject.editor_settings_path;
+            project.valid = updatedProject.valid;
+            project.codeEditorId = updatedProject.codeEditorId;
         }
 
         return {

--- a/main/src/projects/projects.workflows.test.ts
+++ b/main/src/projects/projects.workflows.test.ts
@@ -281,6 +281,7 @@ function createProjectsService(
         git,
         {} as ProjectCreationService,
         tray,
+        {} as never,
         projectsStore,
         {
             inspectPublicGitSource: vi.fn(),

--- a/renderer/src/hooks/projects.hook.test.tsx
+++ b/renderer/src/hooks/projects.hook.test.tsx
@@ -4,6 +4,7 @@ import type {
     CreateProjectPublicationOptions,
     InstalledRelease,
     ProjectDetails,
+    ReleaseSummary,
 } from '@shared/contracts';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -12,6 +13,9 @@ import { ProjectsProvider, useProjects } from './projects.hook.tsx';
 
 const mocks = vi.hoisted(() => ({
     createProject: vi.fn(),
+    installRelease: vi.fn(),
+    setProjectEditor: vi.fn(),
+    addAlert: vi.fn(),
 }));
 
 vi.mock('react-i18next', () => ({
@@ -27,19 +31,20 @@ vi.mock('../renderer.bridge.ts', () => ({
     codeEditorIntegrationBridge: {},
     projectsBridge: {
         createProject: mocks.createProject,
+        setProjectEditor: mocks.setProjectEditor,
     },
     subscribeAppEvent: vi.fn(() => () => {}),
 }));
 
 vi.mock('./alerts.hook', () => ({
     useAlerts: () => ({
-        addAlert: vi.fn(),
+        addAlert: mocks.addAlert,
         addCustomConfirm: vi.fn(),
     }),
 }));
 
 vi.mock('./release.hook', () => ({
-    useRelease: () => ({ installRelease: vi.fn() }),
+    useRelease: () => ({ installRelease: mocks.installRelease }),
 }));
 
 describe('useProjects', () => {
@@ -107,6 +112,73 @@ describe('useProjects', () => {
         hook.startSettingsSave('/project', draft, retry);
         expect(retry).toHaveBeenCalledOnce();
     });
+
+    it('waits for installation and repairs only the requested editor selection', async () => {
+        const hook = renderHook();
+        const project = { path: '/project' } as ProjectDetails;
+        const release = { version: '4.6' } as ReleaseSummary;
+        const installed = { version: '4.6', mono: true } as InstalledRelease;
+        let finish!: (result: {
+            success: boolean;
+            release: InstalledRelease;
+        }) => void;
+        mocks.installRelease.mockReturnValue(
+            new Promise((resolve) => {
+                finish = resolve;
+            }),
+        );
+        mocks.setProjectEditor.mockResolvedValue({
+            success: true,
+            projects: [],
+        });
+        const repair = hook.queueProjectEditorRepairs([
+            { release, mono: true, projects: [project] },
+        ]);
+        expect(mocks.setProjectEditor).not.toHaveBeenCalled();
+        finish({ success: true, release: installed });
+        await repair;
+        expect(mocks.setProjectEditor).toHaveBeenCalledWith(
+            project,
+            installed,
+            { version: '4.6', mono: true },
+        );
+        expect(mocks.addAlert).not.toHaveBeenCalled();
+    });
+
+    it.each(['Download failed', 'Cancelled'])(
+        'retains the selection after %s and allows retry',
+        async (error) => {
+            const hook = renderHook();
+            const project = { path: '/project' } as ProjectDetails;
+            const release = { version: '4.6' } as ReleaseSummary;
+            const request = { release, mono: false, projects: [project] };
+            mocks.installRelease.mockResolvedValueOnce({
+                success: false,
+                error,
+            });
+            await hook.queueProjectEditorRepairs([request]);
+            expect(mocks.setProjectEditor).not.toHaveBeenCalled();
+            expect(mocks.addAlert).toHaveBeenCalled();
+            const installed = {
+                version: '4.6',
+                mono: false,
+            } as InstalledRelease;
+            mocks.installRelease.mockResolvedValueOnce({
+                success: true,
+                release: installed,
+            });
+            mocks.setProjectEditor.mockResolvedValue({
+                success: true,
+                projects: [project],
+            });
+            await hook.queueProjectEditorRepairs([request]);
+            expect(mocks.setProjectEditor).toHaveBeenCalledWith(
+                project,
+                installed,
+                { version: '4.6', mono: false },
+            );
+        },
+    );
 
     it('forwards parent repository consent to the Create Project bridge', async () => {
         const hook = renderHook();

--- a/renderer/src/hooks/projects.hook.tsx
+++ b/renderer/src/hooks/projects.hook.tsx
@@ -16,6 +16,8 @@ import type {
     LaunchProjectResult,
     ListCreateProjectPublicationTargetsResult,
     ProjectDetails,
+    ProjectEditorSelection,
+    ProjectEditorSelectionExpectation,
     ProjectGitIdentityResult,
     ProjectPublicationRecoveryAction,
     ReleaseSummary,
@@ -77,7 +79,8 @@ interface ProjectsContext {
     ) => Promise<AddProjectToListResult>;
     setProjectEditor: (
         project: ProjectDetails,
-        release: InstalledRelease,
+        release: ProjectEditorSelection,
+        expectedEditor?: ProjectEditorSelectionExpectation,
     ) => Promise<ChangeProjectEditorResult>;
     queueProjectEditorRepairs: (
         requests: ProjectEditorRepairRequest[],
@@ -412,11 +415,22 @@ export const ProjectsProvider: FC<ProjectsProviderProps> = ({ children }) => {
         return addResult;
     };
 
+    /**
+     * Saves an editor selection, optionally only while its repair target is current.
+     * @param project - Project to update.
+     * @param release - Installed editor or official catalogue selection.
+     * @param expectedEditor - Selection that must still be current for repair.
+     */
     const setProjectEditor = async (
         project: ProjectDetails,
-        release: InstalledRelease,
+        release: ProjectEditorSelection,
+        expectedEditor?: ProjectEditorSelectionExpectation,
     ) => {
-        const result = await projectsBridge.setProjectEditor(project, release);
+        const result = await projectsBridge.setProjectEditor(
+            project,
+            release,
+            expectedEditor,
+        );
         if (result.success && result.projects) {
             setProjects(result.projects);
         }
@@ -425,7 +439,7 @@ export const ProjectsProvider: FC<ProjectsProviderProps> = ({ children }) => {
     };
 
     /**
-     * Installs one queued editor and assigns it to every associated project.
+     * Installs one queued editor and repairs projects still using that selection.
      *
      * @param request - Editor release and projects to repair in the background.
      * @returns A promise that ends after installation and project repair.
@@ -453,6 +467,7 @@ export const ProjectsProvider: FC<ProjectsProviderProps> = ({ children }) => {
                 const result = await setProjectEditor(
                     project,
                     installResult.release,
+                    { version: request.release.version, mono: request.mono },
                 );
                 if (!result.success) {
                     assignmentError ??=

--- a/renderer/src/views/projects.view.tsx
+++ b/renderer/src/views/projects.view.tsx
@@ -1,7 +1,7 @@
 import type {
     CodeEditorId,
-    InstalledRelease,
     ProjectDetails,
+    ProjectEditorSelection,
     ReleaseSummary,
 } from '@shared/contracts';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -331,9 +331,14 @@ export const ProjectsView: React.FC<ProjectsViewProps> = ({
         }
     };
 
+    /**
+     * Saves the selected editor and returns its canonical project state.
+     * @param project - Project being edited.
+     * @param release - Installed editor or official catalogue selection.
+     */
     const onSetProjectEditorFromSettings = async (
         project: ProjectDetails,
-        release: InstalledRelease,
+        release: ProjectEditorSelection,
     ): Promise<ProjectDetails> => {
         setBusyProjects([...busyProjects, project.path]);
 
@@ -343,16 +348,13 @@ export const ProjectsView: React.FC<ProjectsViewProps> = ({
                 throw new Error(result.error || t('messages.setEditorError'));
             }
 
-            return (
-                result.projects?.find(
-                    (updatedProject) => updatedProject.path === project.path,
-                ) ?? {
-                    ...project,
-                    release,
-                    version: release.version,
-                    version_number: release.version_number,
-                }
+            const updatedProject = result.projects?.find(
+                (candidate) => candidate.path === project.path,
             );
+            if (!updatedProject) {
+                throw new Error(t('messages.setEditorError'));
+            }
+            return updatedProject;
         } finally {
             setBusyProjects((prevValues) =>
                 prevValues.filter((p) => p !== project.path),

--- a/renderer/src/views/projects/hooks/add-project-workflow.hook.tsx
+++ b/renderer/src/views/projects/hooks/add-project-workflow.hook.tsx
@@ -6,6 +6,7 @@ import type {
     InstalledRelease,
     InstallReleaseResult,
     ProjectDetails,
+    ProjectEditorSelectionExpectation,
     ReleaseSummary,
 } from '@shared/contracts';
 import logger from 'electron-log';
@@ -66,6 +67,7 @@ type AddProjectWorkflowArgs = {
     setProjectEditor: (
         project: ProjectDetails,
         release: InstalledRelease,
+        expectedEditor?: ProjectEditorSelectionExpectation,
     ) => Promise<ChangeProjectEditorResult>;
     showRecoveredCodeEditorConfigWarning: (recoveredFiles?: string[]) => void;
 };
@@ -190,6 +192,7 @@ export function useAddProjectWorkflow({
                 const changeResult = await setProjectEditor(
                     addedProject,
                     installResult.release,
+                    { version: release.version, mono },
                 );
 
                 if (!changeResult.success) {

--- a/renderer/src/views/sub-views/project-settings-drawer.subview.tsx
+++ b/renderer/src/views/sub-views/project-settings-drawer.subview.tsx
@@ -1,105 +1,59 @@
-import type {
-    CodeEditorId,
-    CodeEditorIntegrationSettings,
-    GitIdentity,
-    InitializeProjectGitResult,
-    InstalledRelease,
-    ProjectDetails,
-    ProjectEditorSelection,
-    ProjectGitIdentityResult,
-    RenameProjectOptions,
-    RenameProjectResult,
-} from '@shared/contracts';
+import type { ProjectEditorSelection } from '@shared/contracts';
 import clsx from 'clsx';
-import { CircleCheck, GitBranch, PanelTop, Pin } from 'lucide-react';
+import { Pin } from 'lucide-react';
 import type React from 'react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ContentDivider } from '../../components/ui/content-divider.component';
 import { CopyBadge } from '../../components/ui/copy-badge.component';
-import { CopyButton } from '../../components/ui/copy-button.component';
 import { Drawer } from '../../components/ui/drawer/drawer.component';
-import { TextField } from '../../components/ui/text-field.component';
 import { useAlerts } from '../../hooks/alerts.hook';
-import { useCodeEditorIntegrations } from '../../hooks/code-editor-integrations.hook';
 import { useProjects } from '../../hooks/projects.hook';
-import { useRelease } from '../../hooks/release.hook';
-import { useToolIntegrations } from '../../hooks/tool-integrations.hook';
-import { sortReleases } from '../../release-sorting.util';
-import { CreateProjectEditorPicker } from './create-project/components/create-project-editor-picker.component';
-import {
-    type CreateProjectEditorSelection,
-    getCreateProjectReleaseKey,
-} from './create-project/create-project.model';
+import { getCreateProjectReleaseKey } from './create-project/create-project.model';
 import { ProjectCodeEditorSection } from './project-settings-drawer/components/project-code-editor-section.component';
+import { ProjectSettingsLaunchSection } from './project-settings-drawer/components/project-settings-launch-section.component';
+import { ProjectSettingsProjectSection } from './project-settings-drawer/components/project-settings-project-section.component';
+import { ProjectSettingsSourceControlSection } from './project-settings-drawer/components/project-settings-source-control-section.component';
+import { useProjectSettingsForm } from './project-settings-drawer/hooks/project-settings-form.hook';
+import { useProjectSettingsSourceControl } from './project-settings-drawer/hooks/project-settings-source-control.hook';
 import {
-    canRenameGodotProject,
     hasProjectCodeEditorChanges,
     hasProjectRenameChanges,
-    validateProjectRenameName,
 } from './project-settings-drawer/project-settings.model';
+import type {
+    ProjectSettingsDrawerProps,
+    ProjectSettingsTab,
+} from './project-settings-drawer/project-settings.types';
 
-type ProjectSettingsTab = 'project' | 'sourceControl' | 'codeEditor' | 'launch';
-
-const projectSettingsTabs: ProjectSettingsTab[] = [
+const tabs: ProjectSettingsTab[] = [
     'project',
     'sourceControl',
     'codeEditor',
     'launch',
 ];
 
-type ProjectSettingsDrawerProps = {
-    project: ProjectDetails | null;
-    open: boolean;
-    installedReleases: InstalledRelease[];
-    onOpenChange: (open: boolean) => void;
-    onRenameProject: (
-        project: ProjectDetails,
-        options: RenameProjectOptions,
-    ) => Promise<RenameProjectResult>;
-    onSetProjectEditor: (
-        project: ProjectDetails,
-        release: ProjectEditorSelection,
-    ) => Promise<ProjectDetails>;
-    onSetProjectCodeEditor: (
-        project: ProjectDetails,
-        codeEditorId: CodeEditorId | null,
-    ) => Promise<ProjectDetails>;
-    onSetProjectWindowed: (
-        project: ProjectDetails,
-        windowed: boolean,
-    ) => Promise<ProjectDetails>;
-    onInitializeProjectGit: (
-        project: ProjectDetails,
-    ) => Promise<InitializeProjectGitResult>;
-    getProjectGitIdentity: (
-        project: ProjectDetails,
-    ) => Promise<ProjectGitIdentityResult>;
-    onSetProjectGitIdentity: (
-        project: ProjectDetails,
-        identity: GitIdentity,
-    ) => Promise<ProjectGitIdentityResult>;
-    onResetProjectCodeEditorConfig: (
-        project: ProjectDetails,
-    ) => Promise<ProjectDetails>;
-    getProjectGodotName: (project: ProjectDetails) => Promise<string | null>;
-};
-
-export const ProjectSettingsDrawer: React.FC<ProjectSettingsDrawerProps> = ({
-    project,
-    open,
-    installedReleases,
-    onOpenChange,
-    onRenameProject,
-    onSetProjectEditor,
-    onSetProjectCodeEditor,
-    onSetProjectWindowed,
-    onInitializeProjectGit,
-    getProjectGitIdentity,
-    onSetProjectGitIdentity,
-    onResetProjectCodeEditorConfig,
-    getProjectGodotName,
-}) => {
+/**
+ * Renders the Project Settings drawer and coordinates its ordered save operation.
+ *
+ * @param props - The active project and its update operations.
+ * @returns The drawer element.
+ */
+export const ProjectSettingsDrawer: React.FC<ProjectSettingsDrawerProps> = (
+    props,
+) => {
+    const {
+        project,
+        open,
+        installedReleases,
+        onOpenChange,
+        onRenameProject,
+        onSetProjectEditor,
+        onSetProjectCodeEditor,
+        onSetProjectWindowed,
+        onInitializeProjectGit,
+        getProjectGitIdentity,
+        onSetProjectGitIdentity,
+        getProjectGodotName,
+    } = props;
     const { t } = useTranslation([
         'projects',
         'common',
@@ -107,674 +61,62 @@ export const ProjectSettingsDrawer: React.FC<ProjectSettingsDrawerProps> = ({
         'createProject',
     ]);
     const { addAlert, addCustomConfirm } = useAlerts();
-    const { listIntegrationSettings } = useCodeEditorIntegrations();
-    const { listIntegrations } = useToolIntegrations();
-    const {
-        availableReleases,
-        availablePrereleases,
-        releaseInstallProgress,
-        loading: releasesLoading,
-        hasError: catalogueError,
-        refreshAvailableReleases,
-        cancelInstall,
-    } = useRelease();
-    const [activeTab, setActiveTab] = useState<ProjectSettingsTab>('project');
-    const [initialName, setInitialName] = useState('');
-    const [name, setName] = useState('');
-    const [initialReleaseKey, setInitialReleaseKey] = useState('');
-    const [releaseSelection, setReleaseSelection] =
-        useState<CreateProjectEditorSelection | null>(null);
-    const [initialWindowed, setInitialWindowed] = useState(false);
-    const [windowed, setWindowed] = useState(false);
-    const [withGit, setWithGit] = useState(false);
-    const [gitAvailable, setGitAvailable] = useState(false);
-    const [loadingGitAvailability, setLoadingGitAvailability] = useState(false);
-    const [isInitializingGit, setIsInitializingGit] = useState(false);
-    const [gitIdentity, setGitIdentity] =
-        useState<ProjectGitIdentityResult | null>(null);
-    const [loadingGitIdentity, setLoadingGitIdentity] = useState(false);
-    const [editingGitIdentity, setEditingGitIdentity] = useState(false);
-    const [gitIdentityName, setGitIdentityName] = useState('');
-    const [gitIdentityEmail, setGitIdentityEmail] = useState('');
-    const [savingGitIdentity, setSavingGitIdentity] = useState(false);
-    const [gitIdentityError, setGitIdentityError] = useState<string>();
-    const [godotProjectName, setGodotProjectName] = useState<string | null>(
-        null,
-    );
-    const [loadingGodotName, setLoadingGodotName] = useState(false);
-    const [renameGodotProject, setRenameGodotProject] = useState(false);
-    const [nameError, setNameError] = useState<string>();
-    const [godotError, setGodotError] = useState<string>();
-    const [formError, setFormError] = useState<string>();
-    const [isSavingLocally, setIsSubmitting] = useState(false);
     const { settingsSaves, queueProjectEditorRepairs, clearSettingsSave } =
         useProjects();
-    const settingsSave = project ? settingsSaves?.get(project.path) : undefined;
-    const savingInBackground = settingsSave?.status === 'pending';
-    const isSubmitting = isSavingLocally || savingInBackground;
-    const [initialCodeEditorId, setInitialCodeEditorId] =
-        useState<CodeEditorId | null>(null);
-    const [codeEditorId, setCodeEditorId] = useState<CodeEditorId | null>(null);
-    const [codeEditorTouched, setCodeEditorTouched] = useState(false);
-    const [codeEditorSettings, setCodeEditorSettings] = useState<
-        CodeEditorIntegrationSettings[]
-    >([]);
-    const [loadingCodeEditors, setLoadingCodeEditors] = useState(false);
-    const [codeEditorLoadFailed, setCodeEditorLoadFailed] = useState(false);
+    const [activeTab, setActiveTab] = useState<ProjectSettingsTab>('project');
     const activeProjectPathRef = useRef<string | null>(null);
-    const codeEditorProjectPathRef = useRef<string | null>(null);
-    const sessionRef = useRef(0);
-    const submissionRef = useRef(false);
-
-    useEffect(() => {
-        return () => {
-            sessionRef.current += 1;
-        };
-    }, []);
+    const [savingLocally, setSavingLocally] = useState(false);
+    const submitting = useRef(false);
+    const save = project ? settingsSaves?.get(project.path) : undefined;
+    const savingInBackground = save?.status === 'pending';
+    const form = useProjectSettingsForm({
+        project,
+        open,
+        installedReleases,
+        getProjectGodotName,
+        settingsSave: save,
+        clearSettingsSave,
+        t,
+    });
+    const sourceControl = useProjectSettingsSourceControl({
+        open,
+        project,
+        activeTab,
+        onFormError: form.setSaveError,
+        onInitializeProjectGit,
+        getProjectGitIdentity,
+        onSetProjectGitIdentity,
+    });
+    const isSubmitting = savingLocally || savingInBackground;
 
     useEffect(() => {
         if (!open || !project) {
             activeProjectPathRef.current = null;
-            codeEditorProjectPathRef.current = null;
-            sessionRef.current += 1;
             return;
         }
-
-        const projectChanged = activeProjectPathRef.current !== project.path;
-        activeProjectPathRef.current = project.path;
-        if (!projectChanged) {
-            return;
+        if (activeProjectPathRef.current !== project.path) {
+            activeProjectPathRef.current = project.path;
+            setActiveTab('project');
+            setSavingLocally(false);
+            submitting.current = false;
         }
-
-        sessionRef.current += 1;
-        let disposed = false;
-        const currentReleaseKey = getCreateProjectReleaseKey(project.release);
-
-        setActiveTab('project');
-        setInitialName(project.name);
-        setName(project.name);
-        setInitialReleaseKey(currentReleaseKey);
-        setReleaseSelection({
-            source: 'installed',
-            key: currentReleaseKey,
-            release: project.release,
-        });
-        setInitialWindowed(Boolean(project.open_windowed));
-        setWindowed(Boolean(project.open_windowed));
-        setWithGit(project.withGit);
-        setIsInitializingGit(false);
-        setGitIdentity(null);
-        setEditingGitIdentity(false);
-        setGitIdentityError(undefined);
-        setGodotProjectName(null);
-        setRenameGodotProject(false);
-        setNameError(undefined);
-        setGodotError(undefined);
-        setFormError(undefined);
-        setIsSubmitting(false);
-        submissionRef.current = false;
-        setLoadingGodotName(true);
-
-        getProjectGodotName(project)
-            .then((currentGodotProjectName) => {
-                if (!disposed) {
-                    setGodotProjectName(currentGodotProjectName);
-                }
-            })
-            .catch(() => {
-                if (!disposed) {
-                    setGodotProjectName(null);
-                }
-            })
-            .finally(() => {
-                if (!disposed) {
-                    setLoadingGodotName(false);
-                }
-            });
-
-        return () => {
-            disposed = true;
-        };
-    }, [getProjectGodotName, open, project]);
-
-    useEffect(() => {
-        if (!open) {
-            return;
-        }
-
-        let disposed = false;
-        setGitAvailable(false);
-        setLoadingGitAvailability(true);
-
-        listIntegrations()
-            .then((tools) => {
-                if (!disposed) {
-                    setGitAvailable(
-                        tools.some(
-                            (tool) =>
-                                tool.id === 'git' &&
-                                tool.status === 'available',
-                        ),
-                    );
-                }
-            })
-            .catch(() => {
-                if (!disposed) {
-                    setGitAvailable(false);
-                }
-            })
-            .finally(() => {
-                if (!disposed) {
-                    setLoadingGitAvailability(false);
-                }
-            });
-
-        return () => {
-            disposed = true;
-        };
-    }, [listIntegrations, open]);
-
-    useEffect(() => {
-        if (!open || !project || activeTab !== 'sourceControl' || !withGit) {
-            return;
-        }
-
-        let disposed = false;
-        setLoadingGitIdentity(true);
-        setGitIdentityError(undefined);
-        getProjectGitIdentity(project)
-            .then((identity) => {
-                if (!disposed) {
-                    setGitIdentity(identity);
-                }
-            })
-            .catch((error) => {
-                if (!disposed) {
-                    setGitIdentityError(
-                        error instanceof Error
-                            ? error.message
-                            : t('editProject.sourceControl.identityLoadFailed'),
-                    );
-                }
-            })
-            .finally(() => {
-                if (!disposed) {
-                    setLoadingGitIdentity(false);
-                }
-            });
-
-        return () => {
-            disposed = true;
-        };
-    }, [activeTab, getProjectGitIdentity, open, project, t, withGit]);
-
-    useEffect(() => {
-        if (!open || !project) {
-            codeEditorProjectPathRef.current = null;
-            return;
-        }
-
-        if (codeEditorProjectPathRef.current === project.path) {
-            return;
-        }
-
-        codeEditorProjectPathRef.current = project.path;
-
-        let disposed = false;
-        const currentCodeEditorId = project.codeEditorId ?? null;
-
-        setInitialCodeEditorId(currentCodeEditorId);
-        setCodeEditorId(currentCodeEditorId);
-        setCodeEditorTouched(false);
-        setCodeEditorSettings([]);
-        setCodeEditorLoadFailed(false);
-        setLoadingCodeEditors(true);
-
-        listIntegrationSettings()
-            .then((settings) => {
-                if (!disposed) {
-                    setCodeEditorSettings(settings);
-                }
-            })
-            .catch(() => {
-                if (!disposed) {
-                    setCodeEditorLoadFailed(true);
-                }
-            })
-            .finally(() => {
-                if (!disposed) {
-                    setLoadingCodeEditors(false);
-                }
-            });
-
-        return () => {
-            disposed = true;
-        };
-    }, [listIntegrationSettings, open, project]);
-
-    const restoredSaveRef = useRef<typeof settingsSave>(undefined);
-    useEffect(() => {
-        if (!open || !project) {
-            restoredSaveRef.current = undefined;
-            return;
-        }
-        if (
-            !settingsSave ||
-            restoredSaveRef.current === settingsSave ||
-            loadingCodeEditors ||
-            loadingGodotName
-        )
-            return;
-        restoredSaveRef.current = settingsSave;
-        if (settingsSave.status === 'complete' && settingsSave.project) {
-            const saved = settingsSave.project;
-            setName(saved.name);
-            setInitialName(saved.name);
-            setReleaseSelection({
-                source: 'installed',
-                key: getCreateProjectReleaseKey(saved.release),
-                release: saved.release,
-            });
-            setInitialReleaseKey(getCreateProjectReleaseKey(saved.release));
-            setWindowed(Boolean(saved.open_windowed));
-            setInitialWindowed(Boolean(saved.open_windowed));
-            setCodeEditorId(saved.codeEditorId ?? null);
-            setInitialCodeEditorId(saved.codeEditorId ?? null);
-            setCodeEditorTouched(false);
-            setRenameGodotProject(false);
-            if (settingsSave.draft.renameGodotProject)
-                setGodotProjectName(saved.name);
-            setFormError(undefined);
-            clearSettingsSave(project.path);
-        } else {
-            const draft = settingsSave.draft;
-            setName(draft.name);
-            setReleaseSelection(draft.releaseSelection);
-            setWindowed(draft.windowed);
-            setCodeEditorId(draft.codeEditorId);
-            setCodeEditorTouched(draft.codeEditorTouched);
-            setRenameGodotProject(draft.renameGodotProject);
-            setFormError(settingsSave.error);
-        }
-    }, [
-        open,
-        project,
-        settingsSave,
-        loadingCodeEditors,
-        loadingGodotName,
-        clearSettingsSave,
-    ]);
-
-    const selectableReleases = useMemo(() => {
-        if (!project) {
-            return [];
-        }
-
-        const currentMajor = Math.trunc(project.release.version_number);
-        return installedReleases
-            .filter(
-                (release) =>
-                    release.valid !== false &&
-                    Boolean(release.editor_path) &&
-                    Math.trunc(release.version_number) >= currentMajor,
-            )
-            .sort(sortReleases);
-    }, [installedReleases, project]);
-
-    const compatibleCatalogueReleases = useMemo(() => {
-        if (!project) {
-            return [];
-        }
-
-        const currentMajor = Math.trunc(project.release.version_number);
-        return availableReleases.filter(
-            (release) => Math.trunc(release.version_number) >= currentMajor,
-        );
-    }, [availableReleases, project]);
-
-    const compatibleCataloguePrereleases = useMemo(() => {
-        if (!project) {
-            return [];
-        }
-
-        const currentMajor = Math.trunc(project.release.version_number);
-        return availablePrereleases.filter(
-            (release) => Math.trunc(release.version_number) >= currentMajor,
-        );
-    }, [availablePrereleases, project]);
-
-    const getValidationMessage = (
-        validationError: ReturnType<typeof validateProjectRenameName>,
-    ): string | undefined => {
-        if (!validationError) {
-            return undefined;
-        }
-
-        return t(`editProject.validation.${validationError}`);
-    };
-
-    const validateNameField = (): boolean => {
-        const validationMessage = getValidationMessage(
-            validateProjectRenameName(name),
-        );
-        setNameError(validationMessage);
-        return !validationMessage;
-    };
-
-    const handleNameChange = (value: string) => {
-        setName(value);
-        setNameError(undefined);
-        setFormError(undefined);
-        setGodotError(undefined);
-
-        if (!canRenameGodotProject(value, godotProjectName)) {
-            setRenameGodotProject(false);
-        }
-    };
-
-    const handleCodeEditorChange = (nextCodeEditorId: CodeEditorId | null) => {
-        setCodeEditorId(nextCodeEditorId);
-        setCodeEditorTouched(true);
-        setFormError(undefined);
-    };
-
-    const handleInitializeGit = async () => {
-        if (!project || withGit) {
-            return;
-        }
-
-        setIsInitializingGit(true);
-        setFormError(undefined);
-        try {
-            const result = await onInitializeProjectGit(project);
-            setWithGit(result.project.withGit);
-            if (result.gitSetup.status === 'existing-repository') {
-                addAlert(
-                    t('editProject.sourceControl.existingRepositoryTitle'),
-                    result.gitSetup.isProjectRoot
-                        ? t('editProject.sourceControl.existingRepositoryRoot')
-                        : t(
-                              'editProject.sourceControl.existingRepositoryParent',
-                              { root: result.gitSetup.root },
-                          ),
-                );
-            }
-        } catch (error) {
-            setFormError(
-                error instanceof Error
-                    ? error.message
-                    : t('editProject.sourceControl.initFailed'),
-            );
-        } finally {
-            setIsInitializingGit(false);
-        }
-    };
-
-    const handleEditGitIdentity = () => {
-        if (gitIdentity?.status !== 'available' || !gitIdentity.canUpdate) {
-            return;
-        }
-        setGitIdentityName(gitIdentity.name.value);
-        setGitIdentityEmail(gitIdentity.email.value);
-        setGitIdentityError(undefined);
-        setEditingGitIdentity(true);
-    };
-
-    const handleSaveGitIdentity = async () => {
-        if (!project || !gitIdentityName.trim() || !gitIdentityEmail.trim()) {
-            setGitIdentityError(
-                t('editProject.sourceControl.identityRequired'),
-            );
-            return;
-        }
-
-        setSavingGitIdentity(true);
-        setGitIdentityError(undefined);
-        try {
-            const identity = await onSetProjectGitIdentity(project, {
-                name: gitIdentityName,
-                email: gitIdentityEmail,
-            });
-            setGitIdentity(identity);
-            setEditingGitIdentity(false);
-        } catch (error) {
-            setGitIdentityError(
-                error instanceof Error
-                    ? error.message
-                    : t('editProject.sourceControl.updateFailed'),
-            );
-        } finally {
-            setSavingGitIdentity(false);
-        }
-    };
+    }, [open, project]);
 
     /**
-     * Saves settings and the selected editor before queuing any required download.
+     * Confirms resetting the selected code editor configuration for this project.
      *
-     * @param event - The settings form submission event.
-     * @returns A promise that ends after the staged settings are saved or fail.
+     * @returns Nothing when no resettable editor is selected.
      */
-    const handleSubmit = async (event: React.FormEvent) => {
-        event.preventDefault();
-
-        if (submissionRef.current || savingInBackground) {
-            return;
-        }
-
-        if (!project || !releaseSelection || !validateNameField()) {
-            setActiveTab('project');
-            return;
-        }
-
-        submissionRef.current = true;
-        const submissionSession = sessionRef.current;
-        setIsSubmitting(true);
-        setFormError(undefined);
-        setGodotError(undefined);
-
-        try {
-            let currentProject = project;
-            const renameChanged = hasProjectRenameChanges(
-                initialName,
-                godotProjectName,
-                name,
-                renameGodotProject,
-            );
-            const codeEditorChanged = hasProjectCodeEditorChanges(
-                initialCodeEditorId,
-                codeEditorId,
-                codeEditorTouched,
-            );
-            const selectedReleaseKey = getCreateProjectReleaseKey({
-                version: releaseSelection.release.version,
-                mono:
-                    releaseSelection.source === 'installed'
-                        ? releaseSelection.release.mono
-                        : releaseSelection.mono,
-            });
-            const releaseChanged =
-                initialReleaseKey !== selectedReleaseKey ||
-                (releaseSelection.source === 'catalogue' &&
-                    (project.release.valid === false ||
-                        !project.release.editor_path));
-            const windowedChanged = initialWindowed !== windowed;
-            let selectedRelease: ProjectEditorSelection | undefined;
-
-            if (releaseChanged) {
-                if (
-                    releaseSelection.source === 'installed' &&
-                    (releaseSelection.release.valid === false ||
-                        !releaseSelection.release.editor_path)
-                ) {
-                    setFormError(t('editProject.godotEditor.unavailable'));
-                    return;
-                }
-
-                selectedRelease =
-                    releaseSelection.source === 'installed'
-                        ? releaseSelection.release
-                        : {
-                              release: releaseSelection.release,
-                              mono: releaseSelection.mono,
-                          };
-            }
-
-            if (renameChanged) {
-                const result = await onRenameProject(project, {
-                    name: name.trim(),
-                    renameGodotProject,
-                });
-
-                if (!result.success) {
-                    const message =
-                        result.error ?? t('editProject.updateFailed');
-                    setFormError(message);
-                    setActiveTab('project');
-
-                    if (result.errorField === 'name') {
-                        setNameError(message);
-                    } else if (result.errorField === 'godot') {
-                        setGodotError(message);
-                    }
-
-                    return;
-                }
-
-                const updatedName = result.project?.name ?? name.trim();
-                currentProject = result.project ?? {
-                    ...currentProject,
-                    name: updatedName,
-                };
-                setInitialName(updatedName);
-                setName(updatedName);
-                if (renameGodotProject) {
-                    setGodotProjectName(updatedName);
-                }
-                setRenameGodotProject(false);
-            }
-
-            if (codeEditorChanged) {
-                currentProject = await onSetProjectCodeEditor(
-                    currentProject,
-                    codeEditorId,
-                );
-                setInitialCodeEditorId(codeEditorId);
-                setCodeEditorTouched(false);
-            }
-
-            if (releaseChanged) {
-                if (!selectedRelease) {
-                    throw new Error(t('editProject.godotEditor.unavailable'));
-                }
-                currentProject = await onSetProjectEditor(
-                    currentProject,
-                    selectedRelease,
-                );
-                setInitialReleaseKey(selectedReleaseKey);
-            }
-
-            if (windowedChanged) {
-                currentProject = await onSetProjectWindowed(
-                    currentProject,
-                    windowed,
-                );
-                setInitialWindowed(windowed);
-            }
-
-            clearSettingsSave(project.path);
-            onOpenChange(false);
-            if (
-                releaseSelection.source === 'catalogue' &&
-                (currentProject.release.valid === false ||
-                    !currentProject.release.editor_path)
-            ) {
-                void queueProjectEditorRepairs([
-                    {
-                        release: releaseSelection.release,
-                        mono: releaseSelection.mono,
-                        projects: [currentProject],
-                    },
-                ]).catch((error: unknown) => {
-                    addAlert(
-                        t('common:error'),
-                        error instanceof Error
-                            ? error.message
-                            : t('editProject.updateFailed'),
-                    );
-                });
-            }
-        } catch (error) {
-            if (submissionSession === sessionRef.current) {
-                setFormError(
-                    error instanceof Error
-                        ? error.message
-                        : t('editProject.updateFailed'),
-                );
-            }
-        } finally {
-            if (submissionSession === sessionRef.current) {
-                submissionRef.current = false;
-                setIsSubmitting(false);
-            }
-        }
-    };
-
-    const trimmedName = name.trim();
-    const godotProjectAvailable = godotProjectName !== null;
-    const godotRenameEnabled = canRenameGodotProject(name, godotProjectName);
-    const hasRenameChanges =
-        project &&
-        hasProjectRenameChanges(
-            initialName,
-            godotProjectName,
-            name,
-            renameGodotProject,
-        );
-    const hasCodeEditorChanges =
-        project &&
-        hasProjectCodeEditorChanges(
-            initialCodeEditorId,
-            codeEditorId,
-            codeEditorTouched,
-        );
-    const hasReleaseChanges =
-        project &&
-        releaseSelection !== null &&
-        (initialReleaseKey !==
-            getCreateProjectReleaseKey({
-                version: releaseSelection.release.version,
-                mono:
-                    releaseSelection.source === 'installed'
-                        ? releaseSelection.release.mono
-                        : releaseSelection.mono,
-            }) ||
-            (releaseSelection.source === 'catalogue' &&
-                (project.release.valid === false ||
-                    !project.release.editor_path)));
-    const hasWindowedChanges = project && initialWindowed !== windowed;
-    const hasChanges =
-        hasRenameChanges ||
-        hasCodeEditorChanges ||
-        hasReleaseChanges ||
-        hasWindowedChanges;
-    const selectedCodeEditorSettings = codeEditorId
-        ? codeEditorSettings.find(
-              (settings) => settings.integration.id === codeEditorId,
-          )
-        : undefined;
-    const selectedCodeEditorName =
-        selectedCodeEditorSettings?.integration.displayName ?? codeEditorId;
-    const showResetCodeEditorConfig =
-        initialCodeEditorId !== null && initialCodeEditorId === codeEditorId;
-    const requestCodeEditorConfigReset = () => {
-        if (!project || !selectedCodeEditorName) {
-            return;
-        }
-
+    const resetCodeEditorConfig = () => {
+        const selected = form.codeEditorId
+            ? form.codeEditorSettings.find(
+                  (item) => item.integration.id === form.codeEditorId,
+              )
+            : undefined;
+        const editor = selected?.integration.displayName ?? form.codeEditorId;
+        if (!project || !editor) return;
         addCustomConfirm(
-            t('editProject.codeEditor.resetConfig.confirmTitle', {
-                editor: selectedCodeEditorName,
-            }),
+            t('editProject.codeEditor.resetConfig.confirmTitle', { editor }),
             <div className="flex flex-col gap-4 text-base">
                 <p className="text-base-content/75">
                     {t('editProject.codeEditor.resetConfig.confirmMessage')}
@@ -794,9 +136,9 @@ export const ProjectSettingsDrawer: React.FC<ProjectSettingsDrawerProps> = ({
                     text: t('editProject.codeEditor.resetConfig.label'),
                     onClick: async () => {
                         try {
-                            await onResetProjectCodeEditorConfig(project);
+                            await props.onResetProjectCodeEditorConfig(project);
                         } catch (error) {
-                            setFormError(
+                            form.setSaveError(
                                 error instanceof Error
                                     ? error.message
                                     : t('editProject.updateFailed'),
@@ -810,38 +152,175 @@ export const ProjectSettingsDrawer: React.FC<ProjectSettingsDrawerProps> = ({
             'warning',
         );
     };
-    const saveDisabled =
-        !project ||
-        trimmedName.length === 0 ||
-        !hasChanges ||
-        isSubmitting ||
-        loadingGodotName;
-    const drawerTitle = project
-        ? t('editProject.drawerTitle', { project: project.name })
-        : t('editProject.title');
-    const gitUnavailable = withGit && gitIdentity?.status === 'git-unavailable';
 
-    return (
-        <Drawer
-            open={open && Boolean(project)}
-            onOpenChange={(nextOpen) => {
-                if (!nextOpen && isSavingLocally) {
+    /**
+     * Persists staged changes in rename, code-editor, release, then launch order.
+     *
+     * @param event - The form submit event.
+     * @returns A promise that ends after all applicable saves complete.
+     */
+    const submit = async (event: React.FormEvent) => {
+        event.preventDefault();
+        if (submitting.current || savingInBackground) return;
+        if (!project || !form.releaseSelection || !form.validateName()) {
+            setActiveTab('project');
+            return;
+        }
+        submitting.current = true;
+        const session = form.sessionRef.current;
+        setSavingLocally(true);
+        form.setSaveError(undefined);
+        form.setGodotNameError(undefined);
+        try {
+            let current = project;
+            const rename = hasProjectRenameChanges(
+                form.initialName,
+                form.godotProjectName,
+                form.name,
+                form.renameGodotProject,
+            );
+            const editor = hasProjectCodeEditorChanges(
+                form.initialCodeEditorId,
+                form.codeEditorId,
+                form.codeEditorTouched,
+            );
+            const key = getCreateProjectReleaseKey({
+                version: form.releaseSelection.release.version,
+                mono:
+                    form.releaseSelection.source === 'installed'
+                        ? form.releaseSelection.release.mono
+                        : form.releaseSelection.mono,
+            });
+            const release =
+                form.initialReleaseKey !== key ||
+                (form.releaseSelection.source === 'catalogue' &&
+                    (project.release.valid === false ||
+                        !project.release.editor_path));
+            const windowed = form.initialWindowed !== form.windowed;
+            let selection: ProjectEditorSelection | undefined;
+            if (release) {
+                if (
+                    form.releaseSelection.source === 'installed' &&
+                    (form.releaseSelection.release.valid === false ||
+                        !form.releaseSelection.release.editor_path)
+                ) {
+                    form.setSaveError(t('editProject.godotEditor.unavailable'));
                     return;
                 }
-                onOpenChange(nextOpen);
+                selection =
+                    form.releaseSelection.source === 'installed'
+                        ? form.releaseSelection.release
+                        : {
+                              release: form.releaseSelection.release,
+                              mono: form.releaseSelection.mono,
+                          };
+            }
+            if (rename) {
+                const result = await onRenameProject(project, {
+                    name: form.name.trim(),
+                    renameGodotProject: form.renameGodotProject,
+                });
+                if (!result.success) {
+                    const error = result.error ?? t('editProject.updateFailed');
+                    form.setSaveError(error);
+                    if (result.errorField === 'name')
+                        form.setProjectNameError(error);
+                    if (result.errorField === 'godot')
+                        form.setGodotNameError(error);
+                    setActiveTab('project');
+                    return;
+                }
+                current = result.project ?? {
+                    ...current,
+                    name: form.name.trim(),
+                };
+                form.acceptRename(current);
+            }
+            if (editor) {
+                current = await onSetProjectCodeEditor(
+                    current,
+                    form.codeEditorId,
+                );
+                form.acceptCodeEditor(current);
+            }
+            if (release) {
+                if (!selection)
+                    throw new Error(t('editProject.godotEditor.unavailable'));
+                current = await onSetProjectEditor(current, selection);
+                form.acceptRelease(key);
+            }
+            if (windowed) {
+                current = await onSetProjectWindowed(current, form.windowed);
+                form.acceptWindowed(form.windowed);
+            }
+            clearSettingsSave(project.path);
+            onOpenChange(false);
+            if (
+                form.releaseSelection.source === 'catalogue' &&
+                (current.release.valid === false ||
+                    !current.release.editor_path)
+            )
+                void queueProjectEditorRepairs([
+                    {
+                        release: form.releaseSelection.release,
+                        mono: form.releaseSelection.mono,
+                        projects: [current],
+                    },
+                ]).catch((error: unknown) =>
+                    addAlert(
+                        t('common:error'),
+                        error instanceof Error
+                            ? error.message
+                            : t('editProject.updateFailed'),
+                    ),
+                );
+        } catch (error) {
+            if (session === form.sessionRef.current)
+                form.setSaveError(
+                    error instanceof Error
+                        ? error.message
+                        : t('editProject.updateFailed'),
+                );
+        } finally {
+            if (session === form.sessionRef.current) {
+                submitting.current = false;
+                setSavingLocally(false);
+            }
+        }
+    };
+    const changed =
+        form.hasRenameChanges ||
+        form.hasCodeEditorChanges ||
+        form.hasReleaseChanges ||
+        form.hasWindowedChanges;
+    const title = project
+        ? t('editProject.drawerTitle', { project: project.name })
+        : t('editProject.title');
+    const disabled =
+        !project ||
+        !changed ||
+        !form.name.trim() ||
+        isSubmitting ||
+        form.loadingGodotName;
+    return (
+        <Drawer
+            open={open && !!project}
+            onOpenChange={(next) => {
+                if (!next && savingLocally) return;
+                onOpenChange(next);
             }}
             side="right"
-            ariaLabel={drawerTitle}
+            ariaLabel={title}
             width={560}
             panelClassName="max-w-[100vw]"
-            closeOnBackdrop={!isSavingLocally}
-            closeOnEscape={!isSavingLocally}
+            closeOnBackdrop={!savingLocally}
+            closeOnEscape={!savingLocally}
         >
             <Drawer.Header className="items-start">
                 <div className="flex min-w-0 flex-1 flex-col gap-2">
                     <div className="flex min-w-0 flex-wrap items-center gap-2">
                         <Drawer.Title className="text-lg font-semibold">
-                            {drawerTitle}
+                            {title}
                         </Drawer.Title>
                         {project?.pinned && (
                             <span className="badge badge-sm badge-primary badge-soft gap-1">
@@ -861,18 +340,18 @@ export const ProjectSettingsDrawer: React.FC<ProjectSettingsDrawerProps> = ({
                 </div>
                 <Drawer.CloseButton
                     className="btn-sm"
-                    disabled={isSavingLocally}
+                    disabled={savingLocally}
                 />
             </Drawer.Header>
             <form
                 className="flex min-h-0 flex-1 flex-col"
-                onSubmit={(event) => void handleSubmit(event)}
+                onSubmit={(event) => void submit(event)}
             >
                 <div
                     role="tablist"
                     className="tabs tabs-border grid shrink-0 grid-cols-4 px-5 pt-2"
                 >
-                    {projectSettingsTabs.map((tab) => (
+                    {tabs.map((tab) => (
                         <button
                             key={tab}
                             type="button"
@@ -889,7 +368,6 @@ export const ProjectSettingsDrawer: React.FC<ProjectSettingsDrawerProps> = ({
                         </button>
                     ))}
                 </div>
-
                 <Drawer.Body className="flex flex-col gap-4 text-base">
                     {savingInBackground && (
                         <p className="text-base-content/75" role="status">
@@ -900,522 +378,127 @@ export const ProjectSettingsDrawer: React.FC<ProjectSettingsDrawerProps> = ({
                         disabled={isSubmitting}
                         className="flex min-w-0 flex-col gap-4"
                     >
-                        {formError && (
+                        {form.formError && (
                             <div
                                 className="alert alert-error alert-soft text-error-content dark:text-error"
                                 role="alert"
                             >
-                                {formError}
+                                {form.formError}
                             </div>
                         )}
-
                         {activeTab === 'project' && (
-                            <div className="flex flex-col gap-[12px]">
-                                <TextField
-                                    id="projectEditName"
-                                    label={t('editProject.fields.name.label')}
-                                    help={t('editProject.fields.name.help')}
-                                    value={name}
-                                    onChange={handleNameChange}
-                                    onBlur={validateNameField}
-                                    placeholder={t(
-                                        'editProject.fields.name.placeholder',
-                                    )}
-                                    error={nameError}
-                                />
-
-                                <label className="flex items-start gap-3 rounded-md bg-base-content/5 p-3">
-                                    <input
-                                        type="checkbox"
-                                        className={clsx(
-                                            'checkbox checkbox-sm mt-0.5 shrink-0',
-                                            godotError && 'checkbox-error',
-                                        )}
-                                        checked={renameGodotProject}
-                                        disabled={
-                                            !godotProjectAvailable ||
-                                            loadingGodotName ||
-                                            !godotRenameEnabled
-                                        }
-                                        onChange={(event) => {
-                                            setRenameGodotProject(
-                                                event.currentTarget.checked,
-                                            );
-                                            setGodotError(undefined);
-                                            setFormError(undefined);
-                                        }}
-                                    />
-                                    <span
-                                        className={clsx(
-                                            'flex min-w-0 flex-col gap-1',
-                                            (isSubmitting ||
-                                                !godotProjectAvailable ||
-                                                loadingGodotName ||
-                                                !godotRenameEnabled) &&
-                                                'opacity-50',
-                                        )}
-                                    >
-                                        <span>
-                                            {t('editProject.godot.renameLabel')}
-                                        </span>
-                                        <span className="text-base-content">
-                                            {loadingGodotName &&
-                                                t('editProject.godot.loading')}
-                                            {!loadingGodotName &&
-                                                godotProjectAvailable &&
-                                                t(
-                                                    'editProject.godot.currentName',
-                                                    {
-                                                        name: godotProjectName,
-                                                    },
-                                                )}
-                                            {!loadingGodotName &&
-                                                !godotProjectAvailable &&
-                                                t(
-                                                    'editProject.godot.unavailable',
-                                                )}
-                                        </span>
-                                        {godotError && (
-                                            <span className="text-error">
-                                                {godotError}
-                                            </span>
-                                        )}
-                                    </span>
-                                </label>
-
-                                <ContentDivider />
-                                <div className="flex flex-col gap-2">
-                                    <div>
-                                        <h3 className="text-base font-semibold">
-                                            {t('editProject.godotEditor.title')}
-                                        </h3>
-                                        <p className="text-base-content/75">
-                                            {t('editProject.godotEditor.help')}
-                                        </p>
-                                    </div>
-                                    <CreateProjectEditorPicker
-                                        open={open}
-                                        disabled={isSubmitting}
-                                        triggerTestId="selectProjectGodotEditor"
-                                        triggerLabel={t(
-                                            'editProject.godotEditor.title',
-                                        )}
-                                        installedReleases={selectableReleases}
-                                        availableReleases={
-                                            compatibleCatalogueReleases
-                                        }
-                                        availablePrereleases={
-                                            compatibleCataloguePrereleases
-                                        }
-                                        releaseInstallProgress={
-                                            releaseInstallProgress
-                                        }
-                                        loading={releasesLoading}
-                                        catalogueError={catalogueError}
-                                        selection={releaseSelection}
-                                        onSelectionChange={(selection) => {
-                                            setReleaseSelection(selection);
-                                            setFormError(undefined);
-                                        }}
-                                        onCancelInstall={(jobId) =>
-                                            void cancelInstall(jobId)
-                                        }
-                                        onRetryCatalogue={
-                                            refreshAvailableReleases
-                                        }
-                                    />
-                                </div>
-                            </div>
+                            <ProjectSettingsProjectSection
+                                t={t}
+                                open={open}
+                                disabled={isSubmitting}
+                                name={form.name}
+                                nameError={form.nameError}
+                                godotProjectName={form.godotProjectName}
+                                loadingGodotName={form.loadingGodotName}
+                                renameGodotProject={form.renameGodotProject}
+                                godotError={form.godotError}
+                                selectableReleases={form.selectableReleases}
+                                compatibleCatalogueReleases={
+                                    form.compatibleCatalogueReleases
+                                }
+                                compatibleCataloguePrereleases={
+                                    form.compatibleCataloguePrereleases
+                                }
+                                releaseInstallProgress={
+                                    form.releaseInstallProgress
+                                }
+                                releasesLoading={form.releasesLoading}
+                                catalogueError={form.catalogueError}
+                                releaseSelection={form.releaseSelection}
+                                onNameChange={form.changeName}
+                                onNameBlur={form.validateName}
+                                onRenameGodotProjectChange={
+                                    form.changeRenameGodotProject
+                                }
+                                onReleaseSelectionChange={
+                                    form.changeReleaseSelection
+                                }
+                                onCancelInstall={(job) =>
+                                    void form.cancelInstall(job)
+                                }
+                                onRetryCatalogue={form.refreshAvailableReleases}
+                            />
                         )}
-
                         {activeTab === 'sourceControl' && project && (
-                            <section className="flex flex-col gap-[12px]">
-                                <div className="flex min-w-0 flex-col gap-[4px]">
-                                    <h2 className="text-base font-semibold">
-                                        {t('editProject.sourceControl.title')}
-                                    </h2>
-                                    <p className="break-words text-base-content/75">
-                                        {t('editProject.sourceControl.help')}
-                                    </p>
-                                </div>
-                                <div className="flex items-start justify-between gap-4 rounded-md bg-base-200/40 p-4">
-                                    <div className="flex min-w-0 items-start gap-3">
-                                        <GitBranch
-                                            className="size-5 shrink-0"
-                                            aria-hidden="true"
-                                        />
-                                        <div className="flex min-w-0 flex-col gap-1">
-                                            <span className="font-semibold">
-                                                Git
-                                            </span>
-                                            <span className="text-base-content/75">
-                                                {t(
-                                                    withGit
-                                                        ? gitUnavailable
-                                                            ? 'editProject.sourceControl.enabledUnavailable'
-                                                            : 'editProject.sourceControl.enabled'
-                                                        : 'editProject.sourceControl.notConfigured',
-                                                )}
-                                            </span>
-                                            {!withGit &&
-                                                !loadingGitAvailability &&
-                                                !gitAvailable && (
-                                                    <span className="text-warning">
-                                                        {t(
-                                                            'createProject:otherSettings.gitNotInstalled',
-                                                        )}
-                                                    </span>
-                                                )}
-                                        </div>
-                                    </div>
-                                    {gitUnavailable ? (
-                                        <span
-                                            className="badge badge-sm badge-soft badge-warning text-warning-content dark:text-warning"
-                                            data-testid="projectGitUnavailable"
-                                        >
-                                            {t(
-                                                'editProject.sourceControl.identityUnavailable',
-                                            )}
-                                        </span>
-                                    ) : withGit ? (
-                                        <span
-                                            className="badge badge-sm badge-soft badge-success text-success-content dark:text-success gap-1.5"
-                                            data-testid="projectGitActive"
-                                        >
-                                            <CircleCheck
-                                                className="h-4 w-4"
-                                                aria-hidden="true"
-                                            />
-                                            {t(
-                                                'editProject.sourceControl.active',
-                                            )}
-                                        </span>
-                                    ) : loadingGitAvailability ? (
-                                        <span className="loading loading-spinner loading-sm" />
-                                    ) : gitAvailable ? (
-                                        <button
-                                            type="button"
-                                            className="btn btn-primary shrink-0 text-base"
-                                            disabled={
-                                                !project.valid ||
-                                                isInitializingGit
-                                            }
-                                            onClick={() =>
-                                                void handleInitializeGit()
-                                            }
-                                        >
-                                            {isInitializingGit && (
-                                                <span className="loading loading-spinner loading-xs" />
-                                            )}
-                                            {t(
-                                                isInitializingGit
-                                                    ? 'editProject.sourceControl.initializing'
-                                                    : 'editProject.sourceControl.initialize',
-                                            )}
-                                        </button>
-                                    ) : null}
-                                </div>
-                                {withGit && <ContentDivider />}
-                                {withGit && loadingGitIdentity && (
-                                    <div className="flex justify-center py-4">
-                                        <span className="loading loading-spinner loading-sm" />
-                                    </div>
-                                )}
-                                {withGit &&
-                                    gitIdentity?.status === 'available' && (
-                                        <div className="flex flex-col gap-[12px]">
-                                            <div className="flex items-start justify-between gap-4">
-                                                <div className="flex min-w-0 flex-col gap-[4px]">
-                                                    <h3 className="text-base font-semibold">
-                                                        {t(
-                                                            'editProject.sourceControl.identityTitle',
-                                                        )}
-                                                    </h3>
-                                                    <p className="break-words text-base-content/75">
-                                                        {t(
-                                                            'editProject.sourceControl.identityHelp',
-                                                        )}
-                                                    </p>
-                                                </div>
-                                                {!editingGitIdentity &&
-                                                    gitIdentity.canUpdate && (
-                                                        <button
-                                                            type="button"
-                                                            className="btn btn-ghost shrink-0 text-base"
-                                                            onClick={
-                                                                handleEditGitIdentity
-                                                            }
-                                                        >
-                                                            {t(
-                                                                'editProject.sourceControl.updateIdentity',
-                                                            )}
-                                                        </button>
-                                                    )}
-                                            </div>
-                                            {editingGitIdentity ? (
-                                                <div className="flex flex-col gap-3">
-                                                    <TextField
-                                                        id="projectGitIdentityName"
-                                                        label={t(
-                                                            'editProject.sourceControl.identityName',
-                                                        )}
-                                                        help={t(
-                                                            'editProject.sourceControl.identityNameHelp',
-                                                        )}
-                                                        value={gitIdentityName}
-                                                        onChange={
-                                                            setGitIdentityName
-                                                        }
-                                                        disabled={
-                                                            savingGitIdentity
-                                                        }
-                                                    />
-                                                    <TextField
-                                                        id="projectGitIdentityEmail"
-                                                        label={t(
-                                                            'editProject.sourceControl.identityEmail',
-                                                        )}
-                                                        help={t(
-                                                            'editProject.sourceControl.identityEmailHelp',
-                                                        )}
-                                                        value={gitIdentityEmail}
-                                                        onChange={
-                                                            setGitIdentityEmail
-                                                        }
-                                                        disabled={
-                                                            savingGitIdentity
-                                                        }
-                                                    />
-                                                    <div className="flex justify-end gap-2">
-                                                        <button
-                                                            type="button"
-                                                            className="btn btn-ghost text-base"
-                                                            disabled={
-                                                                savingGitIdentity
-                                                            }
-                                                            onClick={() => {
-                                                                setEditingGitIdentity(
-                                                                    false,
-                                                                );
-                                                                setGitIdentityError(
-                                                                    undefined,
-                                                                );
-                                                            }}
-                                                        >
-                                                            {t(
-                                                                'common:buttons.cancel',
-                                                            )}
-                                                        </button>
-                                                        <button
-                                                            type="button"
-                                                            className="btn btn-primary shrink-0 text-base"
-                                                            disabled={
-                                                                savingGitIdentity
-                                                            }
-                                                            onClick={() =>
-                                                                void handleSaveGitIdentity()
-                                                            }
-                                                        >
-                                                            {savingGitIdentity && (
-                                                                <span className="loading loading-spinner loading-xs" />
-                                                            )}
-                                                            {t(
-                                                                'editProject.sourceControl.saveIdentity',
-                                                            )}
-                                                        </button>
-                                                    </div>
-                                                </div>
-                                            ) : (
-                                                <dl className="grid gap-3">
-                                                    {(
-                                                        [
-                                                            [
-                                                                'identityName',
-                                                                gitIdentity.name,
-                                                            ],
-                                                            [
-                                                                'identityEmail',
-                                                                gitIdentity.email,
-                                                            ],
-                                                        ] as const
-                                                    ).map(([label, value]) => (
-                                                        <div
-                                                            key={label}
-                                                            className="min-w-0"
-                                                        >
-                                                            <dt className="flex flex-wrap items-center gap-2 text-base-content/75">
-                                                                <span>
-                                                                    {t(
-                                                                        `editProject.sourceControl.${label}`,
-                                                                    )}
-                                                                </span>
-                                                                <span className="badge badge-sm badge-soft capitalize">
-                                                                    {t(
-                                                                        `editProject.sourceControl.identitySource.${value.source}`,
-                                                                    )}
-                                                                </span>
-                                                            </dt>
-                                                            <dd className="mt-1 flex min-w-0 items-center gap-2 rounded-md bg-base-content/5 px-3 py-2">
-                                                                <span className="min-w-0 flex-1 break-all select-text">
-                                                                    {value.value ||
-                                                                        t(
-                                                                            'editProject.sourceControl.identityMissing',
-                                                                        )}
-                                                                </span>
-                                                                {value.value && (
-                                                                    <div className="shrink-0">
-                                                                        <CopyButton
-                                                                            value={
-                                                                                value.value
-                                                                            }
-                                                                        />
-                                                                    </div>
-                                                                )}
-                                                            </dd>
-                                                        </div>
-                                                    ))}
-                                                </dl>
-                                            )}
-                                            {!gitIdentity.canUpdate && (
-                                                <p className="break-words text-base-content/75">
-                                                    {t(
-                                                        gitIdentity.repository
-                                                            .kind ===
-                                                            'linked-worktree'
-                                                            ? 'editProject.sourceControl.linkedWorktreeReadOnly'
-                                                            : 'editProject.sourceControl.parentRepositoryReadOnly',
-                                                        {
-                                                            root: gitIdentity
-                                                                .repository
-                                                                .root,
-                                                        },
-                                                    )}
-                                                </p>
-                                            )}
-                                        </div>
-                                    )}
-                                {withGit &&
-                                    gitIdentity?.status ===
-                                        'git-unavailable' && (
-                                        <div className="flex flex-col gap-[12px]">
-                                            <div className="flex items-start justify-between gap-4">
-                                                <div className="flex min-w-0 flex-col gap-[4px]">
-                                                    <h3 className="text-base font-semibold">
-                                                        {t(
-                                                            'editProject.sourceControl.identityTitle',
-                                                        )}
-                                                    </h3>
-                                                    <p className="break-words text-base-content/75">
-                                                        {t(
-                                                            'editProject.sourceControl.identityUnavailableHelp',
-                                                        )}
-                                                    </p>
-                                                </div>
-                                                <button
-                                                    type="button"
-                                                    className="btn btn-ghost shrink-0 text-base"
-                                                    disabled
-                                                >
-                                                    {t(
-                                                        'editProject.sourceControl.updateIdentity',
-                                                    )}
-                                                </button>
-                                            </div>
-                                            <dl className="grid gap-3">
-                                                {[
-                                                    'identityName',
-                                                    'identityEmail',
-                                                ].map((label) => (
-                                                    <div
-                                                        key={label}
-                                                        className="min-w-0"
-                                                    >
-                                                        <dt className="text-base-content/75">
-                                                            {t(
-                                                                `editProject.sourceControl.${label}`,
-                                                            )}
-                                                        </dt>
-                                                        <dd className="mt-1 rounded-md bg-base-content/5 px-3 py-2 text-base-content/60">
-                                                            {t(
-                                                                'editProject.sourceControl.identityUnavailable',
-                                                            )}
-                                                        </dd>
-                                                    </div>
-                                                ))}
-                                            </dl>
-                                        </div>
-                                    )}
-                                {gitIdentityError && (
-                                    <p
-                                        className="break-words text-error"
-                                        role="alert"
-                                    >
-                                        {gitIdentityError}
-                                    </p>
-                                )}
-                            </section>
+                            <ProjectSettingsSourceControlSection
+                                t={t}
+                                project={project}
+                                withGit={sourceControl.withGit}
+                                gitAvailable={sourceControl.gitAvailable}
+                                loadingGitAvailability={
+                                    sourceControl.loadingGitAvailability
+                                }
+                                isInitializingGit={
+                                    sourceControl.isInitializingGit
+                                }
+                                gitIdentity={sourceControl.gitIdentity}
+                                loadingGitIdentity={
+                                    sourceControl.loadingGitIdentity
+                                }
+                                editingGitIdentity={
+                                    sourceControl.editingGitIdentity
+                                }
+                                gitIdentityName={sourceControl.gitIdentityName}
+                                gitIdentityEmail={
+                                    sourceControl.gitIdentityEmail
+                                }
+                                savingGitIdentity={
+                                    sourceControl.savingGitIdentity
+                                }
+                                gitIdentityError={
+                                    sourceControl.gitIdentityError
+                                }
+                                gitUnavailable={sourceControl.gitUnavailable}
+                                disabled={isSubmitting}
+                                onInitializeGit={() =>
+                                    void sourceControl.initializeGit()
+                                }
+                                onEditGitIdentity={
+                                    sourceControl.editGitIdentity
+                                }
+                                onSaveGitIdentity={() =>
+                                    void sourceControl.saveGitIdentity()
+                                }
+                                onCancelGitIdentity={
+                                    sourceControl.cancelGitIdentity
+                                }
+                                onGitIdentityNameChange={
+                                    sourceControl.setGitIdentityName
+                                }
+                                onGitIdentityEmailChange={
+                                    sourceControl.setGitIdentityEmail
+                                }
+                            />
                         )}
-
                         {activeTab === 'codeEditor' && (
                             <ProjectCodeEditorSection
                                 t={t}
-                                codeEditorId={codeEditorId}
-                                settings={codeEditorSettings}
-                                loading={loadingCodeEditors}
-                                loadFailed={codeEditorLoadFailed}
+                                codeEditorId={form.codeEditorId}
+                                settings={form.codeEditorSettings}
+                                loading={form.loadingCodeEditors}
+                                loadFailed={form.codeEditorLoadFailed}
                                 disabled={!project?.valid || isSubmitting}
-                                showResetConfig={showResetCodeEditorConfig}
-                                onChange={handleCodeEditorChange}
-                                onResetConfig={requestCodeEditorConfigReset}
+                                showResetConfig={
+                                    form.initialCodeEditorId !== null &&
+                                    form.initialCodeEditorId ===
+                                        form.codeEditorId
+                                }
+                                onChange={form.changeCodeEditor}
+                                onResetConfig={resetCodeEditorConfig}
                             />
                         )}
-
                         {activeTab === 'launch' && (
-                            <section className="flex flex-col gap-[12px]">
-                                <div className="flex flex-col gap-[4px]">
-                                    <h2 className="text-base font-semibold">
-                                        {t('editProject.launch.title')}
-                                    </h2>
-                                    <p className="text-base-content/75">
-                                        {t('editProject.launch.help')}
-                                    </p>
-                                </div>
-                                <label
-                                    className={clsx(
-                                        'flex items-start gap-3 rounded-md bg-base-content/5 p-3',
-                                        isSubmitting && 'opacity-50',
-                                    )}
-                                >
-                                    <input
-                                        type="checkbox"
-                                        className="checkbox checkbox-sm mt-0.5 shrink-0"
-                                        checked={windowed}
-                                        disabled={isSubmitting}
-                                        onChange={(event) => {
-                                            setWindowed(
-                                                event.currentTarget.checked,
-                                            );
-                                            setFormError(undefined);
-                                        }}
-                                    />
-                                    <PanelTop
-                                        className="mt-0.5 size-5 shrink-0"
-                                        aria-hidden="true"
-                                    />
-                                    <span className="flex flex-col gap-1">
-                                        <span>
-                                            {t(
-                                                'editProject.launch.windowed.label',
-                                            )}
-                                        </span>
-                                        <span className="text-base-content/75">
-                                            {t(
-                                                'editProject.launch.windowed.help',
-                                            )}
-                                        </span>
-                                    </span>
-                                </label>
-                            </section>
+                            <ProjectSettingsLaunchSection
+                                t={t}
+                                windowed={form.windowed}
+                                disabled={isSubmitting}
+                                onWindowedChange={form.changeWindowed}
+                            />
                         )}
                     </fieldset>
                 </Drawer.Body>
@@ -1424,25 +507,25 @@ export const ProjectSettingsDrawer: React.FC<ProjectSettingsDrawerProps> = ({
                         type="button"
                         className="btn btn-ghost text-base"
                         onClick={() => onOpenChange(false)}
-                        disabled={isSavingLocally}
+                        disabled={savingLocally}
                     >
                         {t('common:buttons.cancel')}
                     </button>
                     <button
                         type="submit"
                         className="btn btn-primary text-base"
-                        disabled={saveDisabled}
+                        disabled={disabled}
                     >
                         {isSubmitting && (
                             <span className="loading loading-spinner loading-xs" />
                         )}
                         {isSubmitting &&
-                        releaseSelection?.source === 'catalogue' &&
-                        !releaseSelection.installedRelease
+                        form.releaseSelection?.source === 'catalogue' &&
+                        !form.releaseSelection.installedRelease
                             ? t('editProject.actions.installingEditor')
-                            : hasReleaseChanges &&
-                                releaseSelection?.source === 'catalogue' &&
-                                !releaseSelection.installedRelease
+                            : form.hasReleaseChanges &&
+                                form.releaseSelection?.source === 'catalogue' &&
+                                !form.releaseSelection.installedRelease
                               ? t('editProject.actions.installAndSave')
                               : isSubmitting
                                 ? t('editProject.actions.updating')

--- a/renderer/src/views/sub-views/project-settings-drawer.subview.tsx
+++ b/renderer/src/views/sub-views/project-settings-drawer.subview.tsx
@@ -5,6 +5,7 @@ import type {
     InitializeProjectGitResult,
     InstalledRelease,
     ProjectDetails,
+    ProjectEditorSelection,
     ProjectGitIdentityResult,
     RenameProjectOptions,
     RenameProjectResult,
@@ -29,7 +30,6 @@ import { CreateProjectEditorPicker } from './create-project/components/create-pr
 import {
     type CreateProjectEditorSelection,
     getCreateProjectReleaseKey,
-    prepareCreateProjectRelease,
 } from './create-project/create-project.model';
 import { ProjectCodeEditorSection } from './project-settings-drawer/components/project-code-editor-section.component';
 import {
@@ -59,7 +59,7 @@ type ProjectSettingsDrawerProps = {
     ) => Promise<RenameProjectResult>;
     onSetProjectEditor: (
         project: ProjectDetails,
-        release: InstalledRelease,
+        release: ProjectEditorSelection,
     ) => Promise<ProjectDetails>;
     onSetProjectCodeEditor: (
         project: ProjectDetails,
@@ -117,7 +117,6 @@ export const ProjectSettingsDrawer: React.FC<ProjectSettingsDrawerProps> = ({
         hasError: catalogueError,
         refreshAvailableReleases,
         cancelInstall,
-        installRelease,
     } = useRelease();
     const [activeTab, setActiveTab] = useState<ProjectSettingsTab>('project');
     const [initialName, setInitialName] = useState('');
@@ -148,7 +147,7 @@ export const ProjectSettingsDrawer: React.FC<ProjectSettingsDrawerProps> = ({
     const [godotError, setGodotError] = useState<string>();
     const [formError, setFormError] = useState<string>();
     const [isSavingLocally, setIsSubmitting] = useState(false);
-    const { settingsSaves, startSettingsSave, clearSettingsSave } =
+    const { settingsSaves, queueProjectEditorRepairs, clearSettingsSave } =
         useProjects();
     const settingsSave = project ? settingsSaves?.get(project.path) : undefined;
     const savingInBackground = settingsSave?.status === 'pending';
@@ -550,7 +549,7 @@ export const ProjectSettingsDrawer: React.FC<ProjectSettingsDrawerProps> = ({
     };
 
     /**
-     * Submits catalogue installation and settings in the background, or saves an installed selection.
+     * Saves settings and the selected editor before queuing any required download.
      *
      * @param event - The settings form submission event.
      * @returns A promise that ends after the staged settings are saved or fail.
@@ -572,85 +571,6 @@ export const ProjectSettingsDrawer: React.FC<ProjectSettingsDrawerProps> = ({
         setIsSubmitting(true);
         setFormError(undefined);
         setGodotError(undefined);
-
-        if (
-            releaseSelection.source === 'catalogue' &&
-            !releaseSelection.installedRelease
-        ) {
-            startSettingsSave(
-                project.path,
-                {
-                    name,
-                    renameGodotProject,
-                    windowed,
-                    codeEditorId,
-                    codeEditorTouched,
-                    releaseSelection,
-                },
-                async () => {
-                    const installation = prepareCreateProjectRelease(
-                        releaseSelection,
-                        installRelease,
-                    );
-                    const result = await installation;
-                    if (!result.success || !result.release) {
-                        throw new Error(
-                            result.error ?? t('editProject.updateFailed'),
-                        );
-                    }
-                    let savedProject = project;
-                    if (
-                        hasProjectRenameChanges(
-                            initialName,
-                            godotProjectName,
-                            name,
-                            renameGodotProject,
-                        )
-                    ) {
-                        const renamed = await onRenameProject(savedProject, {
-                            name: name.trim(),
-                            renameGodotProject,
-                        });
-                        if (!renamed.success) {
-                            throw new Error(
-                                renamed.error ?? t('editProject.updateFailed'),
-                            );
-                        }
-                        savedProject = renamed.project ?? {
-                            ...savedProject,
-                            name: name.trim(),
-                        };
-                    }
-                    if (
-                        hasProjectCodeEditorChanges(
-                            initialCodeEditorId,
-                            codeEditorId,
-                            codeEditorTouched,
-                        )
-                    ) {
-                        savedProject = await onSetProjectCodeEditor(
-                            savedProject,
-                            codeEditorId,
-                        );
-                    }
-                    savedProject = await onSetProjectEditor(
-                        savedProject,
-                        result.release,
-                    );
-                    if (initialWindowed !== windowed) {
-                        savedProject = await onSetProjectWindowed(
-                            savedProject,
-                            windowed,
-                        );
-                    }
-                    return savedProject;
-                },
-            );
-            setIsSubmitting(false);
-            submissionRef.current = false;
-            onOpenChange(false);
-            return;
-        }
 
         try {
             let currentProject = project;
@@ -678,7 +598,7 @@ export const ProjectSettingsDrawer: React.FC<ProjectSettingsDrawerProps> = ({
                     (project.release.valid === false ||
                         !project.release.editor_path));
             const windowedChanged = initialWindowed !== windowed;
-            let selectedRelease: InstalledRelease | undefined;
+            let selectedRelease: ProjectEditorSelection | undefined;
 
             if (releaseChanged) {
                 if (
@@ -690,34 +610,13 @@ export const ProjectSettingsDrawer: React.FC<ProjectSettingsDrawerProps> = ({
                     return;
                 }
 
-                const installResult = await prepareCreateProjectRelease(
-                    releaseSelection,
-                    installRelease,
-                );
-
-                if (submissionSession !== sessionRef.current) {
-                    return;
-                }
-
-                if (!installResult.success || !installResult.release) {
-                    setFormError(
-                        installResult.error ?? t('editProject.updateFailed'),
-                    );
-                    return;
-                }
-
-                selectedRelease = installResult.release;
-                if (releaseSelection.source === 'catalogue') {
-                    setReleaseSelection((currentSelection) =>
-                        currentSelection?.source === 'catalogue' &&
-                        currentSelection.key === releaseSelection.key
-                            ? {
-                                  ...currentSelection,
-                                  installedRelease: installResult.release,
-                              }
-                            : currentSelection,
-                    );
-                }
+                selectedRelease =
+                    releaseSelection.source === 'installed'
+                        ? releaseSelection.release
+                        : {
+                              release: releaseSelection.release,
+                              mono: releaseSelection.mono,
+                          };
             }
 
             if (renameChanged) {
@@ -771,18 +670,39 @@ export const ProjectSettingsDrawer: React.FC<ProjectSettingsDrawerProps> = ({
                     currentProject,
                     selectedRelease,
                 );
-                setInitialReleaseKey(
-                    getCreateProjectReleaseKey(selectedRelease),
-                );
+                setInitialReleaseKey(selectedReleaseKey);
             }
 
             if (windowedChanged) {
-                await onSetProjectWindowed(currentProject, windowed);
+                currentProject = await onSetProjectWindowed(
+                    currentProject,
+                    windowed,
+                );
                 setInitialWindowed(windowed);
             }
 
             clearSettingsSave(project.path);
             onOpenChange(false);
+            if (
+                releaseSelection.source === 'catalogue' &&
+                (currentProject.release.valid === false ||
+                    !currentProject.release.editor_path)
+            ) {
+                void queueProjectEditorRepairs([
+                    {
+                        release: releaseSelection.release,
+                        mono: releaseSelection.mono,
+                        projects: [currentProject],
+                    },
+                ]).catch((error: unknown) => {
+                    addAlert(
+                        t('common:error'),
+                        error instanceof Error
+                            ? error.message
+                            : t('editProject.updateFailed'),
+                    );
+                });
+            }
         } catch (error) {
             if (submissionSession === sessionRef.current) {
                 setFormError(

--- a/renderer/src/views/sub-views/project-settings-drawer/components/project-settings-launch-section.component.tsx
+++ b/renderer/src/views/sub-views/project-settings-drawer/components/project-settings-launch-section.component.tsx
@@ -1,0 +1,62 @@
+import clsx from 'clsx';
+import type { TFunction } from 'i18next';
+import { PanelTop } from 'lucide-react';
+
+type ProjectSettingsLaunchSectionProps = {
+    t: TFunction;
+    windowed: boolean;
+    disabled: boolean;
+    onWindowedChange: (windowed: boolean) => void;
+};
+
+/**
+ * Renders the staged launch preferences.
+ *
+ * @param props - The launch value and its update action.
+ * @returns The launch settings section.
+ */
+export function ProjectSettingsLaunchSection({
+    t,
+    windowed,
+    disabled,
+    onWindowedChange,
+}: ProjectSettingsLaunchSectionProps) {
+    return (
+        <section className="flex flex-col gap-[12px]">
+            <div className="flex flex-col gap-[4px]">
+                <h2 className="text-base font-semibold">
+                    {t('editProject.launch.title')}
+                </h2>
+                <p className="text-base-content/75">
+                    {t('editProject.launch.help')}
+                </p>
+            </div>
+            <label
+                className={clsx(
+                    'flex items-start gap-3 rounded-md bg-base-content/5 p-3',
+                    disabled && 'opacity-50',
+                )}
+            >
+                <input
+                    type="checkbox"
+                    className="checkbox checkbox-sm mt-0.5 shrink-0"
+                    checked={windowed}
+                    disabled={disabled}
+                    onChange={(event) =>
+                        onWindowedChange(event.currentTarget.checked)
+                    }
+                />
+                <PanelTop
+                    className="mt-0.5 size-5 shrink-0"
+                    aria-hidden="true"
+                />
+                <span className="flex flex-col gap-1">
+                    <span>{t('editProject.launch.windowed.label')}</span>
+                    <span className="text-base-content/75">
+                        {t('editProject.launch.windowed.help')}
+                    </span>
+                </span>
+            </label>
+        </section>
+    );
+}

--- a/renderer/src/views/sub-views/project-settings-drawer/components/project-settings-project-section.component.tsx
+++ b/renderer/src/views/sub-views/project-settings-drawer/components/project-settings-project-section.component.tsx
@@ -1,0 +1,161 @@
+import type { InstalledRelease } from '@shared/contracts';
+import clsx from 'clsx';
+import type { TFunction } from 'i18next';
+import { ContentDivider } from '../../../../components/ui/content-divider.component';
+import { TextField } from '../../../../components/ui/text-field.component';
+import { CreateProjectEditorPicker } from '../../create-project/components/create-project-editor-picker.component';
+import type { CreateProjectEditorSelection } from '../../create-project/create-project.model';
+import { canRenameGodotProject } from '../project-settings.model';
+
+type ProjectSettingsProjectSectionProps = {
+    t: TFunction;
+    open: boolean;
+    disabled: boolean;
+    name: string;
+    nameError?: string;
+    godotProjectName: string | null;
+    loadingGodotName: boolean;
+    renameGodotProject: boolean;
+    godotError?: string;
+    selectableReleases: InstalledRelease[];
+    compatibleCatalogueReleases: Parameters<
+        typeof CreateProjectEditorPicker
+    >[0]['availableReleases'];
+    compatibleCataloguePrereleases: Parameters<
+        typeof CreateProjectEditorPicker
+    >[0]['availablePrereleases'];
+    releaseInstallProgress: Parameters<
+        typeof CreateProjectEditorPicker
+    >[0]['releaseInstallProgress'];
+    releasesLoading: boolean;
+    catalogueError: string | undefined;
+    releaseSelection: CreateProjectEditorSelection | null;
+    onNameChange: (value: string) => void;
+    onNameBlur: () => boolean;
+    onRenameGodotProjectChange: (value: boolean) => void;
+    onReleaseSelectionChange: (
+        selection: CreateProjectEditorSelection | null,
+    ) => void;
+    onCancelInstall: (jobId: string) => void;
+    onRetryCatalogue: () => Promise<void>;
+};
+
+/**
+ * Renders the staged project name, Godot name and editor fields.
+ *
+ * @param props - The current form values and editor catalogue actions.
+ * @returns The project settings fields.
+ */
+export function ProjectSettingsProjectSection({
+    t,
+    open,
+    disabled,
+    name,
+    nameError,
+    godotProjectName,
+    loadingGodotName,
+    renameGodotProject,
+    godotError,
+    selectableReleases,
+    compatibleCatalogueReleases,
+    compatibleCataloguePrereleases,
+    releaseInstallProgress,
+    releasesLoading,
+    catalogueError,
+    releaseSelection,
+    onNameChange,
+    onNameBlur,
+    onRenameGodotProjectChange,
+    onReleaseSelectionChange,
+    onCancelInstall,
+    onRetryCatalogue,
+}: ProjectSettingsProjectSectionProps) {
+    const godotProjectAvailable = godotProjectName !== null;
+    const godotRenameEnabled = canRenameGodotProject(name, godotProjectName);
+
+    return (
+        <div className="flex flex-col gap-[12px]">
+            <TextField
+                id="projectEditName"
+                label={t('editProject.fields.name.label')}
+                help={t('editProject.fields.name.help')}
+                value={name}
+                onChange={onNameChange}
+                onBlur={onNameBlur}
+                placeholder={t('editProject.fields.name.placeholder')}
+                error={nameError}
+            />
+            <label className="flex items-start gap-3 rounded-md bg-base-content/5 p-3">
+                <input
+                    type="checkbox"
+                    className={clsx(
+                        'checkbox checkbox-sm mt-0.5 shrink-0',
+                        godotError && 'checkbox-error',
+                    )}
+                    checked={renameGodotProject}
+                    disabled={
+                        !godotProjectAvailable ||
+                        loadingGodotName ||
+                        !godotRenameEnabled
+                    }
+                    onChange={(event) =>
+                        onRenameGodotProjectChange(event.currentTarget.checked)
+                    }
+                />
+                <span
+                    className={clsx(
+                        'flex min-w-0 flex-col gap-1',
+                        (disabled ||
+                            !godotProjectAvailable ||
+                            loadingGodotName ||
+                            !godotRenameEnabled) &&
+                            'opacity-50',
+                    )}
+                >
+                    <span>{t('editProject.godot.renameLabel')}</span>
+                    <span className="text-base-content">
+                        {loadingGodotName && t('editProject.godot.loading')}
+                        {!loadingGodotName &&
+                            godotProjectAvailable &&
+                            t('editProject.godot.currentName', {
+                                name: godotProjectName,
+                            })}
+                        {!loadingGodotName &&
+                            !godotProjectAvailable &&
+                            t('editProject.godot.unavailable')}
+                    </span>
+                    {godotError && (
+                        <span className="text-error">{godotError}</span>
+                    )}
+                </span>
+            </label>
+            <ContentDivider />
+            <div className="flex flex-col gap-2">
+                <div>
+                    <h3 className="text-base font-semibold">
+                        {t('editProject.godotEditor.title')}
+                    </h3>
+                    <p className="text-base-content/75">
+                        {t('editProject.godotEditor.help')}
+                    </p>
+                </div>
+                <CreateProjectEditorPicker
+                    open={open}
+                    disabled={disabled}
+                    triggerTestId="selectProjectGodotEditor"
+                    triggerLabel={t('editProject.godotEditor.title')}
+                    installedReleases={selectableReleases}
+                    availableReleases={compatibleCatalogueReleases}
+                    availablePrereleases={compatibleCataloguePrereleases}
+                    releaseInstallProgress={releaseInstallProgress}
+                    loading={releasesLoading}
+                    catalogueError={catalogueError}
+                    selection={releaseSelection}
+                    onSelectionChange={onReleaseSelectionChange}
+                    onCancelInstall={onCancelInstall}
+                    onRetryCatalogue={onRetryCatalogue}
+                />
+            </div>
+        </div>
+    );
+}

--- a/renderer/src/views/sub-views/project-settings-drawer/components/project-settings-source-control-section.component.tsx
+++ b/renderer/src/views/sub-views/project-settings-drawer/components/project-settings-source-control-section.component.tsx
@@ -1,0 +1,298 @@
+import type {
+    ProjectDetails,
+    ProjectGitIdentityResult,
+} from '@shared/contracts';
+import { CircleCheck, GitBranch } from 'lucide-react';
+import type React from 'react';
+import { ContentDivider } from '../../../../components/ui/content-divider.component';
+import { CopyButton } from '../../../../components/ui/copy-button.component';
+import { TextField } from '../../../../components/ui/text-field.component';
+
+type Translate = (key: string, options?: Record<string, unknown>) => string;
+
+type ProjectSettingsSourceControlSectionProps = {
+    t: Translate;
+    project: ProjectDetails;
+    withGit: boolean;
+    gitAvailable: boolean;
+    loadingGitAvailability: boolean;
+    isInitializingGit: boolean;
+    gitIdentity: ProjectGitIdentityResult | null;
+    loadingGitIdentity: boolean;
+    editingGitIdentity: boolean;
+    gitIdentityName: string;
+    gitIdentityEmail: string;
+    savingGitIdentity: boolean;
+    gitIdentityError: string | undefined;
+    gitUnavailable: boolean;
+    disabled: boolean;
+    onInitializeGit: () => void;
+    onEditGitIdentity: () => void;
+    onSaveGitIdentity: () => void;
+    onCancelGitIdentity: () => void;
+    onGitIdentityNameChange: (value: string) => void;
+    onGitIdentityEmailChange: (value: string) => void;
+};
+
+/**
+ * Renders the Source Control tab of the project settings drawer.
+ *
+ * @param props - Git state, actions, and translation function.
+ * @returns The Source Control section.
+ */
+export const ProjectSettingsSourceControlSection: React.FC<
+    ProjectSettingsSourceControlSectionProps
+> = ({
+    t,
+    project,
+    withGit,
+    gitAvailable,
+    loadingGitAvailability,
+    isInitializingGit,
+    gitIdentity,
+    loadingGitIdentity,
+    editingGitIdentity,
+    gitIdentityName,
+    gitIdentityEmail,
+    savingGitIdentity,
+    gitIdentityError,
+    gitUnavailable,
+    disabled,
+    onInitializeGit,
+    onEditGitIdentity,
+    onSaveGitIdentity,
+    onCancelGitIdentity,
+    onGitIdentityNameChange,
+    onGitIdentityEmailChange,
+}) => (
+    <section className="flex flex-col gap-[12px]">
+        <div className="flex min-w-0 flex-col gap-[4px]">
+            <h2 className="text-base font-semibold">
+                {t('editProject.sourceControl.title')}
+            </h2>
+            <p className="break-words text-base-content/75">
+                {t('editProject.sourceControl.help')}
+            </p>
+        </div>
+        <div className="flex items-start justify-between gap-4 rounded-md bg-base-200/40 p-4">
+            <div className="flex min-w-0 items-start gap-3">
+                <GitBranch className="size-5 shrink-0" aria-hidden="true" />
+                <div className="flex min-w-0 flex-col gap-1">
+                    <span className="font-semibold">Git</span>
+                    <span className="text-base-content/75">
+                        {t(
+                            withGit
+                                ? gitUnavailable
+                                    ? 'editProject.sourceControl.enabledUnavailable'
+                                    : 'editProject.sourceControl.enabled'
+                                : 'editProject.sourceControl.notConfigured',
+                        )}
+                    </span>
+                    {!withGit && !loadingGitAvailability && !gitAvailable && (
+                        <span className="text-warning">
+                            {t('createProject:otherSettings.gitNotInstalled')}
+                        </span>
+                    )}
+                </div>
+            </div>
+            {gitUnavailable ? (
+                <span
+                    className="badge badge-sm badge-soft badge-warning text-warning-content dark:text-warning"
+                    data-testid="projectGitUnavailable"
+                >
+                    {t('editProject.sourceControl.identityUnavailable')}
+                </span>
+            ) : withGit ? (
+                <span
+                    className="badge badge-sm badge-soft badge-success text-success-content dark:text-success gap-1.5"
+                    data-testid="projectGitActive"
+                >
+                    <CircleCheck className="h-4 w-4" aria-hidden="true" />
+                    {t('editProject.sourceControl.active')}
+                </span>
+            ) : loadingGitAvailability ? (
+                <span className="loading loading-spinner loading-sm" />
+            ) : gitAvailable ? (
+                <button
+                    type="button"
+                    className="btn btn-primary shrink-0 text-base"
+                    disabled={!project.valid || disabled || isInitializingGit}
+                    onClick={onInitializeGit}
+                >
+                    {isInitializingGit && (
+                        <span className="loading loading-spinner loading-xs" />
+                    )}
+                    {t(
+                        isInitializingGit
+                            ? 'editProject.sourceControl.initializing'
+                            : 'editProject.sourceControl.initialize',
+                    )}
+                </button>
+            ) : null}
+        </div>
+        {withGit && <ContentDivider />}
+        {withGit && loadingGitIdentity && (
+            <div className="flex justify-center py-4">
+                <span className="loading loading-spinner loading-sm" />
+            </div>
+        )}
+        {withGit && gitIdentity?.status === 'available' && (
+            <div className="flex flex-col gap-[12px]">
+                <div className="flex items-start justify-between gap-4">
+                    <div className="flex min-w-0 flex-col gap-[4px]">
+                        <h3 className="text-base font-semibold">
+                            {t('editProject.sourceControl.identityTitle')}
+                        </h3>
+                        <p className="break-words text-base-content/75">
+                            {t('editProject.sourceControl.identityHelp')}
+                        </p>
+                    </div>
+                    {!editingGitIdentity && gitIdentity.canUpdate && (
+                        <button
+                            type="button"
+                            className="btn btn-ghost shrink-0 text-base"
+                            disabled={disabled}
+                            onClick={onEditGitIdentity}
+                        >
+                            {t('editProject.sourceControl.updateIdentity')}
+                        </button>
+                    )}
+                </div>
+                {editingGitIdentity ? (
+                    <div className="flex flex-col gap-3">
+                        <TextField
+                            id="projectGitIdentityName"
+                            label={t('editProject.sourceControl.identityName')}
+                            help={t(
+                                'editProject.sourceControl.identityNameHelp',
+                            )}
+                            value={gitIdentityName}
+                            onChange={onGitIdentityNameChange}
+                            disabled={savingGitIdentity || disabled}
+                        />
+                        <TextField
+                            id="projectGitIdentityEmail"
+                            label={t('editProject.sourceControl.identityEmail')}
+                            help={t(
+                                'editProject.sourceControl.identityEmailHelp',
+                            )}
+                            value={gitIdentityEmail}
+                            onChange={onGitIdentityEmailChange}
+                            disabled={savingGitIdentity || disabled}
+                        />
+                        <div className="flex justify-end gap-2">
+                            <button
+                                type="button"
+                                className="btn btn-ghost text-base"
+                                disabled={savingGitIdentity || disabled}
+                                onClick={onCancelGitIdentity}
+                            >
+                                {t('common:buttons.cancel')}
+                            </button>
+                            <button
+                                type="button"
+                                className="btn btn-primary shrink-0 text-base"
+                                disabled={savingGitIdentity || disabled}
+                                onClick={onSaveGitIdentity}
+                            >
+                                {savingGitIdentity && (
+                                    <span className="loading loading-spinner loading-xs" />
+                                )}
+                                {t('editProject.sourceControl.saveIdentity')}
+                            </button>
+                        </div>
+                    </div>
+                ) : (
+                    <dl className="grid gap-3">
+                        {(
+                            [
+                                ['identityName', gitIdentity.name],
+                                ['identityEmail', gitIdentity.email],
+                            ] as const
+                        ).map(([label, value]) => (
+                            <div key={label} className="min-w-0">
+                                <dt className="flex flex-wrap items-center gap-2 text-base-content/75">
+                                    <span>
+                                        {t(
+                                            `editProject.sourceControl.${label}`,
+                                        )}
+                                    </span>
+                                    <span className="badge badge-sm badge-soft capitalize">
+                                        {t(
+                                            `editProject.sourceControl.identitySource.${value.source}`,
+                                        )}
+                                    </span>
+                                </dt>
+                                <dd className="mt-1 flex min-w-0 items-center gap-2 rounded-md bg-base-content/5 px-3 py-2">
+                                    <span className="min-w-0 flex-1 break-all select-text">
+                                        {value.value ||
+                                            t(
+                                                'editProject.sourceControl.identityMissing',
+                                            )}
+                                    </span>
+                                    {value.value && (
+                                        <div className="shrink-0">
+                                            <CopyButton value={value.value} />
+                                        </div>
+                                    )}
+                                </dd>
+                            </div>
+                        ))}
+                    </dl>
+                )}
+                {!gitIdentity.canUpdate && (
+                    <p className="break-words text-base-content/75">
+                        {t(
+                            gitIdentity.repository.kind === 'linked-worktree'
+                                ? 'editProject.sourceControl.linkedWorktreeReadOnly'
+                                : 'editProject.sourceControl.parentRepositoryReadOnly',
+                            { root: gitIdentity.repository.root },
+                        )}
+                    </p>
+                )}
+            </div>
+        )}
+        {withGit && gitIdentity?.status === 'git-unavailable' && (
+            <div className="flex flex-col gap-[12px]">
+                <div className="flex items-start justify-between gap-4">
+                    <div className="flex min-w-0 flex-col gap-[4px]">
+                        <h3 className="text-base font-semibold">
+                            {t('editProject.sourceControl.identityTitle')}
+                        </h3>
+                        <p className="break-words text-base-content/75">
+                            {t(
+                                'editProject.sourceControl.identityUnavailableHelp',
+                            )}
+                        </p>
+                    </div>
+                    <button
+                        type="button"
+                        className="btn btn-ghost shrink-0 text-base"
+                        disabled
+                    >
+                        {t('editProject.sourceControl.updateIdentity')}
+                    </button>
+                </div>
+                <dl className="grid gap-3">
+                    {['identityName', 'identityEmail'].map((label) => (
+                        <div key={label} className="min-w-0">
+                            <dt className="text-base-content/75">
+                                {t(`editProject.sourceControl.${label}`)}
+                            </dt>
+                            <dd className="mt-1 rounded-md bg-base-content/5 px-3 py-2 text-base-content/60">
+                                {t(
+                                    'editProject.sourceControl.identityUnavailable',
+                                )}
+                            </dd>
+                        </div>
+                    ))}
+                </dl>
+            </div>
+        )}
+        {gitIdentityError && (
+            <p className="break-words text-error" role="alert">
+                {gitIdentityError}
+            </p>
+        )}
+    </section>
+);

--- a/renderer/src/views/sub-views/project-settings-drawer/hooks/project-settings-form.hook.ts
+++ b/renderer/src/views/sub-views/project-settings-drawer/hooks/project-settings-form.hook.ts
@@ -1,0 +1,388 @@
+import type {
+    CodeEditorId,
+    CodeEditorIntegrationSettings,
+    InstalledRelease,
+    ProjectDetails,
+} from '@shared/contracts';
+import type { TFunction } from 'i18next';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCodeEditorIntegrations } from '../../../../hooks/code-editor-integrations.hook';
+import type { ProjectSettingsSave } from '../../../../hooks/project-settings-save.types';
+import { useRelease } from '../../../../hooks/release.hook';
+import { sortReleases } from '../../../../release-sorting.util';
+import {
+    type CreateProjectEditorSelection,
+    getCreateProjectReleaseKey,
+} from '../../create-project/create-project.model';
+import {
+    canRenameGodotProject,
+    hasProjectCodeEditorChanges,
+    hasProjectRenameChanges,
+    validateProjectRenameName,
+} from '../project-settings.model';
+
+type ProjectSettingsFormOptions = {
+    project: ProjectDetails | null;
+    open: boolean;
+    installedReleases: InstalledRelease[];
+    getProjectGodotName: (project: ProjectDetails) => Promise<string | null>;
+    settingsSave: ProjectSettingsSave | undefined;
+    clearSettingsSave: (path: string) => void;
+    t: TFunction;
+};
+
+/**
+ * Owns staged Settings values and session-safe project initialisation.
+ *
+ * @param options - The project session, persisted draft and external lookups.
+ * @returns Form values, derived state and domain actions for the drawer coordinator.
+ */
+export function useProjectSettingsForm({
+    project,
+    open,
+    installedReleases,
+    getProjectGodotName,
+    settingsSave,
+    clearSettingsSave,
+    t,
+}: ProjectSettingsFormOptions) {
+    const { listIntegrationSettings } = useCodeEditorIntegrations();
+    const {
+        availableReleases,
+        availablePrereleases,
+        releaseInstallProgress,
+        loading: releasesLoading,
+        hasError: catalogueError,
+        refreshAvailableReleases,
+        cancelInstall,
+    } = useRelease();
+    const [initialName, setInitialName] = useState('');
+    const [name, setName] = useState('');
+    const [initialReleaseKey, setInitialReleaseKey] = useState('');
+    const [releaseSelection, setReleaseSelection] =
+        useState<CreateProjectEditorSelection | null>(null);
+    const [initialWindowed, setInitialWindowed] = useState(false);
+    const [windowed, setWindowed] = useState(false);
+    const [godotProjectName, setGodotProjectName] = useState<string | null>(
+        null,
+    );
+    const [loadingGodotName, setLoadingGodotName] = useState(false);
+    const [renameGodotProject, setRenameGodotProject] = useState(false);
+    const [nameError, setNameError] = useState<string>();
+    const [godotError, setGodotError] = useState<string>();
+    const [formError, setFormError] = useState<string>();
+    const [initialCodeEditorId, setInitialCodeEditorId] =
+        useState<CodeEditorId | null>(null);
+    const [codeEditorId, setCodeEditorId] = useState<CodeEditorId | null>(null);
+    const [codeEditorTouched, setCodeEditorTouched] = useState(false);
+    const [codeEditorSettings, setCodeEditorSettings] = useState<
+        CodeEditorIntegrationSettings[]
+    >([]);
+    const [loadingCodeEditors, setLoadingCodeEditors] = useState(false);
+    const [codeEditorLoadFailed, setCodeEditorLoadFailed] = useState(false);
+    const activeProjectPathRef = useRef<string | null>(null);
+    const sessionRef = useRef(0);
+    const restoredSaveRef = useRef<ProjectSettingsSave | undefined>(undefined);
+
+    useEffect(
+        () => () => {
+            sessionRef.current += 1;
+        },
+        [],
+    );
+    useEffect(() => {
+        if (!open || !project) {
+            activeProjectPathRef.current = null;
+            sessionRef.current += 1;
+            return;
+        }
+        if (activeProjectPathRef.current === project.path) return;
+
+        activeProjectPathRef.current = project.path;
+        sessionRef.current += 1;
+        const session = sessionRef.current;
+        const releaseKey = getCreateProjectReleaseKey(project.release);
+        const currentCodeEditorId = project.codeEditorId ?? null;
+        setInitialName(project.name);
+        setName(project.name);
+        setInitialReleaseKey(releaseKey);
+        setReleaseSelection({
+            source: 'installed',
+            key: releaseKey,
+            release: project.release,
+        });
+        setInitialWindowed(Boolean(project.open_windowed));
+        setWindowed(Boolean(project.open_windowed));
+        setGodotProjectName(null);
+        setRenameGodotProject(false);
+        setNameError(undefined);
+        setGodotError(undefined);
+        setFormError(undefined);
+        setInitialCodeEditorId(currentCodeEditorId);
+        setCodeEditorId(currentCodeEditorId);
+        setCodeEditorTouched(false);
+        setCodeEditorSettings([]);
+        setCodeEditorLoadFailed(false);
+        setLoadingGodotName(true);
+        setLoadingCodeEditors(true);
+
+        getProjectGodotName(project)
+            .then((value) => {
+                if (session === sessionRef.current) setGodotProjectName(value);
+            })
+            .catch(() => {
+                if (session === sessionRef.current) setGodotProjectName(null);
+            })
+            .finally(() => {
+                if (session === sessionRef.current) setLoadingGodotName(false);
+            });
+        listIntegrationSettings()
+            .then((settings) => {
+                if (session === sessionRef.current)
+                    setCodeEditorSettings(settings);
+            })
+            .catch(() => {
+                if (session === sessionRef.current)
+                    setCodeEditorLoadFailed(true);
+            })
+            .finally(() => {
+                if (session === sessionRef.current)
+                    setLoadingCodeEditors(false);
+            });
+    }, [getProjectGodotName, listIntegrationSettings, open, project]);
+
+    useEffect(() => {
+        if (!open || !project) {
+            restoredSaveRef.current = undefined;
+            return;
+        }
+        if (
+            !settingsSave ||
+            restoredSaveRef.current === settingsSave ||
+            loadingCodeEditors ||
+            loadingGodotName
+        )
+            return;
+        restoredSaveRef.current = settingsSave;
+        if (settingsSave.status === 'complete' && settingsSave.project) {
+            const saved = settingsSave.project;
+            const releaseKey = getCreateProjectReleaseKey(saved.release);
+            setName(saved.name);
+            setInitialName(saved.name);
+            setReleaseSelection({
+                source: 'installed',
+                key: releaseKey,
+                release: saved.release,
+            });
+            setInitialReleaseKey(releaseKey);
+            setWindowed(Boolean(saved.open_windowed));
+            setInitialWindowed(Boolean(saved.open_windowed));
+            setCodeEditorId(saved.codeEditorId ?? null);
+            setInitialCodeEditorId(saved.codeEditorId ?? null);
+            setCodeEditorTouched(false);
+            setRenameGodotProject(false);
+            if (settingsSave.draft.renameGodotProject)
+                setGodotProjectName(saved.name);
+            setFormError(undefined);
+            clearSettingsSave(project.path);
+            return;
+        }
+        const draft = settingsSave.draft;
+        setName(draft.name);
+        setReleaseSelection(draft.releaseSelection);
+        setWindowed(draft.windowed);
+        setCodeEditorId(draft.codeEditorId);
+        setCodeEditorTouched(draft.codeEditorTouched);
+        setRenameGodotProject(draft.renameGodotProject);
+        setFormError(settingsSave.error);
+    }, [
+        clearSettingsSave,
+        loadingCodeEditors,
+        loadingGodotName,
+        open,
+        project,
+        settingsSave,
+    ]);
+
+    const selectableReleases = useMemo(() => {
+        if (!project) return [];
+        const major = Math.trunc(project.release.version_number);
+        return installedReleases
+            .filter(
+                (release) =>
+                    release.valid !== false &&
+                    Boolean(release.editor_path) &&
+                    Math.trunc(release.version_number) >= major,
+            )
+            .sort(sortReleases);
+    }, [installedReleases, project]);
+    const compatibleCatalogueReleases = useMemo(
+        () =>
+            project
+                ? availableReleases.filter(
+                      (release) =>
+                          Math.trunc(release.version_number) >=
+                          Math.trunc(project.release.version_number),
+                  )
+                : [],
+        [availableReleases, project],
+    );
+    const compatibleCataloguePrereleases = useMemo(
+        () =>
+            project
+                ? availablePrereleases.filter(
+                      (release) =>
+                          Math.trunc(release.version_number) >=
+                          Math.trunc(project.release.version_number),
+                  )
+                : [],
+        [availablePrereleases, project],
+    );
+    const hasRenameChanges = Boolean(
+        project &&
+            hasProjectRenameChanges(
+                initialName,
+                godotProjectName,
+                name,
+                renameGodotProject,
+            ),
+    );
+    const hasCodeEditorChanges = Boolean(
+        project &&
+            hasProjectCodeEditorChanges(
+                initialCodeEditorId,
+                codeEditorId,
+                codeEditorTouched,
+            ),
+    );
+    const hasReleaseChanges = Boolean(
+        project &&
+            releaseSelection &&
+            (initialReleaseKey !==
+                getCreateProjectReleaseKey({
+                    version: releaseSelection.release.version,
+                    mono:
+                        releaseSelection.source === 'installed'
+                            ? releaseSelection.release.mono
+                            : releaseSelection.mono,
+                }) ||
+                (releaseSelection.source === 'catalogue' &&
+                    (project.release.valid === false ||
+                        !project.release.editor_path))),
+    );
+    const hasWindowedChanges = Boolean(project && initialWindowed !== windowed);
+
+    /** @param value - The edited Launcher project name. */
+    const changeName = (value: string) => {
+        setName(value);
+        setNameError(undefined);
+        setFormError(undefined);
+        setGodotError(undefined);
+        if (!canRenameGodotProject(value, godotProjectName))
+            setRenameGodotProject(false);
+    };
+    /** @returns Whether the staged name is valid. */
+    const validateName = () => {
+        const error = validateProjectRenameName(name);
+        const message = error
+            ? t(`editProject.validation.${error}`)
+            : undefined;
+        setNameError(message);
+        return !message;
+    };
+    /** @param value - Whether to rename project.godot with the Launcher name. */
+    const changeRenameGodotProject = (value: boolean) => {
+        setRenameGodotProject(value);
+        setGodotError(undefined);
+        setFormError(undefined);
+    };
+    /** @param value - The staged editor picker selection. */
+    const changeReleaseSelection = (
+        value: CreateProjectEditorSelection | null,
+    ) => {
+        setReleaseSelection(value);
+        setFormError(undefined);
+    };
+    /** @param value - The staged code editor id. */
+    const changeCodeEditor = (value: CodeEditorId | null) => {
+        setCodeEditorId(value);
+        setCodeEditorTouched(true);
+        setFormError(undefined);
+    };
+    /** @param value - Whether launches should use a windowed game window. */
+    const changeWindowed = (value: boolean) => {
+        setWindowed(value);
+        setFormError(undefined);
+    };
+    /** @param message - The form-level save error. */
+    const setSaveError = (message: string | undefined) => setFormError(message);
+    /** @param message - The Godot project name error. */
+    const setGodotNameError = (message: string | undefined) =>
+        setGodotError(message);
+    /** @param message - The Launcher project name error. */
+    const setProjectNameError = (message: string | undefined) =>
+        setNameError(message);
+    /** @param saved - The successful renamed project baseline. */
+    const acceptRename = (saved: ProjectDetails) => {
+        setInitialName(saved.name);
+        setName(saved.name);
+        if (renameGodotProject) setGodotProjectName(saved.name);
+        setRenameGodotProject(false);
+    };
+    /** @param saved - The successful code editor baseline. */
+    const acceptCodeEditor = (saved: ProjectDetails) => {
+        setInitialCodeEditorId(saved.codeEditorId ?? null);
+        setCodeEditorTouched(false);
+    };
+    /** @param key - The successful editor selection key. */
+    const acceptRelease = (key: string) => setInitialReleaseKey(key);
+    /** @param value - The successful launch preference baseline. */
+    const acceptWindowed = (value: boolean) => setInitialWindowed(value);
+
+    return {
+        sessionRef,
+        initialName,
+        name,
+        initialReleaseKey,
+        releaseSelection,
+        initialWindowed,
+        windowed,
+        godotProjectName,
+        loadingGodotName,
+        renameGodotProject,
+        nameError,
+        godotError,
+        formError,
+        initialCodeEditorId,
+        codeEditorId,
+        codeEditorTouched,
+        codeEditorSettings,
+        loadingCodeEditors,
+        codeEditorLoadFailed,
+        selectableReleases,
+        compatibleCatalogueReleases,
+        compatibleCataloguePrereleases,
+        releaseInstallProgress,
+        releasesLoading,
+        catalogueError,
+        refreshAvailableReleases,
+        cancelInstall,
+        hasRenameChanges,
+        hasCodeEditorChanges,
+        hasReleaseChanges,
+        hasWindowedChanges,
+        changeName,
+        validateName,
+        changeRenameGodotProject,
+        changeReleaseSelection,
+        changeCodeEditor,
+        changeWindowed,
+        setSaveError,
+        setGodotNameError,
+        setProjectNameError,
+        acceptRename,
+        acceptCodeEditor,
+        acceptRelease,
+        acceptWindowed,
+    };
+}

--- a/renderer/src/views/sub-views/project-settings-drawer/hooks/project-settings-source-control.hook.ts
+++ b/renderer/src/views/sub-views/project-settings-drawer/hooks/project-settings-source-control.hook.ts
@@ -1,0 +1,332 @@
+import type {
+    GitIdentity,
+    InitializeProjectGitResult,
+    ProjectDetails,
+    ProjectGitIdentityResult,
+} from '@shared/contracts';
+import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useAlerts } from '../../../../hooks/alerts.hook';
+import { useToolIntegrations } from '../../../../hooks/tool-integrations.hook';
+import type { ProjectSettingsTab } from '../project-settings.types';
+
+export type ProjectSettingsSourceControlHookProps = {
+    open: boolean;
+    project: ProjectDetails | null;
+    activeTab: ProjectSettingsTab;
+    onFormError: (message: string | undefined) => void;
+    onInitializeProjectGit: (
+        project: ProjectDetails,
+    ) => Promise<InitializeProjectGitResult>;
+    getProjectGitIdentity: (
+        project: ProjectDetails,
+    ) => Promise<ProjectGitIdentityResult>;
+    onSetProjectGitIdentity: (
+        project: ProjectDetails,
+        identity: GitIdentity,
+    ) => Promise<ProjectGitIdentityResult>;
+};
+
+export type ProjectSettingsSourceControlHook = {
+    withGit: boolean;
+    gitAvailable: boolean;
+    loadingGitAvailability: boolean;
+    isInitializingGit: boolean;
+    gitIdentity: ProjectGitIdentityResult | null;
+    loadingGitIdentity: boolean;
+    editingGitIdentity: boolean;
+    gitIdentityName: string;
+    gitIdentityEmail: string;
+    savingGitIdentity: boolean;
+    gitIdentityError: string | undefined;
+    gitUnavailable: boolean;
+    initializeGit: () => Promise<void>;
+    editGitIdentity: () => void;
+    saveGitIdentity: () => Promise<void>;
+    cancelGitIdentity: () => void;
+    setGitIdentityName: (value: string) => void;
+    setGitIdentityEmail: (value: string) => void;
+};
+
+/**
+ * Manages the Git state and actions used by the project settings drawer.
+ *
+ * @param props - Source Control dependencies and drawer lifecycle state.
+ * @returns Git availability, identity state, and Source Control actions.
+ */
+export function useProjectSettingsSourceControl(
+    props: ProjectSettingsSourceControlHookProps,
+): ProjectSettingsSourceControlHook {
+    const {
+        open,
+        project,
+        activeTab,
+        onFormError,
+        onInitializeProjectGit,
+        getProjectGitIdentity,
+        onSetProjectGitIdentity,
+    } = props;
+    const { t } = useTranslation(['projects', 'common', 'createProject']);
+    const { addAlert } = useAlerts();
+    const { listIntegrations } = useToolIntegrations();
+    const [withGit, setWithGit] = useState(false);
+    const [gitAvailable, setGitAvailable] = useState(false);
+    const [loadingGitAvailability, setLoadingGitAvailability] = useState(false);
+    const [isInitializingGit, setIsInitializingGit] = useState(false);
+    const [gitIdentity, setGitIdentity] =
+        useState<ProjectGitIdentityResult | null>(null);
+    const [loadingGitIdentity, setLoadingGitIdentity] = useState(false);
+    const [editingGitIdentity, setEditingGitIdentity] = useState(false);
+    const [gitIdentityName, setGitIdentityName] = useState('');
+    const [gitIdentityEmail, setGitIdentityEmail] = useState('');
+    const [savingGitIdentity, setSavingGitIdentity] = useState(false);
+    const [gitIdentityError, setGitIdentityError] = useState<string>();
+    const projectPathRef = useRef<string | null>(null);
+    const sessionRef = useRef(0);
+
+    useEffect(() => {
+        return () => {
+            sessionRef.current += 1;
+        };
+    }, []);
+
+    useEffect(() => {
+        if (!open || !project) {
+            projectPathRef.current = null;
+            sessionRef.current += 1;
+            setWithGit(false);
+            setGitIdentity(null);
+            setEditingGitIdentity(false);
+            setGitIdentityName('');
+            setGitIdentityEmail('');
+            setGitIdentityError(undefined);
+            setIsInitializingGit(false);
+            setSavingGitIdentity(false);
+            setLoadingGitIdentity(false);
+            return;
+        }
+
+        if (projectPathRef.current === project.path) {
+            return;
+        }
+
+        projectPathRef.current = project.path;
+        sessionRef.current += 1;
+        setWithGit(project.withGit);
+        setGitIdentity(null);
+        setEditingGitIdentity(false);
+        setGitIdentityName('');
+        setGitIdentityEmail('');
+        setGitIdentityError(undefined);
+        setIsInitializingGit(false);
+        setSavingGitIdentity(false);
+        setLoadingGitIdentity(false);
+    }, [open, project]);
+
+    useEffect(() => {
+        if (!open) {
+            return;
+        }
+
+        let disposed = false;
+        setGitAvailable(false);
+        setLoadingGitAvailability(true);
+
+        listIntegrations()
+            .then((tools) => {
+                if (!disposed) {
+                    setGitAvailable(
+                        tools.some(
+                            (tool) =>
+                                tool.id === 'git' &&
+                                tool.status === 'available',
+                        ),
+                    );
+                }
+            })
+            .catch(() => {
+                if (!disposed) {
+                    setGitAvailable(false);
+                }
+            })
+            .finally(() => {
+                if (!disposed) {
+                    setLoadingGitAvailability(false);
+                }
+            });
+
+        return () => {
+            disposed = true;
+        };
+    }, [listIntegrations, open]);
+
+    useEffect(() => {
+        if (!open || !project || activeTab !== 'sourceControl' || !withGit) {
+            return;
+        }
+
+        let disposed = false;
+        setLoadingGitIdentity(true);
+        setGitIdentityError(undefined);
+        getProjectGitIdentity(project)
+            .then((identity) => {
+                if (!disposed) {
+                    setGitIdentity(identity);
+                }
+            })
+            .catch((error) => {
+                if (!disposed) {
+                    setGitIdentityError(
+                        error instanceof Error
+                            ? error.message
+                            : t('editProject.sourceControl.identityLoadFailed'),
+                    );
+                }
+            })
+            .finally(() => {
+                if (!disposed) {
+                    setLoadingGitIdentity(false);
+                }
+            });
+
+        return () => {
+            disposed = true;
+        };
+    }, [activeTab, getProjectGitIdentity, open, project, t, withGit]);
+
+    /**
+     * Initialises Git for the current project.
+     *
+     * @returns A promise that resolves after Git initialisation completes.
+     */
+    const initializeGit = async (): Promise<void> => {
+        if (!project || withGit) {
+            return;
+        }
+
+        setIsInitializingGit(true);
+        onFormError(undefined);
+        const session = sessionRef.current;
+        try {
+            const result = await onInitializeProjectGit(project);
+            if (session !== sessionRef.current) {
+                return;
+            }
+            setWithGit(result.project.withGit);
+            if (result.gitSetup.status === 'existing-repository') {
+                addAlert(
+                    t('editProject.sourceControl.existingRepositoryTitle'),
+                    result.gitSetup.isProjectRoot
+                        ? t('editProject.sourceControl.existingRepositoryRoot')
+                        : t(
+                              'editProject.sourceControl.existingRepositoryParent',
+                              {
+                                  root: result.gitSetup.root,
+                              },
+                          ),
+                );
+            }
+        } catch (error) {
+            if (session !== sessionRef.current) {
+                return;
+            }
+            onFormError(
+                error instanceof Error
+                    ? error.message
+                    : t('editProject.sourceControl.initFailed'),
+            );
+        } finally {
+            if (session === sessionRef.current) {
+                setIsInitializingGit(false);
+            }
+        }
+    };
+
+    /**
+     * Starts editing the available Git identity.
+     *
+     * @returns Nothing when the identity cannot be edited.
+     */
+    const editGitIdentity = (): void => {
+        if (gitIdentity?.status !== 'available' || !gitIdentity.canUpdate) {
+            return;
+        }
+        setGitIdentityName(gitIdentity.name.value);
+        setGitIdentityEmail(gitIdentity.email.value);
+        setGitIdentityError(undefined);
+        setEditingGitIdentity(true);
+    };
+
+    /**
+     * Saves the edited Git identity for the current project.
+     *
+     * @returns A promise that resolves after the identity is saved.
+     */
+    const saveGitIdentity = async (): Promise<void> => {
+        if (!project || !gitIdentityName.trim() || !gitIdentityEmail.trim()) {
+            setGitIdentityError(
+                t('editProject.sourceControl.identityRequired'),
+            );
+            return;
+        }
+
+        setSavingGitIdentity(true);
+        setGitIdentityError(undefined);
+        const session = sessionRef.current;
+        try {
+            const identity = await onSetProjectGitIdentity(project, {
+                name: gitIdentityName,
+                email: gitIdentityEmail,
+            });
+            if (session !== sessionRef.current) {
+                return;
+            }
+            setGitIdentity(identity);
+            setEditingGitIdentity(false);
+        } catch (error) {
+            if (session !== sessionRef.current) {
+                return;
+            }
+            setGitIdentityError(
+                error instanceof Error
+                    ? error.message
+                    : t('editProject.sourceControl.updateFailed'),
+            );
+        } finally {
+            if (session === sessionRef.current) {
+                setSavingGitIdentity(false);
+            }
+        }
+    };
+
+    /**
+     * Cancels Git identity editing and clears its validation error.
+     *
+     * @returns Nothing.
+     */
+    const cancelGitIdentity = (): void => {
+        setEditingGitIdentity(false);
+        setGitIdentityError(undefined);
+    };
+
+    return {
+        withGit,
+        gitAvailable,
+        loadingGitAvailability,
+        isInitializingGit,
+        gitIdentity,
+        loadingGitIdentity,
+        editingGitIdentity,
+        gitIdentityName,
+        gitIdentityEmail,
+        savingGitIdentity,
+        gitIdentityError,
+        gitUnavailable: withGit && gitIdentity?.status === 'git-unavailable',
+        initializeGit,
+        editGitIdentity,
+        saveGitIdentity,
+        cancelGitIdentity,
+        setGitIdentityName,
+        setGitIdentityEmail,
+    };
+}

--- a/renderer/src/views/sub-views/project-settings-drawer/project-settings.types.ts
+++ b/renderer/src/views/sub-views/project-settings-drawer/project-settings.types.ts
@@ -1,0 +1,56 @@
+import type {
+    CodeEditorId,
+    GitIdentity,
+    InitializeProjectGitResult,
+    InstalledRelease,
+    ProjectDetails,
+    ProjectEditorSelection,
+    ProjectGitIdentityResult,
+    RenameProjectOptions,
+    RenameProjectResult,
+} from '@shared/contracts';
+
+/** Identifies one Project Settings tab. */
+export type ProjectSettingsTab =
+    | 'project'
+    | 'sourceControl'
+    | 'codeEditor'
+    | 'launch';
+
+/** Project state and update operations accepted by the drawer. */
+export type ProjectSettingsDrawerProps = {
+    project: ProjectDetails | null;
+    open: boolean;
+    installedReleases: InstalledRelease[];
+    onOpenChange: (open: boolean) => void;
+    onRenameProject: (
+        project: ProjectDetails,
+        options: RenameProjectOptions,
+    ) => Promise<RenameProjectResult>;
+    onSetProjectEditor: (
+        project: ProjectDetails,
+        release: ProjectEditorSelection,
+    ) => Promise<ProjectDetails>;
+    onSetProjectCodeEditor: (
+        project: ProjectDetails,
+        id: CodeEditorId | null,
+    ) => Promise<ProjectDetails>;
+    onSetProjectWindowed: (
+        project: ProjectDetails,
+        windowed: boolean,
+    ) => Promise<ProjectDetails>;
+    onInitializeProjectGit: (
+        project: ProjectDetails,
+    ) => Promise<InitializeProjectGitResult>;
+    getProjectGitIdentity: (
+        project: ProjectDetails,
+    ) => Promise<ProjectGitIdentityResult>;
+    onSetProjectGitIdentity: (
+        project: ProjectDetails,
+        identity: GitIdentity,
+    ) => Promise<ProjectGitIdentityResult>;
+    onResetProjectCodeEditorConfig: (
+        project: ProjectDetails,
+    ) => Promise<ProjectDetails>;
+    getProjectGodotName: (project: ProjectDetails) => Promise<string | null>;
+};

--- a/shared/src/contracts/projects/index.d.ts
+++ b/shared/src/contracts/projects/index.d.ts
@@ -8,6 +8,7 @@ import type {
     EditorChannel,
     EditorFlavor,
     InstalledRelease,
+    ReleaseSummary,
 } from '../releases/index.js';
 
 export type LaunchPath = string;
@@ -347,6 +348,20 @@ export type ChangeProjectEditorResult = BackendResult & {
     projects?: ProjectDetails[];
     recoveredCodeEditorConfigFiles?: string[];
 };
+
+/** An installed editor or an official editor selected before installation. */
+export type ProjectEditorSelection =
+    | InstalledRelease
+    | {
+          release: ReleaseSummary;
+          mono: boolean;
+      };
+
+/** Identifies the selection that an install completion is allowed to repair. */
+export type ProjectEditorSelectionExpectation = Pick<
+    InstalledRelease,
+    'version' | 'mono'
+>;
 
 export type SetProjectCodeEditorResult = ProjectDetails & {
     recoveredCodeEditorConfigFiles?: string[];

--- a/shared/src/contracts/projects/projects.bridge.d.ts
+++ b/shared/src/contracts/projects/projects.bridge.d.ts
@@ -20,6 +20,8 @@ import type {
     ListConnectedRepositoriesResult,
     ListCreateProjectPublicationTargetsResult,
     ProjectDetails,
+    ProjectEditorSelection,
+    ProjectEditorSelectionExpectation,
     ProjectGitHubLink,
     ProjectGitIdentityResult,
     ProjectImportInspection,
@@ -156,7 +158,8 @@ export type ProjectsBridge = {
     /** Changes the Godot editor assigned to a project. */
     setProjectEditor(
         project: ProjectDetails,
-        release: InstalledRelease,
+        selection: ProjectEditorSelection,
+        expectedEditor?: ProjectEditorSelectionExpectation,
     ): Promise<ChangeProjectEditorResult>;
 
     /** Changes whether a project opens in windowed mode. */


### PR DESCRIPTION
- Save the selected editor before downloading and show progress immediately.
- Preserve failed downloads for retry and protect newer editor choices.
- Split Project Settings into focused components and hooks.