### PR TITLE
fix(theme): resolve automatic system contrast

### DIFF
--- a/renderer/src/hooks/theme.hook.test.tsx
+++ b/renderer/src/hooks/theme.hook.test.tsx
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { resolveTheme, subscribeToSystemThemeChanges } from './theme.hook';
+
+describe('theme handling', () => {
+    const mediaQuery = {
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mediaQuery.matches = false;
+        (
+            globalThis as unknown as {
+                window: Window;
+            }
+        ).window = {
+            matchMedia: vi.fn(() => mediaQuery),
+        } as unknown as Window;
+    });
+
+    it.each([
+        ['Automatic follows system dark mode', 'auto', 'dark', 'dark'],
+        ['Automatic follows system light mode', 'auto', 'light', 'light'],
+        ['Dark overrides system light mode', 'dark', 'light', 'dark'],
+        ['Light overrides system dark mode', 'light', 'dark', 'light'],
+    ] as const)('%s', (_description, theme, systemTheme, expectedTheme) => {
+        expect(resolveTheme(theme, systemTheme)).toBe(expectedTheme);
+    });
+
+    it('reports system changes and removes its listener during cleanup', () => {
+        const onSystemThemeChange = vi.fn();
+        const cleanup = subscribeToSystemThemeChanges(onSystemThemeChange);
+        const listener = mediaQuery.addEventListener.mock.calls[0]?.[1] as
+            | (() => void)
+            | undefined;
+
+        mediaQuery.matches = true;
+        listener?.();
+
+        expect(onSystemThemeChange).toHaveBeenCalledWith('dark');
+        cleanup();
+        expect(mediaQuery.removeEventListener).toHaveBeenCalledWith(
+            'change',
+            listener,
+        );
+    });
+});

--- a/renderer/src/hooks/theme.hook.test.tsx
+++ b/renderer/src/hooks/theme.hook.test.tsx
@@ -46,4 +46,16 @@ describe('theme handling', () => {
             listener,
         );
     });
+
+    it('refreshes the system theme when Automatic is selected again', () => {
+        const onSystemThemeChange = vi.fn();
+        const cleanup = subscribeToSystemThemeChanges(onSystemThemeChange);
+        expect(onSystemThemeChange).toHaveBeenLastCalledWith('light');
+        cleanup();
+
+        mediaQuery.matches = true;
+        const unsubscribe = subscribeToSystemThemeChanges(onSystemThemeChange);
+        expect(onSystemThemeChange).toHaveBeenLastCalledWith('dark');
+        unsubscribe();
+    });
 });

--- a/renderer/src/hooks/theme.hook.tsx
+++ b/renderer/src/hooks/theme.hook.tsx
@@ -1,13 +1,19 @@
 import React, { type PropsWithChildren } from 'react';
 
 export type ThemeMode = 'dark' | 'light' | 'auto';
+export type ResolvedTheme = Exclude<ThemeMode, 'auto'>;
 export type ThemeProviderContext = {
-    systemTheme: ThemeMode;
+    systemTheme: ResolvedTheme;
     theme: ThemeMode | null;
     setTheme: (theme: ThemeMode) => void;
 };
 
-const getStoredTheme = () => {
+/**
+ * Reads the valid saved theme preference, falling back to Automatic.
+ *
+ * @returns The saved theme preference.
+ */
+const getStoredTheme = (): ThemeMode => {
     const storedTheme = localStorage.getItem('theme') as ThemeMode | null;
     if (storedTheme === 'dark' || storedTheme === 'light') {
         return storedTheme;
@@ -15,8 +21,53 @@ const getStoredTheme = () => {
     return 'auto';
 };
 
-const setStoredTheme = (theme: ThemeMode) => {
+/**
+ * Stores the user's theme preference.
+ *
+ * @param theme - The theme preference to save.
+ */
+const setStoredTheme = (theme: ThemeMode): void => {
     localStorage.setItem('theme', theme);
+};
+
+/**
+ * Gets the currently preferred operating-system theme.
+ *
+ * @returns The resolved system theme.
+ */
+export const getSystemTheme = (): ResolvedTheme =>
+    window.matchMedia('(prefers-color-scheme: dark)').matches
+        ? 'dark'
+        : 'light';
+
+/**
+ * Resolves Automatic against the current system theme.
+ *
+ * @param theme - The saved theme preference.
+ * @param systemTheme - The current operating-system theme.
+ * @returns The theme that must be applied to the document.
+ */
+export const resolveTheme = (
+    theme: ThemeMode,
+    systemTheme: ResolvedTheme,
+): ResolvedTheme => (theme === 'auto' ? systemTheme : theme);
+
+/**
+ * Subscribes to operating-system theme changes.
+ *
+ * @param onSystemThemeChange - Receives the newly resolved system theme.
+ * @returns A function that removes the subscription.
+ */
+export const subscribeToSystemThemeChanges = (
+    onSystemThemeChange: (theme: ResolvedTheme) => void,
+): (() => void) => {
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleChange = (): void => {
+        onSystemThemeChange(mediaQuery.matches ? 'dark' : 'light');
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
 };
 
 const themeContext = React.createContext<ThemeProviderContext>(
@@ -29,53 +80,24 @@ type ThemeProviderProps = PropsWithChildren;
 
 export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
     const [theme, setTheme] = React.useState<ThemeMode>(getStoredTheme());
+    const [systemTheme, setSystemTheme] =
+        React.useState<ResolvedTheme>(getSystemTheme);
 
-    const updateDocumentTheme = (theme: ThemeMode) => {
-        const systemPrefersDark = window.matchMedia(
-            '(prefers-color-scheme: dark)',
-        ).matches;
-
-        const isDark =
-            theme === 'dark' ||
-            (!('theme' in localStorage) && systemPrefersDark);
-
+    React.useEffect(() => {
         if (theme !== 'auto') {
-            document.documentElement.setAttribute(
-                'data-theme',
-                isDark ? 'dark' : 'light',
-            );
-        } else {
-            document.documentElement.removeAttribute('data-theme');
+            return;
         }
 
-        setStoredTheme(theme);
-    };
-
-    const systemTheme = window.matchMedia('(prefers-color-scheme: dark)')
-        .matches
-        ? 'dark'
-        : 'light';
-
-    // biome-ignore lint/correctness/useExhaustiveDependencies: updateDocumentTheme would refresh infinitely
-    React.useEffect(() => {
-        const storedTheme = localStorage.getItem('theme') as ThemeMode | null;
-
-        if (storedTheme === 'dark' || storedTheme === 'light') {
-            setTheme(storedTheme);
-        } else {
-            setTheme('auto');
-        }
-
-        updateDocumentTheme(storedTheme || 'auto');
-    }, []);
-
-    // biome-ignore lint/correctness/useExhaustiveDependencies: updateDocumentTheme would refresh infinitely
-    React.useEffect(() => {
-        updateDocumentTheme(theme);
-        localStorage.setItem('theme', theme);
-
-        updateDocumentTheme(theme);
+        return subscribeToSystemThemeChanges(setSystemTheme);
     }, [theme]);
+
+    React.useEffect(() => {
+        document.documentElement.setAttribute(
+            'data-theme',
+            resolveTheme(theme, systemTheme),
+        );
+        setStoredTheme(theme);
+    }, [theme, systemTheme]);
 
     return (
         <themeContext.Provider value={{ theme, setTheme, systemTheme }}>

--- a/renderer/src/hooks/theme.hook.tsx
+++ b/renderer/src/hooks/theme.hook.tsx
@@ -53,7 +53,7 @@ export const resolveTheme = (
 ): ResolvedTheme => (theme === 'auto' ? systemTheme : theme);
 
 /**
- * Subscribes to operating-system theme changes.
+ * Subscribes to operating-system theme changes and reports the current value.
  *
  * @param onSystemThemeChange - Receives the newly resolved system theme.
  * @returns A function that removes the subscription.
@@ -67,6 +67,7 @@ export const subscribeToSystemThemeChanges = (
     };
 
     mediaQuery.addEventListener('change', handleChange);
+    handleChange();
     return () => mediaQuery.removeEventListener('change', handleChange);
 };
 


### PR DESCRIPTION
- Keep panel and badge text readable when following the system dark theme.
- Follow system theme changes while Automatic is selected.
- Refresh the system theme when returning to Automatic, preserving explicit Light and Dark choices.